### PR TITLE
Remove mount on `/etc` folder.

### DIFF
--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -51,11 +51,11 @@ spec:
           command:
             - /bin/sh
             - -c
-            - cp /cfg/* /etc/ && chmod 0600 /etc/pgpass && chown 65532:65532
-              /etc/pgpass
+            - cp /cfg/* /thv/ && chmod 0600 /thv/pgpass && chown 65532:65532
+              /thv/pgpass
           volumeMounts:
-            - name: etc
-              mountPath: /etc
+            - name: thv
+              mountPath: /thv
             - name: config
               mountPath: /cfg/config.yaml
               subPath: config.yaml
@@ -67,16 +67,16 @@ spec:
           image: ghcr.io/stacklok/toolhive-registry-server/thv-registry-api:latest
           args:
             - serve
-            - --config=/etc/config.yaml
+            - --config=/thv/config.yaml
           env:
             - name: PGPASSFILE
-              value: /etc/pgpass
+              value: /thv/pgpass
           ports:
             - containerPort: 8080
               name: http
           volumeMounts:
-            - name: etc
-              mountPath: /etc
+            - name: thv
+              mountPath: /thv
               readOnly: true
           livenessProbe:
             httpGet:
@@ -91,7 +91,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:
-        - name: etc
+        - name: thv
           emptyDir: {}
         - name: config
           configMap:


### PR DESCRIPTION
### Description
The example deployment of ToolHive Registry Server mounted an `emptyDir` volume on top of `/etc`. This is a leftover of some local testing and is definitely not something we should suggest users to do.

Thanks @dmartinol for finding it.

### Type of change
<!-- Keep the one that applies and delete the others -->

- Bug fix (typo, broken link, etc.)

### Submitter checklist

#### Content and formatting

- [X] I have reviewed the content for technical accuracy
- [X] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

#### Navigation
<!-- If you added, deleted, renamed, or reordered pages, please check the following -->
<!-- If you did not, you can delete this section -->

- [X] New pages include a frontmatter section with title and description at a minimum
- [X] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [X] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

### Reviewer checklist

#### Content

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
