### PR TITLE
Fix Renovate automerge for linters

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,10 @@
   "packageRules": [
     {
       "matchPackageNames": ["husky", "lint-staged", "markdownlint*", "globals"],
-      "groupName": "linters",
+      "groupName": "linters"
+    },
+    {
+      "matchCategories": ["linters"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Previous config was only applying to the extra packages being added to the linters group.

This should work for all.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>