### PR TITLE
Minor updates to install instructions

### DIFF
--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -25,8 +25,8 @@ depend on how many MCP servers you run and what resources they use.
 You can install ToolHive using several methods:
 
 <Tabs groupId='installer' queryString='installer'>
-<TabItem value='macos' label='Homebrew (macOS)' default>
-If you use Homebrew on macOS, this is the easiest installation method:
+<TabItem value='homebrew' label='Homebrew (macOS/Linux)' default>
+Homebrew is the easiest installation method on macOS or Linux:
 
 ```bash
 brew tap stacklok/tap
@@ -40,6 +40,9 @@ WinGet is available by default on Windows, making this the easiest installation 
 ```bash
 winget install stacklok.thv
 ```
+
+Open a new terminal window after installation to ensure the `thv` command is
+available.
 
 </TabItem>
 <TabItem value='binary' label='Pre-compiled binaries'>
@@ -60,8 +63,7 @@ winget install stacklok.thv
 
    ```bash
    tar -xzf toolhive_<version>_<platform>.tar.gz
-   sudo mv thv /usr/local/bin/
-   sudo chmod +x /usr/local/bin/thv
+   sudo install -m 0755 thv /usr/local/bin/
    ```
 
    On Windows, extract the ZIP file to a folder and add that folder to your PATH
@@ -69,7 +71,6 @@ winget install stacklok.thv
 
 </TabItem>
 <TabItem value='source' label='Build from source'>
-
 #### Prerequisites for building from source
 
 - Go 1.24 or newer
@@ -145,8 +146,7 @@ exists.
 To upgrade ToolHive:
 
 <Tabs groupId='installer' queryString='installer'>
-<TabItem value='macos' label='Homebrew (macOS)' default>
-
+<TabItem value='homebrew' label='Homebrew (macOS)' default>
 If you installed ToolHive via Homebrew, upgrade it with:
 
 ```bash
@@ -155,7 +155,6 @@ brew upgrade thv
 
 </TabItem>
 <TabItem value='winget' label='WinGet (Windows)'>
-
 If you installed ToolHive via WinGet, upgrade it with:
 
 ```bash
@@ -164,13 +163,11 @@ winget upgrade stacklok.thv
 
 </TabItem>
 <TabItem value='binary' label='Pre-compiled binaries'>
-
 Follow the same steps as the [initial installation](#install-toolhive),
 downloading the latest release and overwriting the previous binary.
 
 </TabItem>
 <TabItem value='source' label='Build from source'>
-
 If you built ToolHive from source, upgrade it by pulling the latest changes and
 rebuilding:
 

--- a/docs/toolhive/index.mdx
+++ b/docs/toolhive/index.mdx
@@ -91,7 +91,7 @@ manage MCP servers centrally.
 
 ToolHive offers the following features to simplify MCP deployment:
 
-- **Simplified deployment**: Deploy MCP servers instantly with a single command
+- **Streamlined deployment**: Deploy MCP servers instantly with a single command
   using Docker containers or directly from package managers via protocol schemes
   (`uvx://`, `npx://`, `go://`). Access a curated registry of verified MCP
   servers that you can discover and run effortlessly.

--- a/docs/toolhive/tutorials/quickstart.mdx
+++ b/docs/toolhive/tutorials/quickstart.mdx
@@ -40,12 +40,22 @@ For detailed installation instructions, see the
 [installing ToolHive](../guides-cli/install.mdx) guide. Here's a quick summary:
 
 <Tabs groupId='installer' queryString='installer'>
-  <TabItem value='homebrew' label='Homebrew (macOS)' default>
+  <TabItem value='homebrew' label='Homebrew (macOS/Linux)' default>
 
     ```bash
     brew tap stacklok/tap
     brew install thv
     ```
+
+  </TabItem>
+  <TabItem value='winget' label='WinGet (Windows)' default>
+
+    ```bash
+    winget install stacklok.thv
+    ```
+
+    Open a new terminal window after installation to ensure the `thv` command is
+    available.
 
   </TabItem>
   <TabItem value='binary' label='Pre-compiled binaries'>


### PR DESCRIPTION
- Add WInGet method to the quickstart tutorial
- Note the need to start a new terminal in Windows
- Note that Homebrew works on Linux too
- Simplify *nix binary install commands