### PR TITLE
Update Cline version

### DIFF
--- a/docs/toolhive/_partials/_client-compat-table.md
+++ b/docs/toolhive/_partials/_client-compat-table.md
@@ -1,24 +1,23 @@
-| Client                     | Supported | Auto-configuration | Notes                                          |
-| -------------------------- | :-------: | :----------------: | ---------------------------------------------- |
-| GitHub Copilot (VS Code)   |    ✅     |         ✅         | v1.102+ or Insiders version ([see note][3])    |
-| Cursor                     |    ✅     |         ✅         | v0.50.0+                                       |
-| Roo Code (VS Code)         |    ✅     |         ✅         | v3.19.2+                                       |
-| Cline (VS Code)            |    ✅     |         ✅         | v3.8.5+ (sse only; streamable-http [issue][2]) |
-| Claude Code CLI            |    ✅     |         ✅         | v1.0.27+                                       |
-| Windsurf IDE               |    ✅     |         ✅         |                                                |
-| Windsurf (JetBrains)       |    ✅     |         ✅         |                                                |
-| Sourcegraph Amp CLI        |    ✅     |         ✅         |                                                |
-| Sourcegraph Amp (VS Code)  |    ✅     |         ✅         |                                                |
-| Sourcegraph Amp (Cursor)   |    ✅     |         ✅         |                                                |
-| Sourcegraph Amp (Windsurf) |    ✅     |         ✅         |                                                |
-| GitHub Copilot (JetBrains) |    ✅     |         ❌         | v1.5.47+                                       |
-| Continue (VS Code)         |    ✅     |         ❌         | v1.0.14+                                       |
-| Continue (JetBrains)       |    ✅     |         ❌         | v1.0.23+                                       |
-| PydanticAI                 |    ✅     |         ❌         | v0.2.18+                                       |
-| ChatGPT Desktop            |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
-| Claude Desktop             |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
-| Kiro                       |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]     |
+| Client                     | Supported | Auto-configuration | Notes                                       |
+| -------------------------- | :-------: | :----------------: | ------------------------------------------- |
+| GitHub Copilot (VS Code)   |    ✅     |         ✅         | v1.102+ or Insiders version ([see note][3]) |
+| Cursor                     |    ✅     |         ✅         | v0.50.0+                                    |
+| Roo Code (VS Code)         |    ✅     |         ✅         | v3.19.2+                                    |
+| Cline (VS Code)            |    ✅     |         ✅         | v3.17.10+                                   |
+| Claude Code CLI            |    ✅     |         ✅         | v1.0.27+                                    |
+| Windsurf IDE               |    ✅     |         ✅         |                                             |
+| Windsurf (JetBrains)       |    ✅     |         ✅         |                                             |
+| Sourcegraph Amp CLI        |    ✅     |         ✅         |                                             |
+| Sourcegraph Amp (VS Code)  |    ✅     |         ✅         |                                             |
+| Sourcegraph Amp (Cursor)   |    ✅     |         ✅         |                                             |
+| Sourcegraph Amp (Windsurf) |    ✅     |         ✅         |                                             |
+| GitHub Copilot (JetBrains) |    ✅     |         ❌         | v1.5.47+                                    |
+| Continue (VS Code)         |    ✅     |         ❌         | v1.0.14+                                    |
+| Continue (JetBrains)       |    ✅     |         ❌         | v1.0.23+                                    |
+| PydanticAI                 |    ✅     |         ❌         | v0.2.18+                                    |
+| ChatGPT Desktop            |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]  |
+| Claude Desktop             |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]  |
+| Kiro                       |    ❌     |         ❌         | See [workaround for STDIO-only clients][4]  |
 
-[2]: https://github.com/cline/cline/issues/4391
 [3]: /toolhive/reference/client-compatibility.mdx#vs-code-with-copilot
 [4]: /toolhive/reference/client-compatibility#stdio-only-client-configuration

--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -179,6 +179,7 @@ Example configuration:
     "github": { "url": "http://localhost:19046/sse#github", "type": "sse" },
     "fetch": { "url": "http://localhost:43832/sse#fetch", "type": "sse" },
     "osv": { "url": "http://localhost:51712/mcp", "type": "streamable-http" }
+    // Note: Cline uses "streamableHttp" instead of "streamable-http"
   }
 }
 ```


### PR DESCRIPTION
### Description

Updates the minimum Cline version to 3.17.10. Streamable HTTP support was fixed as of this version.

### Related issues/PRs

stacklok/toolhive#1519

### Merge checklist

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>
