### PR TITLE
Add host param to Playwright K8s examples

### DIFF
--- a/docs/toolhive/guides-mcp/playwright.mdx
+++ b/docs/toolhive/guides-mcp/playwright.mdx
@@ -141,21 +141,23 @@ metadata:
   name: playwright
   namespace: toolhive-system
 spec:
-  image: mcr.microsoft.com/playwright/mcp:v0.0.54
+  image: mcr.microsoft.com/playwright/mcp:v0.0.59
   transport: streamable-http
   mcpPort: 8931
   proxyPort: 8080
   args:
     - '--port'
     - '8931'
+    - '--host'
+    - '0.0.0.0'
     - '--allowed-hosts'
     - '*'
 ```
 
 :::note[Important]
 
-Don't remove the `--port 8931` or `--allowed-hosts "*"` arguments. They are
-required to run the server using Streamable HTTP.
+Don't remove the `--port 8931`, `--host 0.0.0.0`, or `--allowed-hosts "*"`
+arguments. They are required to run the server using Streamable HTTP.
 
 :::
 
@@ -175,13 +177,15 @@ metadata:
   name: playwright
   namespace: toolhive-system
 spec:
-  image: mcr.microsoft.com/playwright/mcp:v0.0.54
+  image: mcr.microsoft.com/playwright/mcp:v0.0.59
   transport: streamable-http
   mcpPort: 8931
   proxyPort: 8080
   args:
     - '--port'
     - '8931'
+    - '--host'
+    - '0.0.0.0'
     - '--allowed-hosts'
     - '*'
     - '--allowed-origins'
@@ -198,13 +202,15 @@ metadata:
   name: playwright
   namespace: toolhive-system
 spec:
-  image: mcr.microsoft.com/playwright/mcp:v0.0.54
+  image: mcr.microsoft.com/playwright/mcp:v0.0.59
   transport: streamable-http
   mcpPort: 8931
   proxyPort: 8080
   args:
     - '--port'
     - '8931'
+    - '--host'
+    - '0.0.0.0'
     - '--allowed-hosts'
     - '*'
     - '--output-dir'


### PR DESCRIPTION
### Description

Updates the Kubernetes manifests for the Playwright MCP server guide to add the `--host 0.0.0.0` argument. This seems to be required now to connect to it from outside the pod.

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
