### PR TITLE
Updates for Docusaurus v4 future-proofing

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -41,7 +41,7 @@ const config: Config = {
   projectName: 'docs-website', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenAnchors: 'warn',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -57,6 +57,10 @@ const config: Config = {
       comments: false,
       admonitions: false,
       headingIds: true,
+    },
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownImages: 'throw',
     },
   },
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -211,23 +211,23 @@ thead th {
 }
 
 /* Tab components */
-.tabs-container {
+.theme-tabs-container {
   background-color: var(--ifm-card-background-color);
   border: 1px solid var(--ifm-table-border-color);
   border-radius: var(--ifm-card-border-radius);
   margin-bottom: 1rem;
 }
 
-.tabs-container > ul {
+.theme-tabs-container > ul {
   background-color: #f8fafc;
 }
 
-[data-theme='dark'] .tabs-container > ul {
+[data-theme='dark'] .theme-tabs-container > ul {
   background-color: #1a1c1f;
   border-color: #1a1a1c;
 }
 
-.tabs-container > ul {
+.theme-tabs-container > ul {
   border-bottom: 1px solid #f0f0f0;
   border-top-left-radius: var(--ifm-card-border-radius);
   border-top-right-radius: var(--ifm-card-border-radius);

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -167,17 +167,17 @@ thead th {
   );
 }
 
-.navbar .DocSearch-Button {
+.theme-layout-navbar .DocSearch-Button {
   border-style: solid;
   border-width: 1px;
   height: 40px;
 }
 
-.navbar .DocSearch-Button {
+.theme-layout-navbar .DocSearch-Button {
   border-color: #dcdcdc;
 }
 
-[data-theme='dark'] .navbar .DocSearch-Button {
+[data-theme='dark'] .theme-layout-navbar .DocSearch-Button {
   border-color: #333333;
 }
 

--- a/src/css/footer.css
+++ b/src/css/footer.css
@@ -29,12 +29,12 @@
   padding: 0px 12px;
 }
 
-.footer__col:first-child {
+.theme-layout-footer-column:first-child {
   max-width: 400px;
   margin-right: auto;
 }
 
-.footer__col:last-child {
+.theme-layout-footer-column:last-child {
   max-width: 200px;
   margin-right: 0px;
 }


### PR DESCRIPTION
Future compatibility updates introduced in Docusaurus v3.8.0 and v3.9.0:

- Use new stable CSS class names
- `onBrokenMarkdownLinks` setting moved to `markdown.hooks.onBrokenMarkdownLinks`

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>