### PR TITLE
Improve registry authentication documentation

### DIFF
--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -61,7 +61,7 @@ auth:
 | `mode`            | string   | Yes      | `oauth`                                   | Authentication mode (`oauth` or `anonymous`)       |
 | `resourceUrl`     | string   | Yes      | -                                         | The URL of the registry resource being protected   |
 | `realm`           | string   | No       | `mcp-registry`                            | OAuth realm identifier                             |
-| `scopesSupported` | []string | No       | `[mcp-registry:read, mcp-registry:write]` | Supported OAuth scopes                             |
+| `scopesSupported` | []string | No       | `[mcp-registry:read, mcp-registry:write]` | OAuth scopes advertised in the discovery endpoint  |
 | `publicPaths`     | []string | No       | `[]`                                      | Additional paths accessible without authentication |
 | `providers`       | array    | Yes      | -                                         | List of OAuth/OIDC identity providers              |
 
@@ -387,6 +387,10 @@ GET /.well-known/oauth-protected-resource
 
 This allows OAuth clients to automatically configure themselves without manual
 setup, improving interoperability and reducing configuration errors.
+
+When a request fails authentication, the server returns a `WWW-Authenticate`
+header that includes a link to the discovery endpoint, helping clients locate
+the authentication requirements.
 
 ## Testing authentication
 


### PR DESCRIPTION
## Summary

This PR improves the registry authentication documentation based on hands-on testing with a Kind cluster. The main changes address several issues found during review:

- The docs incorrectly equated OAuth with JWT tokens - the server actually supports both JWT and opaque tokens via introspection
- The Kubernetes authentication section had outdated configuration that wouldn't work in practice
- The `kubectl get secret` example used a legacy approach that produces tokens incompatible with the documented OAuth setup

Related server changes: https://github.com/stacklok/toolhive-registry-server/pull/298

## Changes

### OAuth token type support
- Clarified that OAuth mode supports both JWT tokens (validated via JWKS) and opaque tokens (validated via introspection)
- Added an example showing opaque token configuration with `introspectionUrl`
- Updated the token validation section to explain both validation methods

### Kubernetes authentication overhaul
- Fixed the `issuerUrl` - K8s tokens use `https://kubernetes.default.svc.cluster.local` (with the `.cluster.local` suffix), not `https://kubernetes.default.svc`
- Added new configuration fields to the provider table: `jwksUrl`, `authTokenFile`, `allowPrivateIP`
- Added a client workload example showing how to mount projected service account tokens with a specific audience
- Replaced the legacy `kubectl get secret` example with `kubectl create token`

### Minor improvements
- Added note about `WWW-Authenticate` header behavior for 401 responses
- Clarified that `scopesSupported` is currently only advertised in the discovery endpoint

## Testing

Tested in a Kind cluster by deploying the registry server with Kubernetes OAuth authentication enabled. The setup used projected service account tokens with a custom audience (`registry-server`) to verify that audience-based access control works correctly.

**Registry server config:**
```yaml
auth:
  mode: oauth
  oauth:
    resourceUrl: http://registry-api.registry-test.svc.cluster.local:8080
    providers:
      - name: kubernetes
        issuerUrl: https://kubernetes.default.svc.cluster.local
        jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
        audience: registry-server
        caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
        allowPrivateIP: true
```

**Client workload with projected token:**
```yaml
volumes:
  - name: registry-token
    projected:
      sources:
        - serviceAccountToken:
            audience: registry-server
            expirationSeconds: 3600
            path: token
```

Verified that clients with tokens issued for the correct audience can access the registry, while clients using the default Kubernetes service account token (wrong audience) are rejected with 401. Also confirmed that requests without tokens or with invalid tokens are properly rejected.

The key finding was that the legacy `kubectl get secret` approach produces tokens with issuer `kubernetes/serviceaccount`, which doesn't match the expected `issuerUrl`. Only the modern `kubectl create token` approach (or projected tokens) produces tokens compatible with the OAuth configuration.