### PR TITLE
Add warning about WinGet delays

### DIFF
--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -43,9 +43,8 @@ brew install thv
 :::warning
 
 The WinGet package for the ToolHive CLI is currently outdated due to publishing
-delays. Use the manual installation method below to get the latest version.
-
-Download the zip file (example: `toolhive_0.5.1_windows_amd64.zip`) from the
+delays. To get the latest version, download the zip file (example:
+`toolhive_0.5.1_windows_amd64.zip`) from the
 [releases page](https://github.com/stacklok/toolhive/releases/latest) and
 extract the `thv.exe` binary to a folder in your PATH.
 

--- a/docs/toolhive/tutorials/quickstart-cli.mdx
+++ b/docs/toolhive/tutorials/quickstart-cli.mdx
@@ -50,9 +50,8 @@ brew install thv
 :::warning
 
 The WinGet package for the ToolHive CLI is currently outdated due to publishing
-delays. Use the manual installation method below to get the latest version.
-
-Download the zip file (example: `toolhive_0.5.1_windows_amd64.zip`) from the
+delays. To get the latest version, download the zip file (example:
+`toolhive_0.5.1_windows_amd64.zip`) from the
 [releases page](https://github.com/stacklok/toolhive/releases/latest) and
 extract the `thv.exe` binary to a folder in your PATH.
 


### PR DESCRIPTION
### Description

WinGet publishing of the CLI has been hung up for several weeks now. While we resolve, adding a warning to the Windows installation steps guiding users to download the pre-compiled exe instead.

### Related issues/PRs

https://github.com/stacklok/toolhive/issues/2100

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>
