### PR TITLE
docs: Add logging infrastructure guide for Kubernetes deployments

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator-helm.md
+++ b/docs/toolhive/guides-k8s/deploy-operator-helm.md
@@ -70,7 +70,8 @@ kubectl logs -f -n toolhive-system <TOOLHIVE_OPERATOR_POD_NAME>
 ```
 
 This shows you the logs of the operator pod, which can help you debug any
-issues.
+issues. For comprehensive logging and audit capabilities, see the
+[Logging infrastructure](./logging-infrastructure.md) guide.
 
 ## Customize the operator
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -123,6 +123,7 @@ const sidebars: SidebarsConfig = {
         'toolhive/guides-k8s/deploy-operator-helm',
         'toolhive/guides-k8s/run-mcp-k8s',
         'toolhive/guides-k8s/telemetry-and-metrics',
+        'toolhive/guides-k8s/logging-infrastructure',
         'toolhive/reference/crd-spec',
       ],
     },


### PR DESCRIPTION
- Add comprehensive logging infrastructure documentation covering standard and audit logs
- Document log format specifications with field definitions
- Include configuration examples for operator and MCPServer resources
- Add log collection strategies and enterprise tool integration (ELK, Splunk, Datadog)
- Update sidebar navigation to include the new guide
- Add contextual reference from deploy-operator-helm.md

Addresses: https://github.com/stacklok/toolhive-enterprise/issues/39
