### PR TITLE
Add Renovate customManager for MCP guide Docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,9 @@
     {
       "customType": "regex",
       "description": "Update Docker images in MCP usage guide Kubernetes manifests",
-      "fileMatch": ["^docs/toolhive/guides-mcp/.*\\.mdx?$"],
+      "managerFilePatterns": ["/^docs/toolhive/guides-mcp/.*\\.mdx?$/"],
       "matchStrings": [
-        "image:\\s+(?<depName>[a-z0-9\\-\\.]+\\.[a-z]+/[^:]+):(?<currentValue>[^\\s]+)"
+        "image:\\s*[\"']?(?<depName>[^:\"'\\s]+):(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:#.*)?"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
@@ -54,11 +54,12 @@
       "matchUpdateTypes": ["major"]
     },
     {
-      "matchManagers": ["regex"],
-      "matchFilePatterns": ["^docs/toolhive/guides-mcp/"],
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["/^docs/toolhive/guides-mcp//"],
       "groupName": "MCP usage guide Docker images",
       "schedule": ["before 10am on the first day of the month"],
       "minimumReleaseAge": "3 days",
+      "internalChecksFilter": "strict",
       "prCreation": "not-pending",
       "labels": ["documentation", "mcp-guides"]
     }


### PR DESCRIPTION
Configure Renovate to automatically update Docker image versions in MCP usage guides on a monthly schedule.

This includes:
- Custom regex manager to detect image references in MDX files
- Monthly update schedule (first day of month)
- 3-day minimum release age for stability
- Grouped PRs with appropriate labels

Closes #357

----

Generated with [Claude Code](https://claude.ai/code)