### PR TITLE
Add warning about MCP server default arguments

### DIFF
--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -150,6 +150,24 @@ thv run my-mcp-server:latest -- --arg1 value1 --arg2 value2
 
 Check the MCP server's documentation for the required arguments.
 
+:::warning
+
+Some MCP servers in the ToolHive registry include default arguments that are
+essential for proper operation. When you provide custom arguments using
+`-- <ARGS>`, these replace the registry defaults entirely rather than adding to
+them.
+
+Before adding custom arguments, check the server's registry entry:
+
+```bash
+thv registry info <SERVER> --format json | jq '.args'
+```
+
+If default arguments are listed, include them along with your custom arguments
+to ensure the server functions correctly.
+
+:::
+
 ### Run a server on a specific port
 
 ToolHive creates a reverse proxy on a random port that forwards requests to the


### PR DESCRIPTION
### Description
Adds a warning to the CLI guide about MCP server default arguments from the registry being overridden when users provide custom arguments. This addresses a potential configuration issue where users unknowingly remove essential default arguments, causing servers to fail.

### Merge checklist

#### Content

- [x] New pages include a frontmatter section with title and description at a minimum (N/A)
- [x] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files (N/A)
- [x] Redirects added to `vercel.json` for moved, renamed, or deleted pages (N/A)

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>