### PR TITLE
Update Operator release badges and tag references

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -81,6 +81,7 @@ To install the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you plan to use:
 
 ```bash
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
 kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
 kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
 kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml


### PR DESCRIPTION
### Description

The new unified release process for ToolHive changes how operator releases are tagged.

This updates the "latest version" badges, example versions, and tags in the kubectl URLs to align.

### Type of change

- Documentation update

### Related issues/PRs

#483
stacklok/toolhive#3511
stacklok/toolhive#3522

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
