### PR TITLE
Fix mobile nav styling for light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -337,3 +337,22 @@ details summary:hover {
 .spacing-icon {
   margin-right: 8px;
 }
+
+/* Mobile navbar sidebar background colors */
+[data-theme='light'] .navbar-sidebar {
+  background-color: #b2e4bc;
+}
+
+[data-theme='dark'] .navbar-sidebar {
+  background-color: #2e6e3e;
+}
+
+/* Mobile navbar toggle (hamburger menu) icon color */
+[data-theme='light'] .navbar__toggle {
+  color: #fafefa;
+}
+
+/* Mobile navbar sidebar logo - use dark logo in light mode */
+[data-theme='light'] .navbar-sidebar .navbar__logo img {
+  content: url('/img/logos/stacklok-default-dark-green.svg');
+}


### PR DESCRIPTION
Fixes #431

This PR fixes multiple mobile navigation styling issues in light mode:

1. **Mobile sidebar background colors**: Set light green background for light mode, dark green for dark mode
2. **Hamburger menu icon**: Changed color to white (#fafefa) in light mode for visibility
3. **Logo visibility**: Swapped to dark green logo in mobile sidebar for light mode

All fixes are CSS-only changes in `src/css/custom.css`.

Before:
![Screenshot_20260108-221211.png](https://github.com/user-attachments/assets/7729aec1-0d79-4b18-ab83-4c07c79e6cc6)

Fixed:
![Screenshot_20260108-221144~2.png](https://github.com/user-attachments/assets/07f7d826-ea87-4d2c-9183-0a443df8bfc2)

---

Generated with [Claude Code](https://claude.ai/code)