### PR TITLE
Move registry contribution to the concepts page

### DIFF
--- a/docs/toolhive/concepts/registry-criteria.md
+++ b/docs/toolhive/concepts/registry-criteria.md
@@ -5,17 +5,32 @@ description: Criteria for adding MCP servers to the ToolHive registry
 
 The ToolHive registry is a curated list of MCP servers that meet specific
 criteria. We aim to establish a curated, community-auditable list of
-high-quality MCP servers through clear, observable, and objective criteria. Here
-are the criteria for adding an MCP server to the ToolHive registry:
+high-quality MCP servers through clear, observable, and objective criteria.
 
-## Heuristics
+## Contribute to the registry
+
+If you have an MCP server that you'd like to add to the ToolHive registry, you
+can
+[open an issue](https://github.com/stacklok/toolhive/issues/new?template=add-an-mcp-server.md)
+or submit a pull request to the ToolHive GitHub repository. The ToolHive team
+will review your submission and consider adding it to the registry.
+
+Criteria for adding an MCP server to the ToolHive registry are outlined below.
+These criteria ensure that the servers in the registry meet the standards of
+security, quality, and usability that ToolHive aims to uphold.
+
+Registry entries are defined in the
+[`pkg/registry/data/registry.json`](https://github.com/stacklok/toolhive/blob/main/pkg/registry/data/registry.json)
+file in the ToolHive repository.
+
+## Criteria for MCP servers
 
 ### Open source requirements
 
 - Must be fully open source with no exceptions
 - Source code must be publicly accessible
 - Must use an acceptable open source license (see
-  [Acceptable licenses](#acceptable-licenses) below)
+  [Acceptable licenses](#acceptable-licenses))
 
 ### Security
 

--- a/docs/toolhive/guides-cli/registry.md
+++ b/docs/toolhive/guides-cli/registry.md
@@ -3,9 +3,11 @@ title: Explore the registry
 description: How to use the built-in registry to find MCP servers.
 ---
 
-ToolHive includes a built-in registry of MCPs with verified configurations,
-allowing you to discover and deploy MCP servers effortlessly. Simply select one
-from the list and run it securely with a single command.
+ToolHive includes a built-in registry of MCP servers with verified
+configurations that meet a
+[minimum quality standard](../concepts/registry-criteria.md), allowing you to
+discover and deploy high-quality tools effortlessly. Simply select one from the
+list and run it securely with a single command.
 
 ## Find MCP servers
 
@@ -173,23 +175,6 @@ thv config unset-registry-url
 ```
 
 This restores the default behavior of using ToolHive's built-in registry.
-
-## Contribute to the registry
-
-If you have an MCP server that you'd like to add to the ToolHive registry, you
-can
-[open an issue](https://github.com/stacklok/toolhive/issues/new?template=add-an-mcp-server.md)
-or submit a pull request to the ToolHive GitHub repository. The ToolHive team
-will review your submission and consider adding it to the registry.
-
-Criteria for adding an MCP server to the ToolHive registry are outlined in
-[Registry criteria](../concepts/registry-criteria.md). These criteria ensure
-that the servers in the registry meet the standards of security, quality, and
-usability that ToolHive aims to uphold.
-
-Registry entries are defined in the
-[`pkg/registry/data/registry.json`](https://github.com/stacklok/toolhive/blob/main/pkg/registry/data/registry.json)
-file in the ToolHive repository.
 
 ## Next steps
 


### PR DESCRIPTION
### Description

Moves the "Contribute to the registry" section from the CLI section out to the Concepts page.

### Related issues/PRs

N/A

### Screenshots

N/A

### Merge checklist

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
