### PR TITLE
Remove permissionProfile from K8s examples

### DIFF
--- a/docs/toolhive/guides-cli/build-containers.mdx
+++ b/docs/toolhive/guides-cli/build-containers.mdx
@@ -222,9 +222,6 @@ you want to pre-build containers before deploying them.
    spec:
      image: ghcr.io/myorg/mcp-git:v1.0.0
      transport: stdio
-     permissionProfile:
-       type: builtin
-       name: network
    ```
 
 ### CI/CD integration

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -120,9 +120,6 @@ spec:
   transport: streamable-http
   targetPort: 8080
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: '100m'
@@ -222,9 +219,6 @@ spec:
   transport: streamable-http
   targetPort: 8080
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   podTemplateSpec:
     spec:
       containers:
@@ -285,9 +279,6 @@ spec:
   image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: token
@@ -334,9 +325,6 @@ spec:
   image: ghcr.io/github/github-mcp-server
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: token
@@ -398,9 +386,6 @@ spec:
   image: docker.io/mcp/filesystem
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: none
   podTemplateSpec:
     spec:
       volumes:
@@ -449,18 +434,6 @@ to learn how to connect to MCP servers using different clients.
   `MCPServer` Custom Resource Definition (CRD)
 - [Deploy the operator using Helm](./deploy-operator-helm.md) - Install the
   ToolHive operator
-- [Custom permissions](../guides-cli/custom-permissions.mdx) - Configure
-  permission profiles
-
-:::info[Important]
-
-Outbound network filtering using permission profiles isn't currently implemented
-in the ToolHive Operator. This is a roadmap feature planned for future releases.
-
-Contributions to help implement this feature are welcome! You can contribute by
-visiting our [GitHub repository](https://github.com/stacklok/toolhive).
-
-:::
 
 ## Troubleshooting
 
@@ -530,7 +503,7 @@ Common causes include:
 - **Missing secrets**: Ensure required secrets exist and are properly referenced
 - **Resource constraints**: Check if the pod has sufficient CPU and memory
   resources
-- **Permission issues**: Verify the security context and permission profile are
+- **Permission issues**: Verify the security context and RBAC permissions are
   correctly configured
 - **Invalid arguments**: Check if the `args` field contains valid arguments for
   the MCP server
@@ -619,33 +592,6 @@ Common causes include:
   setup
 - **Mount path conflicts**: Ensure mount paths don't conflict with existing
   directories
-
-</details>
-
-<details>
-<summary>Permission profile errors</summary>
-
-If the MCP server fails due to permission profile issues:
-
-```bash
-# Check if ConfigMap exists (for custom profiles)
-kubectl -n <NAMESPACE> get configmap <CONFIGMAP_NAME>
-
-# Verify ConfigMap content
-kubectl -n <NAMESPACE> describe configmap <CONFIGMAP_NAME>
-
-# Check operator logs for permission errors
-kubectl -n toolhive-system logs -l app.kubernetes.io/name=toolhive-operator | grep -i permission
-```
-
-Common causes include:
-
-- **Invalid profile name**: Ensure built-in profile names are correct (`none`,
-  `network`)
-- **ConfigMap not found**: Create the ConfigMap with the custom permission
-  profile
-- **Invalid JSON**: Verify the permission profile JSON is valid
-- **Missing key**: Ensure the specified key exists in the ConfigMap
 
 </details>
 

--- a/docs/toolhive/guides-mcp/context7.mdx
+++ b/docs/toolhive/guides-mcp/context7.mdx
@@ -112,9 +112,6 @@ spec:
   image: ghcr.io/stacklok/dockyard/npx/context7:1.0.14
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 Apply the manifest to your cluster:
@@ -138,9 +135,6 @@ spec:
     - 'YOUR_API_KEY'
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 </TabItem>

--- a/docs/toolhive/guides-mcp/fetch.mdx
+++ b/docs/toolhive/guides-mcp/fetch.mdx
@@ -84,9 +84,6 @@ spec:
   transport: streamable-http
   targetPort: 8080
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 Apply the manifest to your Kubernetes cluster:

--- a/docs/toolhive/guides-mcp/filesystem.mdx
+++ b/docs/toolhive/guides-mcp/filesystem.mdx
@@ -124,9 +124,6 @@ spec:
   image: mcp/filesystem:latest
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: none # Note, network isolation in K8s is not implemented yet
   args:
     - '/projects' # Update if you use a different mountPath below
   podTemplateSpec:

--- a/docs/toolhive/guides-mcp/github.mdx
+++ b/docs/toolhive/guides-mcp/github.mdx
@@ -144,9 +144,6 @@ spec:
   image: ghcr.io/github/github-mcp-server:v0.13.0
   transport: stdio
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: github-token
       key: token

--- a/docs/toolhive/guides-mcp/k8s.mdx
+++ b/docs/toolhive/guides-mcp/k8s.mdx
@@ -137,9 +137,6 @@ spec:
   targetPort: 8080
   port: 8080
   serviceAccount: mkp-sa
-  permissionProfile:
-    type: builtin
-    name: network
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/docs/toolhive/guides-mcp/osv.mdx
+++ b/docs/toolhive/guides-mcp/osv.mdx
@@ -79,9 +79,6 @@ spec:
   transport: streamable-http
   targetPort: 8080
   port: 8080
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 Apply the manifest to your Kubernetes cluster:

--- a/docs/toolhive/guides-mcp/playwright.mdx
+++ b/docs/toolhive/guides-mcp/playwright.mdx
@@ -156,9 +156,6 @@ spec:
   args:
     - '--port'
     - '8931'
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 Apply the manifest to your Kubernetes cluster:
@@ -185,9 +182,6 @@ spec:
     - '8931'
     - '--allowed-origins'
     - 'example.com;trusted-domain.org'
-  permissionProfile:
-    type: builtin
-    name: network
 ```
 
 Mount a persistent volume to save browser output files like screenshots and
@@ -211,9 +205,6 @@ spec:
     - '/browser-output'
     - '--save-trace'
     - '--save-session'
-  permissionProfile:
-    type: builtin
-    name: network
   podTemplateSpec:
     spec:
       volumes:

--- a/docs/toolhive/tutorials/vault-integration.mdx
+++ b/docs/toolhive/tutorials/vault-integration.mdx
@@ -168,9 +168,6 @@ spec:
   image: ghcr.io/github/github-mcp-server:latest
   transport: stdio
   port: 9095
-  permissionProfile:
-    type: builtin
-    name: network
   resources:
     limits:
       cpu: '100m'


### PR DESCRIPTION
### Description

Removes `permissionProfile` from all the K8s examples. It's not implemented, and since it's optional there's no need to have it there.

Also removes the note about network isolation/permissions in K8s being a roadmap item; this isn't confirmed. For now, users should use their existing K8s network policy tools.

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>