### PR TITLE
Dev Container: add node-modules volume for improved performance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,11 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "forwardPorts": [3000],
+  "remoteUser": "node",
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+  ],
+  "postCreateCommand": "sudo chown node:node node_modules",
   "containerEnv": {
     "CI": "true"
   },


### PR DESCRIPTION
Adds a Docker volume for node-modules to improve performance vs. the bind mount.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>