### PR TITLE
Temporary fix for new early exit behavior in thv

### DIFF
--- a/scripts/install-thv.sh
+++ b/scripts/install-thv.sh
@@ -33,8 +33,8 @@ fi
 
 # Temporary fix for early exit if container runtime isn't found
 
-RELEASE_VERSION="v0.2.9"
-RELEASE_TARBALL="https://github.com/stacklok/toolhive/releases/download/v0.2.9/toolhive_0.2.9_linux_amd64.tar.gz"
+RELEASE_VERSION="v0.2.17"
+RELEASE_TARBALL="https://github.com/stacklok/toolhive/releases/download/v0.2.17/toolhive_0.2.17_linux_amd64.tar.gz"
 
 # Determine installation location based on write permissions
 if [[ -w "/usr/local/bin" ]]; then

--- a/scripts/install-thv.sh
+++ b/scripts/install-thv.sh
@@ -13,23 +13,28 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
-API_ENDPOINT="https://api.github.com/repos/stacklok/toolhive/releases/latest"
+#API_ENDPOINT="https://api.github.com/repos/stacklok/toolhive/releases/latest"
 
 # Fetch release information
-RELEASE_JSON=$(curl -sf "$API_ENDPOINT" || {
-    echo "Failed to fetch release information from GitHub API"
-    exit 1
-})
-RELEASE_VERSION=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty' | sed 's/^v//')
-RELEASE_TARBALL=$(echo "$RELEASE_JSON" | jq -r \
-    --arg version "$RELEASE_VERSION" \
-    '.assets[] | select(.name == "toolhive_" + $version + "_linux_amd64.tar.gz") | .browser_download_url // empty')
+#RELEASE_JSON=$(curl -sf "$API_ENDPOINT" || {
+#    echo "Failed to fetch release information from GitHub API"
+#    exit 1
+#})
+#RELEASE_VERSION=$(echo "$RELEASE_JSON" | jq -r '.tag_name // empty' | sed 's/^v//')
+#RELEASE_TARBALL=$(echo "$RELEASE_JSON" | jq -r \
+#    --arg version "$RELEASE_VERSION" \
+#    '.assets[] | select(.name == "toolhive_" + $version + "_linux_amd64.tar.gz") | .browser_download_url // empty')
 
-if [ -z "$RELEASE_TARBALL" ]; then
-    echo "Failed to get release tarball URL for release: ${RELEASE_VERSION}"
-    echo "Please check if the tag exists in the repository"
-    exit 1
-fi
+#if [ -z "$RELEASE_TARBALL" ]; then
+#    echo "Failed to get release tarball URL for release: ${RELEASE_VERSION}"
+#    echo "Please check if the tag exists in the repository"
+#    exit 1
+#fi
+
+# Temporary fix for early exit if container runtime isn't found
+
+RELEASE_VERSION="v0.2.9"
+RELEASE_TARBALL="https://github.com/stacklok/toolhive/releases/download/v0.2.9/toolhive_0.2.9__linux_amd64.tar.gz"
 
 # Determine installation location based on write permissions
 if [[ -w "/usr/local/bin" ]]; then

--- a/scripts/install-thv.sh
+++ b/scripts/install-thv.sh
@@ -34,7 +34,7 @@ fi
 # Temporary fix for early exit if container runtime isn't found
 
 RELEASE_VERSION="v0.2.9"
-RELEASE_TARBALL="https://github.com/stacklok/toolhive/releases/download/v0.2.9/toolhive_0.2.9__linux_amd64.tar.gz"
+RELEASE_TARBALL="https://github.com/stacklok/toolhive/releases/download/v0.2.9/toolhive_0.2.9_linux_amd64.tar.gz"
 
 # Determine installation location based on write permissions
 if [[ -w "/usr/local/bin" ]]; then


### PR DESCRIPTION
Temporarily hardcoding the Vercel install script to work aorund the new v0.3.0+ behavior of exiting early if a container runtime isn't found.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>