### PR TITLE
Simplify authentication docs to tested configurations

### DIFF
--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -57,6 +57,12 @@ spec:
     type: anonymous
 ```
 
+:::warning
+
+Never use `anonymous` incoming authentication in production environments.
+
+:::
+
 ### OIDC authentication
 
 Validate tokens from an external identity provider:
@@ -112,51 +118,26 @@ validates service account tokens. The defaults work for most clusters:
 
 ## Outgoing authentication
 
-Configure how Virtual MCP authenticates to backend MCP servers. Outgoing
-authentication is configured through `MCPExternalAuthConfig` resources.
+Configure how Virtual MCP authenticates to backend MCP servers.
 
-### Discovery mode (recommended)
+### Discovery mode
 
 When using discovery mode, Virtual MCP checks each backend MCPServer's
 `externalAuthConfigRef` to determine how to authenticate. If a backend has no
-auth config, Virtual MCP uses the specified default.
+auth config, Virtual MCP connects without authentication.
 
 ```yaml
 spec:
   outgoingAuth:
     source: discovered
-    default:
-      type: discovered
 ```
 
-### External auth config reference
-
-Reference an `MCPExternalAuthConfig` resource for specific backends:
-
-```yaml
-spec:
-  outgoingAuth:
-    source: inline
-    backends:
-      github:
-        type: external_auth_config_ref
-        externalAuthConfigRef:
-          name: github-auth
-```
-
-The `MCPExternalAuthConfig` resource defines the actual authentication strategy:
-
-- **Token exchange**: Exchange the client's token for a backend-specific token
-  using RFC 8693
-- **Header injection**: Inject a static header value (such as an API key)
-
-{/* TODO: Add MCPExternalAuthConfig examples */}
-
-## Example: Complete authentication setup
-
-{/* TODO: Add complete authentication example */}
+This is the recommended approach for most deployments. Backends that don't
+require authentication work automatically, while backends with
+`externalAuthConfigRef` configured use their specified authentication method.
 
 ## Related information
 
 - [Authentication framework concepts](../concepts/auth-framework.mdx)
+- [VirtualMCPServer configuration](./configuration.mdx)
 - [Token exchange in Kubernetes](../guides-k8s/token-exchange-k8s.mdx)


### PR DESCRIPTION
## Summary

- Add warning for anonymous incoming authentication
- Simplify outgoing auth to discovery mode only (tested working)
- Remove broken default config (CRD/binary type mismatch)
- Remove external_auth_config_ref examples (pending code fixes)
- Remove TODO placeholders
- Add link to configuration guide

## Context

Tested outgoing auth configurations against live Kubernetes cluster:
- `source: discovered` ✅ works
- `source: inline` ✅ works  
- `default.type: discovered` ❌ CRD accepts, binary rejects
- `default.type: unauthenticated` ❌ binary accepts, CRD rejects

The inline mode was removed since its intended purpose (pointing to externalAuthConfigRef) doesn't work due to the type mismatch.

## Test plan

- [x] Tested `outgoingAuth.source: discovered` against live cluster
- [x] Verified vMCP starts and discovers backends correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)