### PR TITLE
reflect new Clients management location

### DIFF
--- a/docs/toolhive/guides-ui/client-configuration.mdx
+++ b/docs/toolhive/guides-ui/client-configuration.mdx
@@ -7,32 +7,43 @@ import ClientIntro from '../_partials/_client-config-intro.mdx';
 
 <ClientIntro term='Connect' />
 
-## Manage client connections
+## Manage clients
 
-ToolHive automatically discovers supported AI clients that are installed on your
-system. These are displayed on the **Clients** page. This discovery is dynamic:
-if you install a new client, ToolHive automatically updates the list.
+ToolHive automatically discovers supported AI clients installed on your system.
+To choose which clients ToolHive configures, open the **MCP Servers** page and
+click **Manage Clients**. This opens a dialog that lists detected clients with
+on/off toggles. Discovery is dynamic: if you install a new client, ToolHive
+updates the list.
 
 ### Connect a client
 
-To connect a client to ToolHive, toggle the switch under the client's name.
+To connect a client to ToolHive:
 
-When you connect a client, ToolHive automatically configures it to use your
-currently running MCP servers. Any new servers you start are also added.
+1. Go to **MCP Servers** and click **Manage Clients**.
+2. Turn on the toggle for the client you want to connect.
+3. Click **Save** to apply your changes.
 
-When you stop or remove an MCP server, ToolHive updates the client's
-configuration to remove the server.
+When you connect a client and save, ToolHive configures it to use your running
+MCP servers. Any new servers you start are also added automatically. When you
+stop or remove an MCP server, ToolHive updates the client's configuration to
+remove the server.
 
 ### Disconnect a client
 
-When you disconnect a client, ToolHive removes all MCP server configurations
-from the client. The client will no longer be able to use any ToolHive-managed
-MCP servers.
+To disconnect, open **Manage Clients**, turn off the client's toggle, then click
+**Save**. ToolHive removes the MCP server configurations from that client. The
+client can no longer use ToolHive-managed MCP servers.
+
+### Save your changes
+
+Changes you make in **Manage Clients** are not applied until you click **Save**.
+If you close the dialog or click **Cancel** without saving, your toggle changes
+are discarded.
 
 ## Why don't I see my client?
 
-If you don't see your client listed, ToolHive might not support it, or its
-configuration file might not be in a location ToolHive recognizes.
+If you don't see your client in **Manage Clients**, ToolHive might not support
+it, or its configuration file might not be in a location ToolHive recognizes.
 
 For a list of supported clients and how ToolHive detects them, see the
 [client compatibility reference](../reference/client-compatibility.mdx).
@@ -40,9 +51,9 @@ For a list of supported clients and how ToolHive detects them, see the
 ## Why do I still see a client I uninstalled?
 
 Many clients leave behind configuration files even after you uninstall them.
-ToolHive detects these files and continues to show the client in the UI. If you
-want to remove the client from ToolHive, delete its configuration files
-manually.
+ToolHive detects these files and continues to show the client in the **Manage
+Clients** dialog. If you want to remove the client from ToolHive, delete its
+configuration files manually.
 
 ## Manual client configuration
 


### PR DESCRIPTION


### Description

The UI made slight changes: now client management is part of a modal dialog, not a separate "page". Nevertheless, apart from this visual change, the only real difference is that now you have to click the save button for changes to take effect.

fixes #170

### Related issues/PRs
fixes #170


### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [ ] New pages include a frontmatter section with title and description at a minimum
- [ ] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [ ] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [ ] Content has been reviewed for technical accuracy
- [ ] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
