### PR TITLE
Fix line highlighting in k8s manifest code blocks

### DIFF
--- a/docs/toolhive/guides-k8s/customize-tools.mdx
+++ b/docs/toolhive/guides-k8s/customize-tools.mdx
@@ -109,7 +109,7 @@ use distinct tool names like `github_prod_create_pr` and
 Add `toolConfigRef` to your `MCPServer`. `toolConfigRef` takes precedence over
 the deprecated `spec.tools` field on `MCPServer`.
 
-```yaml {12-13} title="mcpserver-with-toolconfig.yaml"
+```yaml {10-11} title="mcpserver-with-toolconfig.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-k8s/logging.mdx
+++ b/docs/toolhive/guides-k8s/logging.mdx
@@ -79,7 +79,7 @@ Audit logs provide detailed records of all MCP operations for security and
 compliance. To enable audit logging, set the `audit.enabled` field to `true` in
 your MCP server manifest:
 
-```yaml {10-12}
+```yaml {11-12}
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -201,7 +201,7 @@ multiple authentication methods:
 Inline OIDC configuration is the simplest approach and works with most identity
 providers:
 
-```yaml {6-12}
+```yaml {4-6}
 spec:
   remoteURL: https://mcp.example.com
 
@@ -226,7 +226,7 @@ endpoint (`/.well-known/openid-configuration`).
 For more complex configurations or when you need to share OIDC settings across
 multiple proxies, use a ConfigMap:
 
-```yaml title="oidc-config.yaml"
+```yaml {21-25} title="oidc-config.yaml"
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -276,7 +276,7 @@ request. Policies can reference claims from the validated JWT token.
 
 This example shows different policy patterns:
 
-```yaml {6-40}
+```yaml {6-9}
 spec:
   remoteURL: https://mcp.example.com
   oidcConfig:
@@ -344,7 +344,7 @@ available attributes depend on your identity provider's token configuration:
 
 Use `MCPToolConfig` to filter or rename tools from the remote server:
 
-```yaml title="analytics-tools.yaml"
+```yaml {2,31-32} title="analytics-tools.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPToolConfig
 metadata:

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -286,7 +286,7 @@ kubectl -n production create secret generic github-token --from-literal=token=<Y
 
 Next, define the `MCPServer` resource to reference the secret:
 
-```yaml {13-16} title="my-mcpserver-with-secrets.yaml"
+```yaml {10-13} title="my-mcpserver-with-secrets.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -332,7 +332,7 @@ match what you specify in the `MCPServer` resource.
 
 Next, define the `MCPServer` resource to reference the secret:
 
-```yaml {13-16} title="my-mcpserver-with-secrets-eso.yaml"
+```yaml {10-13} title="my-mcpserver-with-secrets-eso.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -393,7 +393,7 @@ specification. Here's an example that mounts a persistent volume claim (PVC) to
 the `/projects` path in the Filesystem MCP server. The PVC must already exist in
 the same namespace as the MCPServer.
 
-```yaml {15-18,22-25} title="my-mcpserver-with-volume.yaml"
+```yaml {12-15,19-22} title="my-mcpserver-with-volume.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-mcp/filesystem.mdx
+++ b/docs/toolhive/guides-mcp/filesystem.mdx
@@ -114,7 +114,7 @@ Create a Kubernetes manifest to deploy the Filesystem MCP server with a
 Update the `podTemplateSpec` section to include your specific volume claim and
 mount path:
 
-```yaml {17-20,23-26} title="filesystem.yaml"
+```yaml {14-17,20-23} title="filesystem.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-mcp/github.mdx
+++ b/docs/toolhive/guides-mcp/github.mdx
@@ -134,7 +134,7 @@ kubectl -n toolhive-system create secret generic github-token --from-literal=tok
 
 Create a Kubernetes manifest to deploy the GitHub MCP server using your secret:
 
-```yaml {14-17} title="github.yaml"
+```yaml {10-14} title="github.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-mcp/grafana.mdx
+++ b/docs/toolhive/guides-mcp/grafana.mdx
@@ -139,9 +139,10 @@ kubectl -n toolhive-system create secret generic grafana-token \
   --from-literal=token=<YOUR_TOKEN>
 ```
 
-Create a Kubernetes manifest to deploy the Grafana MCP server:
+Create a Kubernetes manifest to deploy the Grafana MCP server, specifying your
+Grafana instance URL and referencing the secret:
 
-```yaml {14-17} title="grafana.yaml"
+```yaml title="grafana.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-mcp/notion-remote.mdx
+++ b/docs/toolhive/guides-mcp/notion-remote.mdx
@@ -104,7 +104,7 @@ kubectl -n toolhive-system create secret generic notion-token --from-literal=tok
 
 Create a Kubernetes manifest to deploy the Notion MCP server using your secret:
 
-```yaml {14-17} title="notion.yaml"
+```yaml title="notion.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:

--- a/docs/toolhive/guides-mcp/playwright.mdx
+++ b/docs/toolhive/guides-mcp/playwright.mdx
@@ -191,7 +191,7 @@ spec:
 Mount a persistent volume to save browser output files like screenshots and
 traces:
 
-```yaml {16-17,25-28,31-34} title="playwright-with-volume.yaml"
+```yaml {16-17,22-25,28-31} title="playwright-with-volume.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:


### PR DESCRIPTION
### Description

A while back we removed the unused `permissionProfile` settings from example K8s manifests, but I failed to notice that this threw off the line numbers for highlighting in some examples.

This re-aligns things.

### Related issues/PRs

#230

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>