### PR TITLE
Remove webpack-dev-server override

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.1"
   },
-  "overrides": {
-    "@docusaurus/core": {
-      "webpack-dev-server": "~5.2.2"
-    }
-  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
Not needed anymore with Docusaurus 3.9+

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>