### PR TITLE
Use thv run for vMCP client config in quickstart

### DIFF
--- a/docs/toolhive/tutorials/quickstart-vmcp.mdx
+++ b/docs/toolhive/tutorials/quickstart-vmcp.mdx
@@ -200,30 +200,20 @@ curl http://localhost:4483/health
 
 You should see `{"status":"ok"}`.
 
-Configure VS Code to connect to vMCP. Add the following to your `mcp.json` file:
+Add the port-forwarded vMCP endpoint as a remote server in ToolHive:
 
-- **macOS**: `~/Library/Application Support/Code/User/mcp.json`
-- **Windows**: `%APPDATA%\Code\User\mcp.json`
-- **Linux**: `~/.config/Code/User/mcp.json`
-
-```json
-{
-  "servers": {
-    "demo-vmcp": {
-      "url": "http://localhost:4483/mcp",
-      "type": "http"
-    }
-  }
-}
+```bash
+thv run http://localhost:4483/mcp --name demo-vmcp
 ```
 
-Reload VS Code to apply the configuration.
+This registers the vMCP endpoint as a ToolHive-managed workload, which
+automatically configures your registered MCP clients to connect to it.
 
 :::tip
 
-For other MCP clients, see the
-[Client compatibility reference](../reference/client-compatibility.mdx) for
-configuration file locations and formats.
+If you haven't set up client configuration yet, run `thv client setup` to
+register your MCP clients. See
+[Client configuration](../guides-cli/client-configuration.mdx) for more details.
 
 :::
 


### PR DESCRIPTION


### Description
In `docs/toolhive/tutorials/quickstart-vmcp.mdx`, replace manual VS Code mcp.json configuration with `thv run` to register the port-forwarded vMCP endpoint as a remote server. This simplifies client setup by leveraging ToolHive's automatic client configuration. This also shows how you can treat vMCP like just another MCP server using `thv`.


### Type of change

- Documentation update

### Related issues/PRs
Closes https://github.com/stacklok/docs-website/issues/368

Note: the PR above suggests mentioning multiple options, none of which is using `thv run`. I chose `thv run` because it makes the client connection steps resemble what a user would do for any other MCP server. Also, configuring remote servers in the UI actually requires authentication config. This does not exist for the quickstart, so the UI makes the quickstart more complicated. Also, this quickstart already has multiple command steps, so it does not seem like `thv run` is something the intended audience is incapable of running.

### Screenshots
I tested these steps manually. I could see the vmcp server registered in cursor after following the quickstart:

<img width="471" height="83" alt="Screenshot 2026-01-29 at 12 50 47 PM" src="https://github.com/user-attachments/assets/8b60cbcf-a4ed-4aaa-b281-c455091a975f" />

The actual docs:
<img width="849" height="569" alt="Screenshot 2026-01-29 at 1 03 12 PM" src="https://github.com/user-attachments/assets/464bcc98-3606-448c-8426-127c790a61f3" />

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
