### PR TITLE
Add docs for new `thv run --tools-override` flag.

### DIFF
--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -227,7 +227,8 @@ description like:
 "Fetches a URL from the internet and optionally extracts its contents as markdown."
 ```
 
-You can now change it by supplying a file like the following
+To override this, create a configuration file with one entry under
+`toolsOverride` for each tool you want to modify:
 
 ```json
 {


### PR DESCRIPTION
### Description

This change adds a small section under the "Run MCP servers" page documenting how to override filter names and descriptions.

Fixes #127

### Related issues/PRs

https://github.com/stacklok/toolhive/pull/1841

### Merge checklist

- [ ] ToolHive CLI release

#### Reviews

- [ ] Content has been reviewed for technical accuracy
- [ ] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
