### PR TITLE
Specify --target-port on docs and match port on quickstart guide

### DIFF
--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -146,7 +146,7 @@ ToolHive creates a reverse proxy on a random port that forwards requests to the
 container. To specify the port for an MCP server:
 
 ```bash
-thv run --port <port-number> <server-name>
+thv run --target-port <port-number> <server-name>
 ```
 
 ## Run a custom MCP server

--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -143,10 +143,11 @@ Check the MCP server's documentation for the required arguments.
 ### Run a server on a specific port
 
 ToolHive creates a reverse proxy on a random port that forwards requests to the
-container. To specify the port for an MCP server:
+container. This is the port that client applications connect to. To set a
+specific proxy port instead, use the `--port` flag:
 
 ```bash
-thv run --target-port <port-number> <server-name>
+thv run --port <port-number> <server-name>
 ```
 
 ## Run a custom MCP server

--- a/docs/toolhive/tutorials/quickstart.mdx
+++ b/docs/toolhive/tutorials/quickstart.mdx
@@ -187,7 +187,7 @@ Image [mcp/fetch:latest] has 'latest' tag, pulling to ensure we have the most re
 Pulling image: [mcp/fetch:latest]
 ...
 Successfully pulled image: [mcp/fetch:latest]
-Using host port: [49226]
+Using host port: [15266]
 Logging to: [~/Library/Application Support/toolhive/logs/fetch.log]
 MCP server is running in the background (PID: [80087])
 Use 'thv stop [fetch]' to stop the server
@@ -217,7 +217,7 @@ NAME    PACKAGE            STATUS    URL                                PORT    
 fetch   mcp/fetch:latest   running   http://127.0.0.1:15266/sse#fetch   15266   mcp         2025-06-30 09:12:53 -0400 EDT
 ```
 
-This confirms that the fetch server is running and available on port 49226.
+This confirms that the fetch server is running and available on port 15266.
 
 :::info What's happening?
 

--- a/docs/toolhive/tutorials/quickstart.mdx
+++ b/docs/toolhive/tutorials/quickstart.mdx
@@ -187,7 +187,7 @@ Image [mcp/fetch:latest] has 'latest' tag, pulling to ensure we have the most re
 Pulling image: [mcp/fetch:latest]
 ...
 Successfully pulled image: [mcp/fetch:latest]
-Using host port: [15266]
+Using host port: [49226]
 Logging to: [~/Library/Application Support/toolhive/logs/fetch.log]
 MCP server is running in the background (PID: [80087])
 Use 'thv stop [fetch]' to stop the server


### PR DESCRIPTION
AFAIK we have 2 ports: the proxy port in which ToolHive runs and a hardcoded port that may be used by an MCP server. For the second one, the current flag should be `--target-port` instead of `--port`. Changed the only reference I could find in docs.

Also, there was a small typo in the quickstart guide in the ports. The text was talking about port `49226` but the port shown in the example was port `15266`.