### PR TITLE
Update Claude workflow permissions to allow write

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Allow the Claude Code workflow to push branches and commits.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>