### PR TITLE
Filter stacklokbot from PR reviewers

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -53,8 +53,8 @@ jobs:
           else
             REVIEWER="${{ github.event.inputs.assign_to }}"
           fi
-          # Filter out github-actions bot (can't be requested as reviewer)
-          if [[ "$REVIEWER" =~ ^github-actions ]]; then
+          # Filter out github-actions bot and stacklokbot (can't be requested as reviewers)
+          if [[ "$REVIEWER" =~ ^github-actions ]] || [[ "$REVIEWER" == "stacklokbot" ]]; then
             REVIEWER=""
           fi
           echo "assign_to=$REVIEWER" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds stacklokbot to the list of ignored PR reviewers in the update-toolhive-reference workflow.