### PR TITLE
Document default step outputs for composite tools

### DIFF
--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -117,7 +117,7 @@ spec:
 When a client calls this composite tool, vMCP executes all three steps in
 sequence and returns the paper content.
 
-### Structured content vs JSON text
+## Structured content vs JSON text
 
 MCP servers can return data in two ways:
 
@@ -369,16 +369,15 @@ handle cases where the step fails.
 ### Default step outputs
 
 When steps can be skipped (due to `condition` being false or
-`onError.action: continue`), later steps that reference their outputs need
+`onError.action: continue`), downstream steps that reference their outputs need
 fallback values. Use `defaultResults` to provide these values.
 
 #### When defaultResults are required
 
-You must provide `defaultResults` when **all** of these conditions are true:
+You must provide `defaultResults` when **both** of these conditions are true:
 
 1. A step can be skipped (has a `condition` field or `onError.action: continue`)
 2. A downstream step references the skipped step's output in its arguments
-3. The downstream step doesn't have its own condition that would skip it too
 
 #### Configuration
 
@@ -467,7 +466,7 @@ vMCP validates `defaultResults` at configuration time:
   error
 - **Structure**: The `defaultResults` value can be any valid JSON type (object,
   array, string, number, boolean, null)
-- **No runtime checks**: vMCP does not verify that `defaultResults` match the
+- **No type checking**: vMCP does not verify that `defaultResults` match the
   actual output structure—you must ensure they match the format your downstream
   steps expect
 
@@ -517,6 +516,10 @@ The following functions are available for use in templates:
 | `json`     | Encode a value as a JSON string  | `{{json .steps.s1.output}}`                  |
 | `quote`    | Quote a string value             | `{{quote .params.name}}`                     |
 | `index`    | Access array elements by index   | `{{index .steps.s1.output.items 0}}`         |
+
+All
+[Go template built-in functions](https://pkg.go.dev/text/template#hdr-Functions)
+are also supported (e.g., `len`, `eq`, `and`, `or`, `printf`).
 
 ### Accessing step outputs
 


### PR DESCRIPTION
### Description                                                                            
                                                                                             
Add comprehensive documentation for the `defaultResults` field in Virtual MCP Server       
composite tools. This field provides fallback values when workflow steps are skipped due to
conditional logic (`condition: false`) or continue-on-error behavior (`onError.action:    
continue`).                                                                                
                                                                                             
The new "Default step outputs" section covers:                                             
  - When defaultResults are required (all three conditions explained)                        
  - Configuration syntax with examples for both conditional steps and continue-on-error      
  scenarios                                                                                  
  - Validation behavior and error messages users will encounter                              
  - Cross-references from "Steps" and "Error handling" sections to help users discover the   
  feature when they need it                                                                  
                                                                                             
Also fixed pre-existing markdownlint errors (heading style and JSX comment syntax).        
                                                                                             
### Type of change                                                                         
                                                                                             
- Documentation update                                                                     
                                                                                             
### Related issues/PRs                                                                     
                                                                                             
Resolves: #489                                                                             
                                                                                             
### Screenshots                                                                            
                                                                                             
None needed (text documentation only).                                                     
                                                                                             
### Submitter checklist                                                                    
                                                                                             
#### Content and formatting                                                                
                                                                                             
- [x] I have reviewed the content for technical accuracy                                   
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)       
                                                                                             
#### Navigation                                                                            
                                                                                             
Not applicable - updated existing page, no new pages added or navigation changes.
