### PR TITLE
Renovate: Add minimumReleaseAge setting for npm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
     {
       "matchPackageNames": ["husky", "lint-staged", "markdownlint*", "globals"],
       "groupName": "linters"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
Reference: https://docs.renovatebot.com/configuration-options/#prevent-holding-broken-npm-packages

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>