### PR TITLE
Add the CRD reference and automation

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -2,12 +2,21 @@ name: Update ToolHive Reference Docs
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'ToolHive version to update reference docs for'
+        required: true
+        default: 'latest'
   repository_dispatch:
     types: [published-release]
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: update-toolhive-reference
+  cancel-in-progress: false
 
 jobs:
   update-reference:
@@ -23,11 +32,23 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run update-toolhive-reference.sh and capture version
+      - name: Determine version
+        id: get-version
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "version=${{ github.event.client_payload.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run update script
         id: imports
         run: |
           chmod +x scripts/update-toolhive-reference.sh
-          scripts/update-toolhive-reference.sh
+          if ! scripts/update-toolhive-reference.sh ${{ steps.get-version.outputs.version }}; then
+            echo "::error::Failed to update ToolHive reference docs"
+            exit 1
+          fi
 
       - name: Check for changes
         id: git-diff

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,5 +1,5 @@
 {
   "gitignore": true,
   "globs": ["**/*.md"],
-  "ignores": ["docs/toolhive/reference/cli/"],
+  "ignores": ["docs/toolhive/reference/cli/", "static/api-specs/*.md"],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,20 +9,7 @@
   "prettier.requireConfig": true,
   "yaml.format.proseWrap": "always",
   "css.lint.emptyRules": "ignore",
-
-  "[markdown]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[mdx]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[css]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[yaml]": {
+  "[markdown][mdx][css][json][jsonc][yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.md
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.md
@@ -163,6 +163,10 @@ When you apply an `MCPServer` resource, here's what happens:
 
 :::
 
+For more examples of `MCPServer` resources, see the
+[example MCP server manifests](https://github.com/stacklok/toolhive/tree/main/examples/operator/mcp-servers)
+in the ToolHive repo.
+
 ## Automatic RBAC management
 
 The ToolHive operator automatically handles RBAC (Role-Based Access Control) for
@@ -185,14 +189,13 @@ This approach provides:
 - Better security isolation between different MCPServer instances
 - Support for multi-tenant deployments across different namespaces
 
-For more examples of `MCPServer` resources, see the
-[example MCP server manifests](https://github.com/stacklok/toolhive/tree/main/examples/operator/mcp-servers)
-in the ToolHive repo.
-
 ## Customize server settings
 
 You can customize the MCP server by adding additional fields to the `MCPServer`
-resource. Here are some common configurations.
+resource. The full specification is available in the
+[Kubernetes CRD reference](../reference/crd-spec.mdx).
+
+Below are some common configurations.
 
 ### Customize the MCP server pod
 
@@ -363,56 +366,19 @@ For more details about a specific MCP server:
 kubectl -n <NAMESPACE> describe mcpserver <NAME>
 ```
 
-## Configuration reference
+## Next steps
 
-### MCPServer spec
+See the [Client compatibility](../reference/client-compatibility.mdx) reference
+to learn how to connect to MCP servers using different clients.
 
-| Field               | Description                                     | Required | Default |
-| ------------------- | ----------------------------------------------- | -------- | ------- |
-| `image`             | Container image for the MCP server              | Yes      | -       |
-| `transport`         | Transport method (stdio or sse)                 | No       | stdio   |
-| `port`              | Port to expose the MCP server on                | No       | 8080    |
-| `targetPort`        | Port to use for the MCP server (for SSE)        | No       |         |
-| `args`              | Additional arguments to pass to the MCP server  | No       | -       |
-| `env`               | Environment variables to set in the container   | No       | -       |
-| `resources`         | Resource requirements for the container         | No       | -       |
-| `secrets`           | References to secrets to mount in the container | No       | -       |
-| `permissionProfile` | Permission profile configuration                | No       | -       |
-| `podTemplateSpec`   | Custom pod specification for the MCP server     | No       | -       |
+## Related information
 
-### Secrets
-
-The `secrets` field has the following parameters:
-
-- `name`: The name of the Kubernetes secret (required)
-- `key`: The key in the secret (required)
-- `targetEnvName`: The environment variable to be used when setting up the
-  secret in the MCP server (optional). If left unspecified, it defaults to the
-  key.
-
-### Permission Profiles
-
-Permission profiles can be configured in two ways:
-
-1. Using a built-in profile:
-
-   ```yaml
-   permissionProfile:
-     type: builtin
-     name: network # or "none"
-   ```
-
-2. Using a ConfigMap:
-
-   ```yaml
-   permissionProfile:
-     type: configmap
-     name: my-permission-profile
-     key: profile.json
-   ```
-
-The ConfigMap should contain a JSON
-[permission profile](../guides-cli/custom-permissions.mdx#create-a-custom-permission-profile).
+- [Kubernetes CRD reference](../reference/crd-spec.mdx) - Reference for the
+  `MCPServer` Custom Resource Definition (CRD)
+- [Deploy the operator using Helm](./deploy-operator-helm.md) - Install the
+  ToolHive operator
+- [Custom permissions](../guides-cli/custom-permissions.mdx) - Configure
+  permission profiles
 
 :::important
 
@@ -424,18 +390,6 @@ Contributions to help implement this feature are welcome! You can contribute by
 visiting our [GitHub repository](https://github.com/stacklok/toolhive).
 
 :::
-
-## Next steps
-
-See the [Client compatibility](../reference/client-compatibility.mdx) reference
-to learn how to connect to MCP servers using different clients.
-
-## Related information
-
-- [Deploy the operator using Helm](./deploy-operator-helm.md) - Install the
-  ToolHive operator
-- [Custom permissions](../guides-cli/custom-permissions.mdx) - Configure
-  permission profiles
 
 ## Troubleshooting
 

--- a/docs/toolhive/reference/crd-spec.mdx
+++ b/docs/toolhive/reference/crd-spec.mdx
@@ -1,0 +1,11 @@
+---
+title: Kubernetes CRD reference
+description:
+  ToolHive Kubernetes Operator Custom Resource Definitions (CRDs) reference.
+sidebar_position: 30
+toc_max_heading_level: 4
+---
+
+import CRDRef from '@site/static/api-specs/crd-api.md';
+
+<CRDRef />

--- a/scripts/update-toolhive-reference.sh
+++ b/scripts/update-toolhive-reference.sh
@@ -20,39 +20,97 @@ if [ ! -d "$STATIC_DIR" ]; then
     exit 1
 fi
 
-RELEASE_JSON=$(curl -s https://api.github.com/repos/stacklok/toolhive/releases/latest)
-LATEST_RELEASE_TARBALL=$(echo "$RELEASE_JSON" | grep "tarball_url" | cut -d '"' -f 4)
-LATEST_RELEASE_VERSION=$(echo "$RELEASE_JSON" | grep '"tag_name"' | cut -d '"' -f 4)
+# Handle tag name parameter - default to "latest" if not provided
+if [ -z "$1" ]; then
+    API_ENDPOINT="https://api.github.com/repos/stacklok/toolhive/releases/latest"
+    echo "No tag specified, using latest release"
+else
+    TAG_NAME="$1"
+    API_ENDPOINT="https://api.github.com/repos/stacklok/toolhive/releases/tags/$TAG_NAME"
+    echo "Using specified tag: $TAG_NAME"
+fi
 
-if [ -z "$LATEST_RELEASE_TARBALL" ]; then
-    echo "Failed to get the latest release tarball URL for ${LATEST_RELEASE_VERSION}"
+# Fetch release information
+RELEASE_JSON=$(curl -s "$API_ENDPOINT")
+RELEASE_TARBALL=$(echo "$RELEASE_JSON" | grep "tarball_url" | cut -d '"' -f 4)
+RELEASE_VERSION=$(echo "$RELEASE_JSON" | grep '"tag_name"' | cut -d '"' -f 4)
+
+if [ -z "$RELEASE_TARBALL" ]; then
+    echo "Failed to get release tarball URL for release: ${RELEASE_VERSION}"
+    echo "Please check if the tag exists in the repository"
     exit 1
 fi
 
-# Output the latest release version for use in CI workflows
+# Output the release version for use in CI workflows
 if [ ! -z "$GITHUB_OUTPUT" ]; then
-    echo "version=$LATEST_RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+    echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 fi
 
+# Clean up and prepare import directory
 rm -rf ${IMPORT_DIR}/toolhive
 mkdir -p ${IMPORT_DIR}/toolhive
 
-echo "Fetching the latest ToolHive release (${LATEST_RELEASE_VERSION}) from: $LATEST_RELEASE_TARBALL"
+echo "Fetching ToolHive release (${RELEASE_VERSION}) from: $RELEASE_TARBALL"
 echo "Importing to: $IMPORT_DIR"
 
-curl -sL "$LATEST_RELEASE_TARBALL" | tar xz --strip-components=1  -C ./imports/toolhive
+# Download and extract the release tarball
+curl -sL "$RELEASE_TARBALL" | tar xz --strip-components=1 -C ./imports/toolhive
 
-## CLI reference
+# Determine release type and process accordingly
+if [[ "$RELEASE_VERSION" =~ ^v.* ]]; then
+    echo "Processing main CLI release: $RELEASE_VERSION"
+    
+    ## CLI reference
+    echo "Updating ToolHive CLI reference documentation in ${DOCS_DIR}/toolhive/reference/cli"
+    
+    # Remove existing CLI reference documentation files in case we remove any commands
+    rm -f ${DOCS_DIR}/toolhive/reference/cli/thv_*.md
+    
+    # Copy CLI documentation
+    if [ -d "${IMPORT_DIR}/toolhive/docs/cli" ]; then
+        cp -r ${IMPORT_DIR}/toolhive/docs/cli/* ${DOCS_DIR}/toolhive/reference/cli
+        echo "CLI reference documentation updated successfully"
+    else
+        echo "Warning: CLI documentation not found in ${IMPORT_DIR}/toolhive/docs/cli"
+    fi
+    
+    ## API reference
+    echo "Updating ToolHive API reference in ${STATIC_DIR}/api-specs"
+    
+    # Copy API specification
+    if [ -f "${IMPORT_DIR}/toolhive/docs/server/swagger.yaml" ]; then
+        cp ${IMPORT_DIR}/toolhive/docs/server/swagger.yaml ${STATIC_DIR}/api-specs/toolhive-api.yaml
+        echo "API reference updated successfully"
+    else
+        echo "Warning: API specification not found in ${IMPORT_DIR}/toolhive/docs/server/swagger.yaml"
+    fi
+    
+    elif [[ "$RELEASE_VERSION" =~ ^toolhive-operator-crds-.* ]]; then
+    echo "Processing operator CRD release: $RELEASE_VERSION"
+    
+    ## CRD API reference
+    echo "Updating ToolHive CRD API reference in ${STATIC_DIR}/api-specs"
+    
+    # Copy CRD API documentation
+    if [ -f "${IMPORT_DIR}/toolhive/docs/operator/crd-api.md" ]; then
+        # Remove h1 title from the CRD API documentation, Docusaurus will use the title from the front matter
+        sed '1{/^# /d;}' ${IMPORT_DIR}/toolhive/docs/operator/crd-api.md > ${STATIC_DIR}/api-specs/crd-api.md
+        echo "CRD API reference updated successfully"
+    else
+        echo "Warning: CRD API documentation not found in ${IMPORT_DIR}/toolhive/docs/operator/crd-api.md"
+    fi
+    
+    elif [[ "$RELEASE_VERSION" =~ ^toolhive-operator- ]]; then
+    echo "Processing main operator release: $RELEASE_VERSION"
+    echo "Placeholder: No specific processing implemented for this release type yet"
+    
+else
+    echo "Unknown release type for tag: $RELEASE_VERSION"
+    echo "Supported release types:"
+    echo "  - v* (main CLI releases)"
+    echo "  - toolhive-operator-crds-* (CRD releases)"
+    echo "  - toolhive-operator-* (other operator releases)"
+    exit 1
+fi
 
-echo "Updating ToolHive CLI reference documentation in ${DOCS_DIR}/toolhive/reference/cli"
-
-# Remove existing CLI reference documentation files in case we remove any commands
-rm -f ${DOCS_DIR}/toolhive/reference/cli/thv_*.md
-
-cp -r ${IMPORT_DIR}/toolhive/docs/cli/* ${DOCS_DIR}/toolhive/reference/cli
-
-## API reference
-
-echo "Updating ToolHive API reference in ${STATIC_DIR}/api-specs"
-
-cp -r ${IMPORT_DIR}/toolhive/docs/server/swagger.yaml ${STATIC_DIR}/api-specs/toolhive-api.yaml
+echo "Release processing completed for: $RELEASE_VERSION"

--- a/static/api-specs/crd-api.md
+++ b/static/api-specs/crd-api.md
@@ -1,0 +1,376 @@
+
+## Packages
+- [toolhive.stacklok.dev/v1alpha1](#toolhivestacklokdevv1alpha1)
+
+
+## toolhive.stacklok.dev/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the toolhive v1alpha1 API group
+
+### Resource Types
+- [MCPServer](#mcpserver)
+- [MCPServerList](#mcpserverlist)
+
+
+
+#### ConfigMapOIDCRef
+
+
+
+ConfigMapOIDCRef references a ConfigMap containing OIDC configuration
+
+
+
+_Appears in:_
+- [OIDCConfigRef](#oidcconfigref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the ConfigMap |  | Required: \{\} <br /> |
+| `key` _string_ | Key is the key in the ConfigMap that contains the OIDC configuration | oidc.json |  |
+
+
+#### EnvVar
+
+
+
+EnvVar represents an environment variable in a container
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the environment variable |  | Required: \{\} <br /> |
+| `value` _string_ | Value of the environment variable |  | Required: \{\} <br /> |
+
+
+#### InlineOIDCConfig
+
+
+
+InlineOIDCConfig contains direct OIDC configuration
+
+
+
+_Appears in:_
+- [OIDCConfigRef](#oidcconfigref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `issuer` _string_ | Issuer is the OIDC issuer URL |  | Required: \{\} <br /> |
+| `audience` _string_ | Audience is the expected audience for the token |  |  |
+| `jwksUrl` _string_ | JWKSURL is the URL to fetch the JWKS from |  |  |
+| `clientId` _string_ | ClientID is the OIDC client ID |  |  |
+
+
+#### KubernetesOIDCConfig
+
+
+
+KubernetesOIDCConfig configures OIDC for Kubernetes service account token validation
+
+
+
+_Appears in:_
+- [OIDCConfigRef](#oidcconfigref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `serviceAccount` _string_ | ServiceAccount is the name of the service account to validate tokens for<br />If empty, uses the pod's service account |  |  |
+| `namespace` _string_ | Namespace is the namespace of the service account<br />If empty, uses the MCPServer's namespace |  |  |
+| `audience` _string_ | Audience is the expected audience for the token | toolhive |  |
+| `issuer` _string_ | Issuer is the OIDC issuer URL | https://kubernetes.default.svc |  |
+| `jwksUrl` _string_ | JWKSURL is the URL to fetch the JWKS from | https://kubernetes.default.svc/openid/v1/jwks |  |
+
+
+#### MCPServer
+
+
+
+MCPServer is the Schema for the mcpservers API
+
+
+
+_Appears in:_
+- [MCPServerList](#mcpserverlist)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `toolhive.stacklok.dev/v1alpha1` | | |
+| `kind` _string_ | `MCPServer` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[MCPServerSpec](#mcpserverspec)_ |  |  |  |
+| `status` _[MCPServerStatus](#mcpserverstatus)_ |  |  |  |
+
+
+#### MCPServerList
+
+
+
+MCPServerList contains a list of MCPServer
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `toolhive.stacklok.dev/v1alpha1` | | |
+| `kind` _string_ | `MCPServerList` | | |
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents.<br />Servers may infer this from the endpoint the client submits requests to.<br />Cannot be updated.<br />In CamelCase.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |  |  |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object.<br />Servers should convert recognized schemas to the latest internal value, and<br />may reject unrecognized values.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |  |  |
+| `metadata` _[ListMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#listmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `items` _[MCPServer](#mcpserver) array_ |  |  |  |
+
+
+#### MCPServerPhase
+
+_Underlying type:_ _string_
+
+MCPServerPhase is the phase of the MCPServer
+
+_Validation:_
+- Enum: [Pending Running Failed Terminating]
+
+_Appears in:_
+- [MCPServerStatus](#mcpserverstatus)
+
+| Field | Description |
+| --- | --- |
+| `Pending` | MCPServerPhasePending means the MCPServer is being created<br /> |
+| `Running` | MCPServerPhaseRunning means the MCPServer is running<br /> |
+| `Failed` | MCPServerPhaseFailed means the MCPServer failed to start<br /> |
+| `Terminating` | MCPServerPhaseTerminating means the MCPServer is being deleted<br /> |
+
+
+#### MCPServerSpec
+
+
+
+MCPServerSpec defines the desired state of MCPServer
+
+
+
+_Appears in:_
+- [MCPServer](#mcpserver)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ | Image is the container image for the MCP server |  | Required: \{\} <br /> |
+| `transport` _string_ | Transport is the transport method for the MCP server (stdio, streamable-http or sse) | stdio | Enum: [stdio streamable-http sse] <br /> |
+| `port` _integer_ | Port is the port to expose the MCP server on | 8080 | Maximum: 65535 <br />Minimum: 1 <br /> |
+| `targetPort` _integer_ | TargetPort is the port that MCP server listens to |  | Maximum: 65535 <br />Minimum: 1 <br /> |
+| `args` _string array_ | Args are additional arguments to pass to the MCP server |  |  |
+| `env` _[EnvVar](#envvar) array_ | Env are environment variables to set in the MCP server container |  |  |
+| `volumes` _[Volume](#volume) array_ | Volumes are volumes to mount in the MCP server container |  |  |
+| `resources` _[ResourceRequirements](#resourcerequirements)_ | Resources defines the resource requirements for the MCP server container |  |  |
+| `secrets` _[SecretRef](#secretref) array_ | Secrets are references to secrets to mount in the MCP server container |  |  |
+| `permissionProfile` _[PermissionProfileRef](#permissionprofileref)_ | PermissionProfile defines the permission profile to use |  |  |
+| `podTemplateSpec` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core)_ | PodTemplateSpec defines the pod template to use for the MCP server<br />This allows for customizing the pod configuration beyond what is provided by the other fields.<br />Note that to modify the specific container the MCP server runs in, you must specify<br />the `mcp` container name in the PodTemplateSpec. |  |  |
+| `resourceOverrides` _[ResourceOverrides](#resourceoverrides)_ | ResourceOverrides allows overriding annotations and labels for resources created by the operator |  |  |
+| `oidcConfig` _[OIDCConfigRef](#oidcconfigref)_ | OIDCConfig defines OIDC authentication configuration for the MCP server |  |  |
+
+
+#### MCPServerStatus
+
+
+
+MCPServerStatus defines the observed state of MCPServer
+
+
+
+_Appears in:_
+- [MCPServer](#mcpserver)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#condition-v1-meta) array_ | Conditions represent the latest available observations of the MCPServer's state |  |  |
+| `url` _string_ | URL is the URL where the MCP server can be accessed |  |  |
+| `phase` _[MCPServerPhase](#mcpserverphase)_ | Phase is the current phase of the MCPServer |  | Enum: [Pending Running Failed Terminating] <br /> |
+| `message` _string_ | Message provides additional information about the current phase |  |  |
+
+
+#### NetworkPermissions
+
+
+
+NetworkPermissions defines the network permissions for an MCP server
+
+
+
+_Appears in:_
+- [PermissionProfileSpec](#permissionprofilespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `outbound` _[OutboundNetworkPermissions](#outboundnetworkpermissions)_ | Outbound defines the outbound network permissions |  |  |
+
+
+#### OIDCConfigRef
+
+
+
+OIDCConfigRef defines a reference to OIDC configuration
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _string_ | Type is the type of OIDC configuration | kubernetes | Enum: [kubernetes configmap inline] <br /> |
+| `kubernetes` _[KubernetesOIDCConfig](#kubernetesoidcconfig)_ | Kubernetes configures OIDC for Kubernetes service account token validation<br />Only used when Type is "kubernetes" |  |  |
+| `configMap` _[ConfigMapOIDCRef](#configmapoidcref)_ | ConfigMap references a ConfigMap containing OIDC configuration<br />Only used when Type is "configmap" |  |  |
+| `inline` _[InlineOIDCConfig](#inlineoidcconfig)_ | Inline contains direct OIDC configuration<br />Only used when Type is "inline" |  |  |
+
+
+#### OutboundNetworkPermissions
+
+
+
+OutboundNetworkPermissions defines the outbound network permissions
+
+
+
+_Appears in:_
+- [NetworkPermissions](#networkpermissions)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `insecureAllowAll` _boolean_ | InsecureAllowAll allows all outbound network connections (not recommended) | false |  |
+| `allowTransport` _string array_ | AllowTransport is a list of transport protocols to allow (e.g., "tcp", "udp") |  |  |
+| `allowHost` _string array_ | AllowHost is a list of hosts to allow connections to |  |  |
+| `allowPort` _integer array_ | AllowPort is a list of ports to allow connections to |  |  |
+
+
+#### PermissionProfileRef
+
+
+
+PermissionProfileRef defines a reference to a permission profile
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _string_ | Type is the type of permission profile reference | builtin | Enum: [builtin configmap] <br /> |
+| `name` _string_ | Name is the name of the permission profile<br />If Type is "builtin", Name must be one of: "none", "network"<br />If Type is "configmap", Name is the name of the ConfigMap |  | Required: \{\} <br /> |
+| `key` _string_ | Key is the key in the ConfigMap that contains the permission profile<br />Only used when Type is "configmap" |  |  |
+
+
+
+
+#### ResourceList
+
+
+
+ResourceList is a set of (resource name, quantity) pairs
+
+
+
+_Appears in:_
+- [ResourceRequirements](#resourcerequirements)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cpu` _string_ | CPU is the CPU limit in cores (e.g., "500m" for 0.5 cores) |  |  |
+| `memory` _string_ | Memory is the memory limit in bytes (e.g., "64Mi" for 64 megabytes) |  |  |
+
+
+#### ResourceMetadataOverrides
+
+
+
+ResourceMetadataOverrides defines metadata overrides for a resource
+
+
+
+_Appears in:_
+- [ResourceOverrides](#resourceoverrides)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `annotations` _object (keys:string, values:string)_ | Annotations to add or override on the resource |  |  |
+| `labels` _object (keys:string, values:string)_ | Labels to add or override on the resource |  |  |
+
+
+#### ResourceOverrides
+
+
+
+ResourceOverrides defines overrides for annotations and labels on created resources
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `proxyDeployment` _[ResourceMetadataOverrides](#resourcemetadataoverrides)_ | ProxyDeployment defines overrides for the Proxy Deployment resource (toolhive proxy) |  |  |
+| `proxyService` _[ResourceMetadataOverrides](#resourcemetadataoverrides)_ | ProxyService defines overrides for the Proxy Service resource (points to the proxy deployment) |  |  |
+
+
+#### ResourceRequirements
+
+
+
+ResourceRequirements describes the compute resource requirements
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `limits` _[ResourceList](#resourcelist)_ | Limits describes the maximum amount of compute resources allowed |  |  |
+| `requests` _[ResourceList](#resourcelist)_ | Requests describes the minimum amount of compute resources required |  |  |
+
+
+#### SecretRef
+
+
+
+SecretRef is a reference to a secret
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the secret |  | Required: \{\} <br /> |
+| `key` _string_ | Key is the key in the secret itself |  | Required: \{\} <br /> |
+| `targetEnvName` _string_ | TargetEnvName is the environment variable to be used when setting up the secret in the MCP server<br />If left unspecified, it defaults to the key |  |  |
+
+
+#### Volume
+
+
+
+Volume represents a volume to mount in a container
+
+
+
+_Appears in:_
+- [MCPServerSpec](#mcpserverspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name is the name of the volume |  | Required: \{\} <br /> |
+| `hostPath` _string_ | HostPath is the path on the host to mount |  | Required: \{\} <br /> |
+| `mountPath` _string_ | MountPath is the path in the container to mount to |  | Required: \{\} <br /> |
+| `readOnly` _boolean_ | ReadOnly specifies whether the volume should be mounted read-only | false |  |
+
+


### PR DESCRIPTION
Adds the CRD reference into the reference section, sourcing the spec being generated in the main toolhive repo.

Updated update-toolhive-reference.sh script to take the release tag as a parameter and get the spec file from toolhive-operator-crds releases.

Once merged, will update the workflow on the toolhive repo to remove the condition on the release tag.