### PR TITLE
Fix reference update workflow

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -46,6 +46,7 @@ jobs:
           git checkout -b "$BRANCH"
           git commit -am "Update ToolHive reference docs for ${VERSION}"
           git push origin "$BRANCH"
+          git checkout main
         env:
           VERSION: ${{ steps.imports.outputs.version }}
 


### PR DESCRIPTION
The create-pull-request action expects to be on the base branch