### PR TITLE
Fix composite tools example tool reference

### DIFF
--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -258,11 +258,11 @@ spec:
           - url
       steps:
         - id: fetch_content
-          tool: fetch.fetch_url
+          tool: fetch.fetch
           arguments:
             url: '{{.params.url}}'
         - id: summarize
-          tool: llm.summarize
+          tool: llm.summarize # Hypothetical backend - replace with your actual LLM server
           arguments:
             text: '{{.steps.fetch_content.output.content}}'
           dependsOn: [fetch_content]


### PR DESCRIPTION
## Summary

- Change `fetch.fetch_url` to `fetch.fetch` (correct tool name based on actual tool exposed by fetch server)
- Add comment clarifying `llm.summarize` is a hypothetical backend

## Test plan

- [x] Tested composite tools example against live Kubernetes cluster
- [x] Verified the fetch tool is named `fetch.fetch`, not `fetch.fetch_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)