### PR TITLE
Add note about proxy mode for stdio

### DIFF
--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -159,9 +159,10 @@ server.
 ToolHive supports the following transport methods:
 
 - **Standard I/O** (`stdio`), default:\
-  ToolHive redirects SSE traffic from the client to the container's standard
-  input and output. This acts as a secure proxy, ensuring that the container
-  doesn't have direct access to the network or the host machine.
+  ToolHive redirects SSE or Streamable HTTP traffic from the client to the
+  container's standard input and output. This acts as a secure proxy, ensuring
+  that the container doesn't have direct access to the network or the host
+  machine.
 
 - **HTTP with SSE (server-sent events)** (`sse`):\
   ToolHive creates a reverse proxy that forwards requests to the container using
@@ -178,6 +179,11 @@ We are actively monitoring the adoption of the Streamable HTTP protocol across
 the client ecosystem. Once we confirm that ToolHive's supported clients support
 Streamable HTTP, we will make it the default proxy transport method for stdio
 servers.
+
+Currently, you can add the `--proxy-mode streamable-http` flag to the
+[`thv run`](../reference/cli/thv_run.md) command to use Streamable HTTP for
+stdio servers. This will ensure that the server is compatible with the latest
+MCP specification and can be used with clients that support Streamable HTTP.
 
 :::
 


### PR DESCRIPTION
New in v0.1.3, can optionally use streamable-http for stdio servers.