### PR TITLE
Document new UI settings screen, other minor polish

### DIFF
--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -38,7 +38,7 @@ Select your operating system to see the installation instructions.
 Download the latest ToolHive installer for
 [Apple silicon](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive-arm64.dmg)
 or
-[Intel-based](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive-arm64.dmg)
+[Intel-based](https://github.com/stacklok/toolhive-studio/releases/latest/download/ToolHive-x64.dmg)
 Macs and open the DMG file.
 
 Copy the ToolHive app to your Applications folder. You can then open it from
@@ -53,8 +53,8 @@ and run the setup executable.
 
 :::note
 
-The Windows installer is not digitally signed yet, so you will need to accept
-the warning from Windows Defender SmartScreen. We're working on getting a signed
+The Windows installer is not digitally signed yet, so you'll need to accept the
+warning from Windows Defender SmartScreen. We're working on getting a signed
 installer published soon.
 
 :::
@@ -96,7 +96,7 @@ and extract it, then run the `ToolHive` binary directly.
 
 ## System tray icon
 
-When you close the ToolHive application window, it stays running in the
+When you close the ToolHive application window, it continues running in the
 background so your MCP servers remain available. ToolHive installs a system tray
 icon for quick access. You can use it to:
 
@@ -104,14 +104,23 @@ icon for quick access. You can use it to:
 - Show or hide the ToolHive application window
 - Quit ToolHive, which stops all running MCP servers
 
-## Run ToolHive on login
+## Application settings
 
-You can configure ToolHive to start automatically when you log in to your
-system. This is useful if you want your MCP servers to be available without
-manually starting ToolHive each time.
+Open the ToolHive settings screen from the gear icon (⚙️) in the application
+window. The settings screen allows you to configure various options:
 
-To enable this feature, turn on the **Start on login** option in the system tray
-icon menu or in the settings menu (⚙️) in the application.
+- **Display theme**: Choose between light and dark themes for the application.
+  ToolHive matches your system theme by default.
+- **Start on login**: Automatically start ToolHive when you log in to your
+  system. MCP servers that were running when you quit ToolHive are restarted
+  automatically.
+- **Error reporting**: Enable or disable error reporting and telemetry data
+  collection.
+- **Skip quit confirmation**: Skip the MCP server shutdown confirmation dialog
+  when quitting ToolHive.
+
+From the settings screen, you can also view version information and download the
+application log file for troubleshooting.
 
 ## Upgrade ToolHive
 
@@ -178,13 +187,16 @@ configuration file and secrets store to support coexistence.
 </TabItem>
 </Tabs>
 
+You can also download the application log file from the **Settings** screen (⚙️)
+in the ToolHive UI.
+
 ## Telemetry and error reporting
 
 ToolHive uses [Sentry](https://sentry.io/welcome/) for error tracking and
 performance monitoring to help us identify and fix issues, improve stability,
 and enhance the user experience. This telemetry is enabled by default. You can
-disable this by turning off the **Error reporting** option in the settings menu
-(⚙️) if you prefer not to share this data.
+disable this by turning off the **Error reporting** option in the settings
+screen (⚙️) if you prefer not to share this data.
 
 ToolHive collects the following information:
 
@@ -215,15 +227,15 @@ MCP servers. See [Run MCP servers](./run-mcp-servers.md) to get started.
 <details>
 <summary>Connection Refused error on startup</summary>
 
-If you see a "Connection Refused" error when starting ToolHive, it's likely
-because your container runtime (Docker or Podman) is not installed, not running,
-or not configured correctly.
+If you see a "Connection Refused" error when starting ToolHive, your container
+runtime (Docker or Podman) is likely not installed, not running, or not
+configured correctly.
 
-Follow the instructions on the error message to install or start your container
-runtime. For example, if you're using Docker Desktop, make sure it is running
-and that the Docker daemon is active.
+Follow the instructions in the error message to install or start your container
+runtime. For example, if you're using Docker Desktop, make sure it's running and
+that the Docker daemon is active.
 
-If the retry button doesn't work, try restarting ToolHive.
+If the retry button doesn't work, restart ToolHive.
 
 </details>
 


### PR DESCRIPTION
### Description

Updates the UI install doc to reference the new dedicated settings screen.

Also fixed a bad link to the x64 DMG.

### Related issues/PRs

stacklok/toolhive-studio#622

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  - Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`)

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
