### PR TITLE
Document STDIO on k8s limitation

### DIFF
--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -75,7 +75,7 @@ use SSE (Server-Sent Events) or Streamable HTTP transport instead.
 
 ### Streamable HTTP and SSE transport flow
 
-For MCP servers using Server-Sent Events (SSE) or Stremable HTTP transport, the
+For MCP servers using Server-Sent Events (SSE) or Streamable HTTP transport, the
 proxy creates both a pod and a headless service. This allows direct HTTP/SSE or
 HTTP/Streamable HTTP communication between the proxy and MCP server while
 maintaining network isolation and service discovery.


### PR DESCRIPTION
### Description
Added a note that STDIO servers on kubernetes aren't intended to work with multiple users or multiple MCP clients. This was not explicitly stated before.

### Related issues/PRs


### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [ ] New pages include a frontmatter section with title and description at a minimum
- [ ] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [ ] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [ ] Content has been reviewed for technical accuracy
- [ ] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
