### PR TITLE
Update playground guide with new providers

### DIFF
--- a/docs/toolhive/guides-ui/playground.mdx
+++ b/docs/toolhive/guides-ui/playground.mdx
@@ -17,9 +17,9 @@ servers to production environments.
 
 ### Instant testing of MCP servers
 
-Enter an AI model API key, select your MCP servers and tools, and begin testing
-immediately in the desktop app. The playground eliminates the friction of
-setting up external AI clients just to validate that your MCP servers work
+Configure your AI model providers, select your MCP servers and tools, and begin
+testing immediately in the desktop app. The playground eliminates the friction
+of setting up external AI clients just to validate that your MCP servers work
 correctly.
 
 ### Detailed interaction logs
@@ -43,12 +43,17 @@ To start using the playground:
 1. **Access the playground**: Click the **Playground** tab in the ToolHive UI
    navigation bar.
 
-2. **Configure API keys**: Click **Configure your API Keys** to set up access to
-   AI model providers:
+2. **Configure provider settings**: Click **Provider Settings** to set up access
+   to AI model providers:
    - **OpenAI**: Enter your OpenAI API key to use GPT models
    - **Anthropic**: Add your Anthropic API key for Claude models
    - **Google**: Configure Google AI API key for Gemini models
    - **xAI**: Set up xAI API key for Grok models
+   - **Ollama**: Enter the server URL to connect to your local Ollama instance
+     (default: `http://localhost:11434`)
+   - **LM Studio**: Enter the server URL from the **Developer** section in LM
+     Studio where you started the local server (default:
+     `http://localhost:1234`)
    - **OpenRouter**: Add OpenRouter API key for access to multiple model
      providers
 
@@ -157,11 +162,13 @@ and identify any issues with tool implementation or configuration.
 
 ## Recommended practices
 
-### API key security
+### Provider security
 
 - Use dedicated API keys for testing that have appropriate rate limits
 - Regularly rotate API keys used in development environments
 - Consider using API keys with restricted permissions for testing purposes
+- When using local providers like Ollama or LM Studio, ensure the server URLs
+  are only accessible on your local network to prevent unauthorized access
 
 ### Server management
 
@@ -186,14 +193,21 @@ and identify any issues with tool implementation or configuration.
 ### Common issues
 
 <details>
-<summary>API key not working</summary>
+<summary>Provider not working</summary>
 
-If your API key isn't working:
+If your provider isn't working:
 
-1. Verify the API key is correct and has proper permissions
-2. Check that you have sufficient quota or credits with the provider
-3. Ensure the API key hasn't expired or been revoked
-4. Try creating a new API key from the provider's dashboard
+1. **For API key-based providers** (OpenAI, Anthropic, Google, xAI, OpenRouter):
+   - Verify the API key is correct and has proper permissions
+   - Check that you have sufficient quota or credits with the provider
+   - Ensure the API key hasn't expired or been revoked
+   - Try creating a new API key from the provider's dashboard
+
+2. **For local providers** (Ollama, LM Studio):
+   - Verify the server is running and accessible at the configured URL
+   - Check that the server URL is correct and includes the port number
+   - Ensure no firewall or network settings are blocking the connection
+   - For LM Studio, confirm you started the server in the **Developer** section
 
 </details>
 


### PR DESCRIPTION
### Description

This PR updates the playground documentation to reflect recent UI changes:

- **Updated terminology**: Changed "API keys" to "Provider Settings" throughout the document to match the new UI terminology
- **Added Ollama provider**: Documented the new Ollama provider with server URL configuration (default: `http://localhost:11434`)
- **Added LM Studio provider**: Documented the new LM Studio provider with instructions for obtaining the server URL from the Developer section (default: `http://localhost:1234`)
- **Enhanced security guidance**: Updated the "API key security" section to "Provider security" with additional guidance for securing local providers
- **Improved troubleshooting**: Expanded the troubleshooting section to distinguish between API key-based providers (OpenAI, Anthropic, Google, xAI, OpenRouter) and local providers (Ollama, LM Studio) with specific guidance for each type

These changes ensure the documentation accurately reflects the current capabilities of the ToolHive playground, particularly for users who want to use local LLM providers that don't require API keys.

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and
  [style](STYLE_GUIDE.md)