### PR TITLE
Add governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <code-of-conduct@stacklok.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Stacklok Docs <!-- omit from toc -->
+
+First off, thank you for taking the time to contribute to the Stacklok
+documentation! :+1: :tada: This project is released under the Apache 2.0
+license. If you would like to contribute something or want to hack on the code,
+this document should help you get started. You can find some hints for starting
+development in the [README](README.md).
+
+## Table of contents <!-- omit from toc -->
+
+- [Code of conduct](#code-of-conduct)
+- [Reporting security vulnerabilities](#reporting-security-vulnerabilities)
+- [How to contribute](#how-to-contribute)
+  - [Docs framework and style](#docs-framework-and-style)
+  - [Using GitHub Issues](#using-github-issues)
+  - [Pull request process](#pull-request-process)
+  - [Commit message guidelines](#commit-message-guidelines)
+
+## Code of conduct
+
+This project adheres to the [Contributor Covenant](CODE_OF_CONDUCT.md) code of
+conduct. By participating, you are expected to uphold this code. Please report
+unacceptable behavior to
+[code-of-conduct@stacklok.dev](mailto:code-of-conduct@stacklok.dev).
+
+## Reporting security vulnerabilities
+
+If you think you have found a security vulnerability in the Stacklok Docs
+website, please DO NOT disclose it publicly until we've had a chance to fix it.
+Please don't report security vulnerabilities using GitHub issues; instead,
+please follow this [process](SECURITY.MD).
+
+## How to contribute
+
+### Docs framework and style
+
+Please review the [README](README.md) and [STYLE-GUIDE](STYLE-GUIDE.md) for more
+information about how to contribute to the documentation.
+
+### Using GitHub Issues
+
+We use GitHub issues to track bugs and enhancements. If you have a general usage
+question, please ask in
+[Stacklok's community Discord](https://discord.gg/stacklok).
+
+If you are reporting a bug, please help to speed up problem diagnosis by
+providing as much information as possible. Ideally, that would include a small
+sample project that reproduces the problem.
+
+### Pull request process
+
+- -All commits must include a Signed-off-by trailer at the end of each commit
+  message to indicate that the contributor agrees to the Developer Certificate
+  of Origin. For additional details, check out the [DCO instructions](DCO.md).
+- Create an issue outlining the fix or feature.
+- Fork the repository to your own GitHub account and clone it locally.
+- Hack on your changes.
+- Correctly format your commit messages, see
+  [Commit message guidelines](#commit-message-guidelines) below.
+- Open a PR by ensuring the title and its description reflect the content of the
+  PR.
+- Ensure that CI passes, if it fails, fix the failures.
+- Every pull request requires a review from the Stacklok team before merging.
+- Once approved, all of your commits will be squashed into a single commit with
+  your PR title.
+
+### Commit message guidelines
+
+We follow the commit formatting recommendations found on
+[Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/):
+
+1. Separate subject from body with a blank line
+1. Limit the subject line to 50 characters
+1. Capitalize the subject line
+1. Do not end the subject line with a period
+1. Use the imperative mood in the subject line
+1. Use the body to explain what and why vs. how

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ unacceptable behavior to
 If you think you have found a security vulnerability in the Stacklok Docs
 website, please DO NOT disclose it publicly until we've had a chance to fix it.
 Please don't report security vulnerabilities using GitHub issues; instead,
-please follow this [process](SECURITY.MD).
+please follow this [process](SECURITY.md).
 
 ## How to contribute
 

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,52 @@
+# Developer Certificate of Origin (DCO)
+
+In order to contribute to the project, you must agree to the Developer
+Certificate of Origin. A
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/) is an
+affirmation that the developer contributing the proposed changes has the
+necessary rights to submit those changes. A DCO provides some additional legal
+protections while being relatively easy to do.
+
+The entire DCO can be summarized as:
+
+- Certify that the submitted code can be submitted under the open source license
+  of the project (e.g. Apache 2.0)
+- I understand that what I am contributing is public and will be redistributed
+  indefinitely
+
+## How to Use Developer Certificate of Origin
+
+In order to contribute to the project, you must agree to the Developer
+Certificate of Origin. To confirm that you agree, your commit message must
+include a Signed-off-by trailer at the bottom of the commit message.
+
+For example, it might look like the following:
+
+```bash
+A commit message
+
+Closes gh-345
+
+Signed-off-by: jane marmot <jmarmot@example.org>
+```
+
+The Signed-off-by [trailer](https://git-scm.com/docs/git-interpret-trailers) can
+be added automatically by using the
+[-s or –signoff command line option](https://git-scm.com/docs/git-commit/2.13.7#Documentation/git-commit.txt--s)
+when specifying your commit message:
+
+```bash
+git commit -s -m
+```
+
+If you have chosen the
+[Keep my email address private](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#about-commit-email-addresses)
+option within GitHub, the Signed-off-by trailer might look something like:
+
+```bash
+A commit message
+
+Closes gh-345
+
+Signed-off-by: jane marmot <462403+jmarmot@users.noreply.github.com>
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+Stacklok takes security seriously! We appreciate your efforts to disclose your
+findings responsibly and will make every effort to acknowledge your
+contributions.
+
+## Reporting a vulnerability
+
+To report a security issue, please use the GitHub Security Advisory
+["Report a Vulnerability"](https://github.com/stacklok/docs-website/security/advisories/new)
+tab.
+
+If you are unable to access GitHub you can also email us at
+[security@stacklok.com](mailto:security@stacklok.com).
+
+When reporting a vulnerability, please include:
+
+- Steps to reproduce the issue
+- Description of the potential impact
+- Any additional context that would help us understand the issue
+
+If you are only comfortable sharing under GPG, please start by sending an email
+requesting a public PGP key to use for encryption.
+
+### Contacting the Stacklok security team
+
+Contact the team by sending email to
+[security@stacklok.com](mailto:security@stacklok.com).
+
+## About this project
+
+This repository contains a documentation website built with Docusaurus. Security
+vulnerabilities in this context are most likely to come from:
+
+- Upstream dependencies (Node.js packages, Docusaurus framework)
+- Build and deployment pipeline issues
+- Content injection or cross-site scripting vulnerabilities
+- Infrastructure or hosting configuration issues
+
+## Disclosure process
+
+Stacklok follows a responsible disclosure model for handling security
+vulnerabilities.
+
+### Private disclosure
+
+We prefer that suspected vulnerabilities be reported privately to allow us time
+to investigate and address the issue before public disclosure.
+
+### Public disclosure
+
+If you become aware of a publicly disclosed security vulnerability that affects
+this documentation website, please email
+[security@stacklok.com](mailto:security@stacklok.com) immediately so we can
+assess the impact and take appropriate action.
+
+## Response process
+
+When a vulnerability is reported:
+
+1. **Acknowledgment**: We will acknowledge receipt of your report within 2
+   business days
+2. **Assessment**: Our security team will assess the vulnerability and determine
+   its impact
+3. **Resolution**: We will work to address the issue, which may involve:
+   - Updating dependencies
+   - Modifying configuration
+   - Coordinating with upstream projects
+   - Implementing workarounds or mitigations
+4. **Communication**: We will keep you informed of our progress and notify the
+   community as appropriate
+
+For vulnerabilities in upstream dependencies, our response timeline may depend
+on fixes being available from the upstream maintainers.
+
+## Community notification
+
+Significant security updates will be communicated through:
+
+- GitHub Security Advisories
+- Updates to this documentation
+- The [Stacklok Discord Server](https://discord.gg/stacklok)


### PR DESCRIPTION
Adds OSS governance docs to the repo: contributing guide, CoC, and security policy.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>