### PR TITLE
add an example about accessing internal workloads

### DIFF
--- a/docs/toolhive/guides-ui/network-isolation.mdx
+++ b/docs/toolhive/guides-ui/network-isolation.mdx
@@ -79,6 +79,19 @@ The configuration pictured below allows the MCP server to access
 />
 <br />
 
+### Accessing other workloads on the same network
+
+To allow an MCP server to access other workloads on the same network, you need
+to configure network isolation to include the appropriate hostnames and ports.
+This is commonly needed when your MCP server needs to communicate with
+databases, APIs, or other services that are not publicly accessible.
+
+For example, in Docker environments, you can add `host.docker.internal` to
+access services on the host:
+
+- **Allowed hosts**: `host.docker.internal`
+- **Allowed ports**: `3000`
+
 ## Related information
 
 - [Run MCP servers](./run-mcp-servers.md)


### PR DESCRIPTION
This is specifically for accessing containers on the same network when running network isolation

### Description
Add an example about how to enable access to internal workloads on the same network

### Related issues/PRs
https://stacklok.slack.com/archives/C08JYS26TV3/p1758776181092359

### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [ ] New pages include a frontmatter section with title and description at a minimum
- [ ] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [ ] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [ ] Content has been reviewed for technical accuracy
- [ ] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
