### PR TITLE
Update Renovate configs for minimum age and automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,14 +13,21 @@
   "rangeStrategy": "bump",
   "schedule": ["* 0-7 * * 1"],
   "timezone": "America/New_York",
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "schedule": "at any time"
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "packageRules": [
     {
       "matchPackageNames": ["husky", "lint-staged", "markdownlint*", "globals"],
-      "groupName": "linters"
+      "groupName": "linters",
+      "automerge": true
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Updates the Renovate config:

- Use the recommended npm release age preset
- Add minimum age for GitHub Actions
- Enable lock file maintenance with automerge
- Enable automerge for the linters group

The repo settings have been updated to allow the renovate account to bypass PR review requirements to allow automerge to work. Also set the Vercel build and Lint/Format checks as required so Renovate won't automerge if they fail.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>