### PR TITLE
Add required `targetPort` attribute

### DIFF
--- a/docs/toolhive/guides-k8s/run-mcp-k8s.md
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.md
@@ -118,6 +118,7 @@ metadata:
 spec:
   image: ghcr.io/stackloklabs/osv-mcp/server
   transport: streamable-http
+  targetPort: 8080
   port: 8080
   permissionProfile:
     type: builtin
@@ -219,6 +220,7 @@ metadata:
 spec:
   image: ghcr.io/stackloklabs/gofetch/server
   transport: streamable-http
+  targetPort: 8080
   port: 8080
   permissionProfile:
     type: builtin


### PR DESCRIPTION
Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>

### Description

Fixes some K8s manifest examples, seems `targetPort` is now required for `streamable-http` transport in the latest Operator.

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
