### PR TITLE
Fixup link text to remove "with/using Helm"

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -28,7 +28,7 @@ You'll need:
 
 - Kubernetes cluster with RBAC enabled
 - ToolHive Operator installed (see
-  [Deploy the ToolHive Operator with Helm](./deploy-operator.mdx))
+  [Deploy the ToolHive Operator](./deploy-operator.mdx))
 - `kubectl` access to your cluster
 
 ## Choose your authentication approach
@@ -422,7 +422,7 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/name=weather-server-k8s
 - For running MCP servers without authentication, see
   [Run MCP servers in Kubernetes](./run-mcp-k8s.mdx)
 - For ToolHive Operator installation, see
-  [Deploy the ToolHive Operator with Helm](./deploy-operator.mdx)
+  [Deploy the ToolHive Operator](./deploy-operator.mdx)
 
 ## Troubleshooting
 

--- a/docs/toolhive/guides-k8s/deploy-registry.mdx
+++ b/docs/toolhive/guides-k8s/deploy-registry.mdx
@@ -12,7 +12,7 @@ description:
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
   with your cluster
 - The ToolHive operator installed in your cluster (see
-  [Deploy the operator using Helm](./deploy-operator.mdx))
+  [Deploy the operator](./deploy-operator.mdx))
 - A PostgreSQL database (recommended for production deployments)
 
 ## Overview
@@ -619,8 +619,7 @@ feature.
 
 - [Kubernetes CRD reference](../reference/crd-spec.mdx#apiv1alpha1mcpregistry) -
   Reference for the `MCPRegistry` Custom Resource Definition (CRD)
-- [Deploy the operator using Helm](./deploy-operator.mdx) - Install the ToolHive
-  operator
+- [Deploy the operator](./deploy-operator.mdx) - Install the ToolHive operator
 - [Database configuration](../guides-registry/database.mdx) - Configure
   PostgreSQL storage
 

--- a/docs/toolhive/guides-k8s/intro.mdx
+++ b/docs/toolhive/guides-k8s/intro.mdx
@@ -64,9 +64,8 @@ or Gateway. To learn how to expose your MCP servers and connect clients, see
 
 ## Installation
 
-[Use Helm to install the ToolHive operator](./deploy-operator.mdx) in your
-Kubernetes cluster. Helm simplifies the installation process and lets you manage
-the operator using Helm charts.
+[Deploy the ToolHive operator](./deploy-operator.mdx) in your Kubernetes
+cluster.
 
 Once the operator is installed, you can create and manage MCP servers:
 

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -56,7 +56,7 @@ spec and its capabilities are possible.
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
   with your cluster
 - The ToolHive operator installed in your cluster (see
-  [Deploy the operator using Helm](./deploy-operator.mdx))
+  [Deploy the operator](./deploy-operator.mdx))
 - An OIDC identity provider (Keycloak, Okta, Azure AD, etc.)
 - Access to a remote MCP server that supports HTTP transport (SSE or Streamable
   HTTP)
@@ -657,8 +657,7 @@ feature in the ToolHive Registry Server.
 
 - [Kubernetes CRD reference](../reference/crd-spec.mdx#apiv1alpha1mcpremoteproxy) -
   Full MCPRemoteProxy specification
-- [Deploy the operator using Helm](./deploy-operator.mdx) - Install the ToolHive
-  operator
+- [Deploy the operator](./deploy-operator.mdx) - Install the ToolHive operator
 - [Run MCP servers in Kubernetes](./run-mcp-k8s.mdx) - Deploy local MCP servers
 
 ## Troubleshooting

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -10,7 +10,7 @@ description: How to deploy MCP servers in Kubernetes using the ToolHive operator
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
   with your cluster
 - The ToolHive operator installed in your cluster (see
-  [Deploy the operator using Helm](./deploy-operator.mdx))
+  [Deploy the operator](./deploy-operator.mdx))
 
 ## Overview
 
@@ -463,8 +463,7 @@ feature in the ToolHive Registry Server.
 
 - [Kubernetes CRD reference](../reference/crd-spec.mdx#apiv1alpha1mcpserver) -
   Reference for the `MCPServer` Custom Resource Definition (CRD)
-- [Deploy the operator using Helm](./deploy-operator.mdx) - Install the ToolHive
-  operator
+- [Deploy the operator](./deploy-operator.mdx) - Install the ToolHive operator
 - [Build MCP containers](../guides-cli/build-containers.mdx) - Create custom MCP
   server container images
 

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -284,5 +284,4 @@ Telemetry adds minimal overhead when properly configured:
   of ToolHive's observability architecture
 - [Kubernetes CRD reference](../reference/crd-spec.mdx#apiv1alpha1mcpserver) -
   Reference for the `MCPServer` Custom Resource Definition (CRD)
-- [Deploy the operator using Helm](./deploy-operator.mdx) - Install the ToolHive
-  operator
+- [Deploy the operator](./deploy-operator.mdx) - Install the ToolHive operator

--- a/docs/toolhive/guides-k8s/token-exchange-k8s.mdx
+++ b/docs/toolhive/guides-k8s/token-exchange-k8s.mdx
@@ -19,7 +19,7 @@ Before you begin, make sure you have:
 
 - Kubernetes cluster with RBAC enabled
 - ToolHive Operator installed (see
-  [Deploy the ToolHive Operator with Helm](./deploy-operator.mdx))
+  [Deploy the ToolHive Operator](./deploy-operator.mdx))
 - `kubectl` access to your cluster
 - An identity provider that supports
   [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) token exchange (such


### PR DESCRIPTION
Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>

### Description

Remove "using/with Helm" from links pointing to the operator deployment guide.

### Type of change

- Documentation update

### Related issues/PRs

- #449
- #435

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
