### PR TITLE
Replace duplicate 'Why use groups?' sections with link to concepts page

### DIFF
--- a/docs/toolhive/guides-cli/group-management.mdx
+++ b/docs/toolhive/guides-cli/group-management.mdx
@@ -5,17 +5,15 @@ description:
 ---
 
 This guide explains how to organize your MCP servers into logical groups and
-configure which groups your MCP clients can access. Groups help you organize
-servers by project, environment, or team, and control which tools are available
-to different clients.
+configure which groups your MCP clients can access.
 
-## Why use groups?
+:::tip[New to groups?]
 
-Groups let you organize MCP servers and control client access:
+If you're not sure whether groups are right for your use case, see
+[Organizing MCP servers with groups](../concepts/groups.mdx) for an overview of
+when and why to use them.
 
-- **Project isolation**: Keep development and production servers separate
-- **Environment management**: Organize servers by development stage
-- **Client customization**: Configure different tool sets for different clients
+:::
 
 :::info[What's the default behavior?]
 

--- a/docs/toolhive/guides-ui/group-management.mdx
+++ b/docs/toolhive/guides-ui/group-management.mdx
@@ -6,17 +6,15 @@ description:
 ---
 
 This guide explains how to organize your MCP servers into groups and configure
-which groups your MCP clients can access. Groups help you organize servers by
-project, environment, or team, and control which tools are available to
-different clients.
+which groups your MCP clients can access.
 
-## Why use groups?
+:::tip[New to groups?]
 
-Groups let you organize MCP servers and control client access:
+If you're not sure whether groups are right for your use case, see
+[Organizing MCP servers with groups](../concepts/groups.mdx) for an overview of
+when and why to use them.
 
-- **Project isolation**: Keep development and production servers separate
-- **Environment management**: Organize servers by development stage
-- **Client customization**: Configure different tool sets for different clients
+:::
 
 :::info[What's the default behavior?]
 


### PR DESCRIPTION
## Summary

- Replace duplicate "Why use groups?" sections in CLI and UI group management guides with a tip admonition linking to the comprehensive groups concepts page

## Context

Follow-up from [PR #363 review](https://github.com/stacklok/docs-website/pull/363#pullrequestreview-3542557199) which suggested consolidating the repeated "Why use groups?" content.

## Test plan

- [x] Verify links work in local dev server
- [x] Check tip admonition renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)