### PR TITLE
Add note about stopping before upgrade on Windows

### DIFF
--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -158,8 +158,8 @@ brew upgrade thv
 :::note
 
 On Windows, you must stop all running MCP servers before upgrading ToolHive,
-otherwise the upgrade will fail because the Windows locks the executable is
-locked while it runs.
+otherwise the upgrade will fail because the Windows locks the executable while
+it runs.
 
 Run `thv stop <server-name>` to stop each server. After you complete the
 upgrade, restart them using `thv restart <server-name>`.

--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -344,7 +344,7 @@ the ToolHive executable being locked by a running MCP server proxy.
 
 ```text title="Error example"
 An unexpected error occurred while executing the command:
-remove: Access is denied.: "C:\Users\dan\AppData\Local\Microsoft\WinGet\Packages\stacklok.thv_Microsoft.Winget.Source_8wekyb3d8bbwe\thv.exe"
+remove: Access is denied.: "C:\Users\USERNAME\AppData\Local\Microsoft\WinGet\Packages\stacklok.thv_Microsoft.Winget.Source_8wekyb3d8bbwe\thv.exe"
 Uninstall failed with exit code: 0x8a150003 : Executing command failed
 ```
 

--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -155,6 +155,17 @@ brew upgrade thv
 
 </TabItem>
 <TabItem value='winget' label='WinGet (Windows)'>
+:::note
+
+On Windows, you must stop all running MCP servers before upgrading ToolHive,
+otherwise the upgrade will fail because the Windows locks the executable is
+locked while it runs.
+
+Run `thv stop <server-name>` to stop each server. After you complete the
+upgrade, restart them using `thv restart <server-name>`.
+
+:::
+
 If you installed ToolHive via WinGet, upgrade it with:
 
 ```bash
@@ -325,6 +336,44 @@ If you see "permission denied" errors when running ToolHive:
    See
    [Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
    for more details.
+
+### Upgrade error on Windows
+
+If you encounter an error when upgrading ToolHive on Windows, it may be due to
+the ToolHive executable being locked by a running MCP server proxy.
+
+```text title="Error example"
+An unexpected error occurred while executing the command:
+remove: Access is denied.: "C:\Users\dan\AppData\Local\Microsoft\WinGet\Packages\stacklok.thv_Microsoft.Winget.Source_8wekyb3d8bbwe\thv.exe"
+Uninstall failed with exit code: 0x8a150003 : Executing command failed
+```
+
+To resolve this:
+
+1. Stop all running MCP servers:
+
+   ```powershell
+   thv list
+   thv stop <server-name>
+   # repeat for each server
+   ```
+
+2. After stopping all servers, run the upgrade command again:
+
+   ```powershell
+   winget upgrade stacklok.thv
+   ```
+
+3. If you still encounter issues, check if any ToolHive processes are still
+   running in the background. You can use Task Manager to end any lingering
+   `thv.exe` processes.
+
+4. Restart your MCP servers:
+
+   ```powershell
+   thv restart <server-name>
+   # repeat for each server
+   ```
 
 ### Other issues
 

--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -158,8 +158,8 @@ brew upgrade thv
 :::note
 
 On Windows, you must stop all running MCP servers before upgrading ToolHive,
-otherwise the upgrade will fail because the Windows locks the executable while
-it runs.
+otherwise the upgrade will fail because Windows locks the executable while it
+runs.
 
 Run `thv stop <server-name>` to stop each server. After you complete the
 upgrade, restart them using `thv restart <server-name>`.


### PR DESCRIPTION
Windows locks the exe file while it's running, so WinGet can't replace it if any servers are running.