### PR TITLE
Fix the CRD upgrade and uninstall instructions

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator-helm.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator-helm.mdx
@@ -25,7 +25,7 @@ MCPServer resources. The CRDs define the structure and behavior of MCPServers in
 your cluster.
 
 ```bash
-helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
 ```
 
 This command installs the latest version of the ToolHive operator CRDs Helm
@@ -33,7 +33,7 @@ chart. To install a specific version, append `--version <VERSION>` to the
 command, for example:
 
 ```bash
-helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.0.52
+helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.0.52
 ```
 
 ## Install the operator
@@ -44,7 +44,7 @@ To install the ToolHive operator using default settings, run the following
 command:
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
 ```
 
 This command installs the latest version of the ToolHive operator CRDs Helm
@@ -52,7 +52,7 @@ chart. To install a specific version, append `--version <VERSION>` to the
 command, for example:
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --version 0.3.7
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --version 0.3.7
 ```
 
 Verify the installation:
@@ -88,7 +88,7 @@ operator:
 Install the operator with your custom values:
 
 ```bash {3}
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator\
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator\
   -n toolhive-system --create-namespace\
   -f values.yaml
 ```
@@ -129,7 +129,7 @@ operator:
 Reference the `values.yaml` file when you install the operator using Helm:
 
 ```bash {3}
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator \
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator \
   -n toolhive-system --create-namespace
   -f values.yaml
 ```
@@ -170,7 +170,7 @@ environment.
 Reference the `values.yaml` file when you install the operator using Helm:
 
 ```bash {3}
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator \
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator \
   -n toolhive-system --create-namespace
   -f values.yaml
 ```
@@ -237,7 +237,7 @@ and then apply the CRDs using `kubectl`.
 First, upgrade the CRD Helm chart to match your target operator version:
 
 ```bash
-helm upgrade toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.0.52
+helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.0.52
 ```
 
 Then apply the CRDs from the same version tag:
@@ -253,27 +253,27 @@ kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/t
 
 Replace `0.0.52` in both commands with your target CRD version.
 
-### Upgrade the operator
+### Upgrade the operator Helm release
 
 Then, upgrade the operator installation using Helm.
 
 ![Latest Operator Helm chart release](https://img.shields.io/github/v/release/stacklok/toolhive?filter=toolhive-operator-0*&style=for-the-badge&logo=helm&label=Latest%20Operator%20chart&color=097aff)
 
 ```bash
-helm upgrade toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values
 ```
 
 This upgrades the operator to the latest version available in the OCI registry.
 To upgrade to a specific version, add the `--version` flag:
 
 ```bash
-helm upgrade toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values --version 0.3.7
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values --version 0.3.7
 ```
 
 If you have a custom `values.yaml` file, include it with the `-f` flag:
 
 ```bash
-helm upgrade toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values -f values.yaml
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values -f values.yaml
 ```
 
 ## Uninstall the operator
@@ -287,8 +287,13 @@ helm uninstall toolhive-operator -n toolhive-system
 ```
 
 Then, if you want to completely remove ToolHive including all CRDs and related
-resources, delete the CRDs manually. **Warning**: This will delete all MCPServer
-and related resources in your cluster:
+resources, delete the CRDs manually.
+
+:::warning
+
+This will delete all MCPServer and related resources in your cluster!
+
+:::
 
 ```bash
 kubectl delete crd mcpexternalauthconfigs.toolhive.stacklok.dev

--- a/docs/toolhive/tutorials/quickstart-k8s.mdx
+++ b/docs/toolhive/tutorials/quickstart-k8s.mdx
@@ -105,13 +105,13 @@ watch for MCP server resources and manage their lifecycle automatically.
 First, install the operator CRDs:
 
 ```bash
-helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
 ```
 
 Then install the operator:
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace
 ```
 
 Verify that the operator deployed successfully:


### PR DESCRIPTION
### Description

Fixed operator upgrade and uninstall instructions to correctly handle CRDs, which Helm doesn't manage automatically.

### Related issues/PRs

https://github.com/stacklok/toolhive/issues/2518

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Content

- [x] (N/A) New pages include a frontmatter section with title and description at a minimum
- [x] (N/A) Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] (N/A) Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>