### PR TITLE
Update VS Code compatibility

### DIFF
--- a/docs/toolhive/_partials/_client-compat-table.md
+++ b/docs/toolhive/_partials/_client-compat-table.md
@@ -1,17 +1,17 @@
-| Client                     | Supported | Auto-configuration | Notes                                                |
-| -------------------------- | :-------: | :----------------: | ---------------------------------------------------- |
-| GitHub Copilot (VS Code)   |    ✅     |         ✅         | v1.100+ or Insiders version (v1.102+, [see note][3]) |
-| Cursor                     |    ✅     |         ✅         | v0.50.0+                                             |
-| Roo Code (VS Code)         |    ✅     |         ✅         | v3.19.2+                                             |
-| Cline (VS Code)            |    ✅     |         ✅         | v3.8.5+ (sse only; streamable-http [issue][2])       |
-| Claude Code CLI            |    ✅     |         ✅         | v1.0.27+                                             |
-| GitHub Copilot (JetBrains) |    ✅     |         ❌         | v1.5.47+                                             |
-| Continue (VS Code)         |    ✅     |         ❌         | v1.0.14+                                             |
-| Continue (JetBrains)       |    ✅     |         ❌         | v1.0.23+                                             |
-| PydanticAI                 |    ✅     |         ❌         | v0.2.18+                                             |
-| ChatGPT Desktop            |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]           |
-| Claude Desktop             |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]           |
-| Kiro                       |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]           |
+| Client                     | Supported | Auto-configuration | Notes                                          |
+| -------------------------- | :-------: | :----------------: | ---------------------------------------------- |
+| GitHub Copilot (VS Code)   |    ✅     |         ✅         | v1.102+ or Insiders version ([see note][3])    |
+| Cursor                     |    ✅     |         ✅         | v0.50.0+                                       |
+| Roo Code (VS Code)         |    ✅     |         ✅         | v3.19.2+                                       |
+| Cline (VS Code)            |    ✅     |         ✅         | v3.8.5+ (sse only; streamable-http [issue][2]) |
+| Claude Code CLI            |    ✅     |         ✅         | v1.0.27+                                       |
+| GitHub Copilot (JetBrains) |    ✅     |         ❌         | v1.5.47+                                       |
+| Continue (VS Code)         |    ✅     |         ❌         | v1.0.14+                                       |
+| Continue (JetBrains)       |    ✅     |         ❌         | v1.0.23+                                       |
+| PydanticAI                 |    ✅     |         ❌         | v0.2.18+                                       |
+| ChatGPT Desktop            |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
+| Claude Desktop             |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
+| Kiro                       |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
 
 [2]: https://github.com/cline/cline/issues/4391
 [3]: /toolhive/reference/client-compatibility.mdx#vs-code-with-copilot

--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -54,51 +54,37 @@ in your VS Code user settings file.
 
 :::note
 
-VS Code version 1.102 moved the MCP settings to a new location. Servers are now
-configured in a dedicated `mcp.json` file in the user settings directory.
+VS Code versions prior to v1.102 stored MCP server settings in the main
+`settings.json` file. As of v1.102, this has moved to a dedicated `mcp.json`
+file.
 
-ToolHive currently only supports the previous location (`settings.json`). When
-ToolHive adds a new MCP server, VS Code prompts you to move it to the new
-location.
+ToolHive v0.2.0 and works with VS Code 1.102+ and updates the `mcp.json` file
+when you run an MCP server.
 
-<img
-  src='/img/toolhive/vscode-config-update.webp'
-  alt='Screenshot of the VS Code MCP move prompt'
-  width={440}
-/>
-
-This works, but ToolHive will not automatically update the new `mcp.json` file
-in the same location as the `settings.json` file referenced below. You can still
-use the MCP servers, but you will need to manually update the `mcp.json` file if
-you stop or remove the server.
-
-Subscribe to [this issue](https://github.com/stacklok/toolhive/issues/1037) for
-updates on ToolHive's support for the new MCP configuration location.
+If you're using an older version of either ToolHive or VS Code, automatic client
+configuration will not work as expected and you will need to manually update
+your configurations. We recommend upgrading both for the best experience.
 
 :::
 
 **Standard version**:
 
-- **macOS**: `~/Library/Application Support/Code/User/settings.json`
-- **Linux**: `~/.config/Code/User/settings.json`
+- **macOS**: `~/Library/Application Support/Code/User/mcp.json`
+- **Linux**: `~/.config/Code/User/mcp.json`
 
 **Insiders edition**:
 
-- **macOS**: `~/Library/Application Support/Code - Insiders/User/settings.json`
-- **Linux**: `~/.config/Code - Insiders/User/settings.json`
+- **macOS**: `~/Library/Application Support/Code - Insiders/User/mcp.json`
+- **Linux**: `~/.config/Code - Insiders/User/mcp.json`
 
 Example configuration:
 
 ```json
 {
-  // Other VS Code settings...
-
-  "mcp": {
-    "servers": {
-      "github": { "url": "http://localhost:19046/sse#github", "type": "sse" },
-      "fetch": { "url": "http://localhost:43832/sse#fetch", "type": "sse" },
-      "osv": { "url": "http://localhost:51712/mcp", "type": "http" }
-    }
+  "servers": {
+    "github": { "url": "http://localhost:19046/sse#github", "type": "sse" },
+    "fetch": { "url": "http://localhost:43832/sse#fetch", "type": "sse" },
+    "osv": { "url": "http://localhost:51712/mcp", "type": "http" }
   }
 }
 ```


### PR DESCRIPTION
### Description

Updated the client compatibility for VS Code noting ToolHive v0.2.0's support for Code v1.102+ and the new config file.

### Related issues/PRs

Related to stacklok/toolhive#1037 and stacklok/toolhive#1091

Updates the note originally added in #58

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  - Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`)

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
