### PR TITLE
Add docs for inbound network isolation

### DIFF
--- a/docs/toolhive/guides-cli/custom-permissions.mdx
+++ b/docs/toolhive/guides-cli/custom-permissions.mdx
@@ -32,7 +32,11 @@ Profiles are defined in JSON format and can include the following properties:
 - `read`: List of paths on your host file system that the MCP server can read
 - `write`: List of file system paths that the MCP server can write to (this also
   implies read access)
-- `network`: Network access rules for outbound connections:
+- `network`: Network access rules for inbound and outbound connections:
+  - `inbound`: Inbound network access rules, which include:
+    - `allow_host`: List of allowed hostnames that can send traffic to the MCP
+      server. If not specified, only the container's own hostname, `localhost`,
+      and `127.0.0.1` are allowed.
   - `outbound`: Outbound network access rules, which include:
     - `insecure_allow_all`: If set to `true`, allows unrestricted outbound
       network access. This isn't recommended for production use.

--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -304,10 +304,6 @@ Create a permission profile that allows specific inbound hostnames:
 }
 ```
 
-This profile:
-
-- Allows inbound traffic from `host.docker.internal` and `localhost`
-
 Run the MCP server with this profile:
 
 ```bash

--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -242,11 +242,17 @@ without editing a profile file.
 
 ## Accessing other workloads on the same container network
 
+ToolHive allows you to configure both outbound and inbound network access for
+MCP servers. This is commonly needed when your MCP server needs to communicate
+with databases, APIs, or other services that are running on your local host
+during development, or when other containers need to communicate with your MCP
+server.
+
+### Outbound access: MCP server to other workloads
+
 To allow an MCP server to access other workloads on the same network, you need
-to configure network isolation to include the appropriate hostnames and ports.
-This is commonly needed when your MCP server needs to communicate with
-databases, APIs, or other services that are running on your local host during
-development.
+to configure outbound network isolation to include the appropriate hostnames and
+ports.
 
 For example, in Docker environments, you can add `host.docker.internal` to
 access services on the host. `host.docker.internal` is a special hostname
@@ -272,6 +278,49 @@ Run the MCP server with this profile:
 ```bash
 thv run --isolate-network --permission-profile ./internal-access-profile.json <SERVER>
 ```
+
+### Inbound access: Other containers to MCP server
+
+By default, the ingress proxy only allows traffic from the container's own
+hostname, `localhost`, and `127.0.0.1`. If you need to allow other containers or
+workloads to communicate with your MCP server, configure the
+`network.inbound.allow_host` setting in your permission profile.
+
+This is useful when:
+
+- Other containers need to call your MCP server's API
+- You're running multiple services that need to communicate with each other
+- You need to allow traffic from specific internal hostnames or domains
+
+Create a permission profile that allows specific inbound hostnames:
+
+```json title="inbound-access-profile.json"
+{
+  "network": {
+    "inbound": {
+      "allow_host": ["host.docker.internal", "localhost"]
+    }
+  }
+}
+```
+
+This profile:
+
+- Allows inbound traffic from `host.docker.internal` and `localhost`
+
+Run the MCP server with this profile:
+
+```bash
+thv run --isolate-network --permission-profile ./inbound-access-profile.json <SERVER>
+```
+
+:::info
+
+If no `network.inbound` configuration is specified, the ingress proxy uses the
+default behavior of allowing traffic only from the container's own hostname,
+`localhost`, and `127.0.0.1`.
+
+:::
 
 ## Related information
 


### PR DESCRIPTION
DO NOT MERGE until next release

### Description
Updated the network isolation guides to include the new inbound configuration option.

### Related issues/PRs
https://github.com/stacklok/toolhive/pull/2030

### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [ ] New pages include a frontmatter section with title and description at a minimum
- [ ] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [ ] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [ ] Content has been reviewed for technical accuracy
- [ ] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
