### PR TITLE
Add Google Antigravity IDE to supported clients

### DIFF
--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -16,6 +16,7 @@ We've tested ToolHive with these clients:
 | GitHub Copilot (VS Code)   |    ✅     |         ✅         | v1.102+ or Insiders version ([see note][3]) |
 | Claude Code                |    ✅     |         ✅         | v1.0.27+                                    |
 | Cursor                     |    ✅     |         ✅         | v0.50.0+                                    |
+| Google Antigravity         |    ✅     |         ✅         |                                             |
 | Cline (VS Code)            |    ✅     |         ✅         | v3.17.10+                                   |
 | Continue (VS Code)         |    ✅     |         ✅         | v1.0.14+                                    |
 | Continue (JetBrains)       |    ✅     |         ✅         | v1.0.23+                                    |


### PR DESCRIPTION
### Description

Adds the Google Antigravity IDE to the supported clients list.

Will be supported after the next ToolHive release.

### Related issues/PRs

https://github.com/stacklok/toolhive/pull/2646

### Merge checklist
<!-- If items don't apply, add (N/A) and mark them as complete. -->

#### Reviews

- [x] Content has been reviewed for technical accuracy
- [x] Content has been reviewed for spelling, grammar, and [style](STYLE_GUIDE.md)
