### PR TITLE
Replace hypothetical example with real arxiv-mcp-server workflow

### DIFF
--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -457,11 +457,13 @@ spec:
 > Note: The example above assumes you have:
 >
 > - An `MCPGroup` named `research-tools`.
-> - An `arxiv-mcp-server` deployed as an `MCPServer` or `MCPRemoteProxy` resource that references the `research-tools` group.
+> - An `arxiv-mcp-server` deployed as an `MCPServer` or `MCPRemoteProxy`
+>   resource that references the `research-tools` group.
 >
-> For a complete example of configuring MCP groups and backend servers, see the quickstart and tool aggregation guides.
-For complex, reusable workflows, create `VirtualMCPCompositeToolDefinition`
-resources and reference them with `spec.config.compositeToolRefs`:
+> For a complete example of configuring MCP groups and backend servers, see the
+> quickstart and tool aggregation guides. For complex, reusable workflows,
+> create `VirtualMCPCompositeToolDefinition` resources and reference them with
+> `spec.config.compositeToolRefs`:
 
 ```yaml title="VirtualMCPServer resource"
 spec:


### PR DESCRIPTION

### Description
Replace the hypothetical llm.summarize example in composite tools documentation with a working arxiv-mcp-server example that users can actually deploy and test. Add documentation for template functions (fromJson, json, quote, index) and explain how to handle both structured content and JSON text responses from MCP servers.

Fixes #367

I manually validated I can run this demo locally with the latest vMCP bits.

### Type of change

- New documentation
- Documentation update

### Related issues/PRs
Fixes #367

### Screenshots
<img width="829" height="841" alt="Screenshot 2026-01-28 at 10 36 22 AM" src="https://github.com/user-attachments/assets/f2adf9a3-6799-409e-9703-b4a438c03057" />

<img width="831" height="593" alt="Screenshot 2026-01-28 at 10 35 27 AM" src="https://github.com/user-attachments/assets/86ad7d0d-62f5-41eb-8a8d-04db4a8fe1fb" />

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
