### PR TITLE
Fix workflow again, remove redundant build step

### DIFF
--- a/.github/workflows/_static-checks.yaml
+++ b/.github/workflows/_static-checks.yaml
@@ -25,16 +25,3 @@ jobs:
 
       - name: Run Prettier
         run: npm run prettier
-
-  build:
-    name: Build site
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build site
-        run: npm run build

--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -39,17 +39,6 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create branch, commit, and push
-        if: steps.git-diff.outputs.changed == 'true'
-        run: |
-          BRANCH=update-toolhive-reference-${VERSION}
-          git checkout -b "$BRANCH"
-          git commit -am "Update ToolHive reference docs for ${VERSION}"
-          git push origin "$BRANCH"
-          git checkout main
-        env:
-          VERSION: ${{ steps.imports.outputs.version }}
-
       - name: Create Pull Request
         if: steps.git-diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6


### PR DESCRIPTION
- The update-pull-request action expects to create the branch, so it was
  resetting the changes and then had nothing to do.
- Also removing the "Build site" step from the PR workflow; it's
  redundant since Vercal does this too.