### PR TITLE
Fix deployment guide

### DIFF
--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -198,6 +198,13 @@ endpoint documentation and request/response examples.
 Discovers MCP servers from running Kubernetes deployments. Automatically creates
 registry entries for deployed MCP servers in your cluster.
 
+:::note
+
+Currently, only resources in the same namespace as the Registry Server are
+discovered.
+
+:::
+
 ```yaml title="config-kubernetes.yaml"
 registries:
   - name: k8s-cluster
@@ -220,14 +227,14 @@ of workloads. The types being watched are
 [`VirtualMCPServer`](../guides-vmcp/configuration.mdx).
 
 The Registry Server will receive events when a resource among those listed above
-is annotated with the following annotations
+is annotated with the following annotations:
 
-```yaml
+```yaml {7-10}
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: my-mcp-server
-  namespace: production
+  namespace: toolhive-system # Must match Registry Server namespace
   annotations:
     toolhive.stacklok.dev/registry-export: 'true'
     toolhive.stacklok.dev/registry-url: 'https://mcp.example.com/servers/my-mcp-server'

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -183,8 +183,15 @@ of workloads. The types being watched are
 [`MCPRemoteProxy`](../guides-k8s/remote-mcp-proxy.mdx), and
 [`VirtualMCPServer`](../guides-vmcp/configuration.mdx).
 
+:::note
+
+Currently, only resources in the same namespace as the Registry Server are
+discovered.
+
+:::
+
 This feature requires the Registry Server to be granted access to those
-resources via a Service Account like the following
+resources.
 
 ```yaml title="registry-service-account.yaml"
 apiVersion: v1


### PR DESCRIPTION
### Description

Fixes a few issues with the Registry Server deployment guide for K8s I ran into when trying it:

1. The image reference was wrong
2. The example RBAC config didn't match the deployment above so couldn't be used as-is
3. Added a note about applying the ServiceAccount to the Deployment

### Type of change
<!-- Keep the one that applies and delete the others -->

- Bug fix (typo, broken link, etc.)

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>