### PR TITLE
Fix Renovate automerge for linters (try 2)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "group:linters",
     "helpers:pinGitHubActionDigests",
     ":gitSignOff",
     ":semanticCommitsDisabled",
@@ -25,11 +24,9 @@
   },
   "packageRules": [
     {
+      "extends": ["packages:linters"],
       "matchPackageNames": ["husky", "lint-staged", "markdownlint*", "globals"],
-      "groupName": "linters"
-    },
-    {
-      "matchCategories": ["linters"],
+      "groupName": "linters",
       "automerge": true
     },
     {


### PR DESCRIPTION
First try didn't work as expected.

Instead of extending the group preset at the top level, this will extend the packages preset and apply the group name.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>