### PR TITLE
Request review instead of assigning the auto-update PR

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: 'latest'
       assign_to:
-        description: 'GitHub username to assign the PR to (optional)'
+        description: 'GitHub username to request PR review from (optional)'
         required: false
   repository_dispatch:
     types: [published-release]
@@ -44,19 +44,19 @@ jobs:
             echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Determine assignee
-        id: get-assignee
+      - name: Determine reviewer
+        id: get-reviewer
         run: |
           if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            ASSIGNEE="${{ github.event.client_payload.assign_to }}"
+            REVIEWER="${{ github.event.client_payload.assign_to }}"
           else
-            ASSIGNEE="${{ github.event.inputs.assign_to }}"
+            REVIEWER="${{ github.event.inputs.assign_to }}"
           fi
-          # Filter out github-actions bot (can't be assigned to PRs)
-          if [[ "$ASSIGNEE" =~ ^github-actions ]]; then
-            ASSIGNEE=""
+          # Filter out github-actions bot (can't be requested as reviewer)
+          if [[ "$REVIEWER" =~ ^github-actions ]]; then
+            REVIEWER=""
           fi
-          echo "assign_to=$ASSIGNEE" >> $GITHUB_OUTPUT
+          echo "assign_to=$REVIEWER" >> $GITHUB_OUTPUT
 
       - name: Run update script
         id: imports
@@ -92,6 +92,6 @@ jobs:
             Update ToolHive reference docs for ${{ steps.imports.outputs.version }}
           labels: |
             autogen-docs
-          assignees: ${{ steps.get-assignee.outputs.assign_to }}
+          reviewers: ${{ steps.get-reviewer.outputs.assign_to }}
           delete-branch: true
           sign-commits: true


### PR DESCRIPTION
Instead of assigning the auto-generated docs PR, request a review instead. Fits the workflow better.

Left the input name as `assign_to` so the upstream workflow doesn't need to be updated.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>