### PR TITLE
Remove warnings about WinGet delays

### DIFF
--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -40,16 +40,6 @@ brew install thv
 </TabItem>
 <TabItem value='winget' label='WinGet (Windows)'>
 
-:::warning
-
-The WinGet package for the ToolHive CLI is currently outdated due to publishing
-delays. To get the latest version, download the zip file (example:
-`toolhive_0.5.1_windows_amd64.zip`) from the
-[releases page](https://github.com/stacklok/toolhive/releases/latest) and
-extract the `thv.exe` binary to a folder in your PATH.
-
-:::
-
 WinGet is available by default on Windows, making this the easiest installation
 method:
 

--- a/docs/toolhive/tutorials/quickstart-cli.mdx
+++ b/docs/toolhive/tutorials/quickstart-cli.mdx
@@ -47,16 +47,6 @@ brew install thv
 </TabItem>
 <TabItem value='winget' label='WinGet (Windows)' default>
 
-:::warning
-
-The WinGet package for the ToolHive CLI is currently outdated due to publishing
-delays. To get the latest version, download the zip file (example:
-`toolhive_0.5.1_windows_amd64.zip`) from the
-[releases page](https://github.com/stacklok/toolhive/releases/latest) and
-extract the `thv.exe` binary to a folder in your PATH.
-
-:::
-
 ```bash
 winget install stacklok.thv
 ```


### PR DESCRIPTION
### Description

Removes the warnings about WinGet publishing delays from the CLI install instructions. WinGet has resolved their pipeline issues, and our releases are all caught up.

### Type of change
<!-- Keep the one that applies and delete the others -->

- Documentation update

### Related issues/PRs

Originally added in #270

https://github.com/stacklok/toolhive/issues/2100

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>