### PR TITLE
Fix update-reference workflow by adding checkout step

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -25,6 +25,9 @@ jobs:
   update-reference:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
       - name: Setup
         uses: ./.github/actions/setup
 


### PR DESCRIPTION
### Description
The workflow was broken in commit 9bb3cde when the explicit checkout step was replaced with the local ./.github/actions/setup action. Local actions require the repository to be checked out first so the action file can be found.

### Type of change
<!-- Keep the one that applies and delete the others -->


- Bug fix (typo, broken link, etc.)

### Related issues/PRs
see e.g. https://github.com/stacklok/docs-website/actions/runs/21477366404/job/61864642481

### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Submitter checklist

#### Content and formatting

- [X] I have reviewed the content for technical accuracy
- [N/A] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)


### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
