### PR TITLE
Update registry references to toolhive-registry repo

### DIFF
--- a/docs/toolhive/concepts/registry-criteria.md
+++ b/docs/toolhive/concepts/registry-criteria.md
@@ -11,17 +11,18 @@ high-quality MCP servers through clear, observable, and objective criteria.
 
 If you have an MCP server that you'd like to add to the ToolHive registry, you
 can
-[open an issue](https://github.com/stacklok/toolhive/issues/new?template=add-an-mcp-server.md)
-or submit a pull request to the ToolHive GitHub repository. The ToolHive team
-will review your submission and consider adding it to the registry.
+[open an issue](https://github.com/stacklok/toolhive-registry/issues/new?template=add-an-mcp-server.md)
+or submit a pull request to the
+[ToolHive-registry](https://github.com/stacklok/toolhive-registry) repository.
+The ToolHive team will review your submission and consider adding it to the
+registry.
 
 Criteria for adding an MCP server to the ToolHive registry are outlined below.
 These criteria ensure that the servers in the registry meet the standards of
 security, quality, and usability that ToolHive aims to uphold.
 
 Registry entries are defined in the
-[`pkg/registry/data/registry.json`](https://github.com/stacklok/toolhive/blob/main/pkg/registry/data/registry.json)
-file in the ToolHive repository.
+[ToolHive-registry](https://github.com/stacklok/toolhive-registry) repository.
 
 ## Criteria for MCP servers
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Updated registry definition reference to point to toolhive-registry repo
- Updated issue submission link to use toolhive-registry repo  
- Updated pull request submission reference to toolhive-registry repo

## Test plan
- [x] Verified toolhive-registry repository exists and is accessible
- [x] Verified issue template file exists in the repository
- [x] Ran formatting and linting checks

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)