### PR TITLE
Add release update workflow

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -3,6 +3,10 @@ name: Update ToolHive Reference Docs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-reference:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -50,12 +50,10 @@ jobs:
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           branch: update-toolhive-reference-${{ steps.imports.outputs.version }}
-          title:
-            'Update ToolHive reference docs for ${{
-            steps.imports.outputs.version }}'
+          title: |
+            Update ToolHive reference docs for ${{ steps.imports.outputs.version }}
           body: |
             This PR updates the ToolHive CLI and API reference documentation to the latest release: ${{ steps.imports.outputs.version }}.
-          commit-message:
-            'Update ToolHive reference docs for ${{
-            steps.imports.outputs.version }}'
+          commit-message: |
+            Update ToolHive reference docs for ${{ steps.imports.outputs.version }}
           delete-branch: true

--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -1,0 +1,66 @@
+name: Update ToolHive Reference Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-reference:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run update-toolhive-reference.sh and capture version
+        id: imports
+        run: |
+          chmod +x scripts/update-toolhive-reference.sh
+          scripts/update-toolhive-reference.sh
+        env:
+          GITHUB_OUTPUT: ${{ github.output }}
+
+      - name: Get version output
+        id: get_version
+        run: |
+          VERSION=$(grep '^version=' $GITHUB_OUTPUT | cut -d'=' -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Check for changes
+        id: git-diff
+        run: |
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected."
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create branch, commit, and push
+        if: steps.git-diff.outputs.changed == 'true'
+        run: |
+          BRANCH=update-toolhive-reference-${VERSION}
+          git checkout -b "$BRANCH"
+          git commit -am "Update ToolHive reference docs for ${VERSION}"
+          git push origin "$BRANCH"
+        env:
+          VERSION: ${{ env.VERSION }}
+
+      - name: Create Pull Request
+        if: steps.git-diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: update-toolhive-reference-${{ env.VERSION }}
+          title: 'Update ToolHive reference docs for ${{ env.VERSION }}'
+          body: |
+            This PR updates the ToolHive CLI and API reference documentation to the latest release: ${{ env.VERSION }}.
+          commit-message:
+            'Update ToolHive reference docs for ${{ env.VERSION }}'
+          delete-branch: true

--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -22,14 +22,6 @@ jobs:
         run: |
           chmod +x scripts/update-toolhive-reference.sh
           scripts/update-toolhive-reference.sh
-        env:
-          GITHUB_OUTPUT: ${{ github.output }}
-
-      - name: Get version output
-        id: get_version
-        run: |
-          VERSION=$(grep '^version=' $GITHUB_OUTPUT | cut -d'=' -f2)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Check for changes
         id: git-diff
@@ -51,16 +43,19 @@ jobs:
           git commit -am "Update ToolHive reference docs for ${VERSION}"
           git push origin "$BRANCH"
         env:
-          VERSION: ${{ env.VERSION }}
+          VERSION: ${{ steps.imports.outputs.version }}
 
       - name: Create Pull Request
         if: steps.git-diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
-          branch: update-toolhive-reference-${{ env.VERSION }}
-          title: 'Update ToolHive reference docs for ${{ env.VERSION }}'
+          branch: update-toolhive-reference-${{ steps.imports.outputs.version }}
+          title:
+            'Update ToolHive reference docs for ${{
+            steps.imports.outputs.version }}'
           body: |
-            This PR updates the ToolHive CLI and API reference documentation to the latest release: ${{ env.VERSION }}.
+            This PR updates the ToolHive CLI and API reference documentation to the latest release: ${{ steps.imports.outputs.version }}.
           commit-message:
-            'Update ToolHive reference docs for ${{ env.VERSION }}'
+            'Update ToolHive reference docs for ${{
+            steps.imports.outputs.version }}'
           delete-branch: true


### PR DESCRIPTION
This adds a workflow to pull the CLI and API reference docs from the latest ToolHive release, and opens a PR if anything has changed.

Halfway to closing #1, next step is to get the toolhive repo to call it as part of the release workflow.