### PR TITLE
Document tool definitions annotation support

### DIFF
--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -284,12 +284,25 @@ by the operator during resource reconciliation. If the annotation contains
 invalid JSON, a warning is logged and the tool definitions are omitted from the
 registry, but the server is still registered normally.
 
-Tool definitions appear in the Registry API response at a key of the form:
-`_meta.publisher-provided.io.github.stacklok.<registry-url>.tool_definitions`,
-where `<registry-url>` is the exact value of the `registry-url` annotation for
-that server. For example, if the annotation is
-`https://mcp.example.com/servers/my-mcp-server`, the field appears as
-`_meta.publisher-provided.io.github.stacklok.https://mcp.example.com/servers/my-mcp-server.tool_definitions`.
+Tool definitions appear in the Registry API response under the server's registry
+URL within the publisher-provided metadata:
+
+```json
+{
+  "_meta": {
+    "publisher-provided": {
+      "io.github.stacklok": {
+        "https://mcp.example.com/servers/my-mcp-server": {
+          "tool_definitions": [...]
+        }
+      }
+    }
+  }
+}
+```
+
+The registry URL from the `registry-url` annotation becomes a key in the JSON
+structure.
 
 This feature requires the Registry server to be granted access to those
 resources via a Service Account, check the details in the


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Document the new `toolhive.stacklok.dev/tool-definitions` annotation                                                                                                                                                                                                                                                                                                                                                         
  - Add example showing tool definitions in YAML annotations                                                                                                                                                                                                                                                                                                                                                                     
  - Explain validation behavior, API response format, and supported fields                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Related                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Implements documentation for stacklok/toolhive-registry-server#414 (registry-server implementation of RFC-0015)                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Updated `docs/toolhive/guides-registry/configuration.mdx`:                                                                                                                                                                                                                                                                                                                                                                   
    - Added `tool-definitions` annotation to the annotations table                                                                                                                                                                                                                                                                                                                                                               
    - Included example tool definition in the registry YAML example                                                                                                                                                                                                                                                                                                                                                              
    - Added "Tool definitions format" section explaining:                                                                                                                                                                                                                                                                                                                                                                        
      - JSON array format with MCP tool metadata fields                                                                                                                                                                                                                                                                                                                                                                          
      - JSON syntax validation (registry) vs schema validation (operator)                                                                                                                                                                                                                                                                                                                                                        
      - API response location in publisher-provided metadata                                                                                                                                                                                                                                                                                                                                                                     
      - Graceful error handling for invalid JSON   