### PR TITLE
Add VS Code Server to client compatibility

### DIFF
--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -31,6 +31,7 @@ We've tested ToolHive with these clients:
 | Sourcegraph Amp (Cursor)   |    ✅     |         ✅         |                                             |
 | Sourcegraph Amp (Windsurf) |    ✅     |         ✅         |                                             |
 | Trae IDE                   |    ✅     |         ✅         | v1.4.1+                                     |
+| VS Code Server             |    ✅     |         ✅         |                                             |
 | Windsurf IDE               |    ✅     |         ✅         |                                             |
 | Windsurf (JetBrains)       |    ✅     |         ✅         |                                             |
 | Zed                        |    ✅     |         ✅         | v0.214.5+                                   |
@@ -120,6 +121,29 @@ When you register VS Code as a client, ToolHive automatically updates the global
 MCP configuration file whenever you run an MCP server. You can also
 [configure project-specific MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server-to-your-workspace)
 by creating a `.vscode/mcp.json` file in your project directory.
+
+### VS Code Server
+
+[VS Code Server](https://code.visualstudio.com/docs/remote/vscode-server) is the
+server-side component that enables remote development with Visual Studio Code.
+It stores its global MCP configuration in a JSON file on the remote server.
+
+- **All platforms**: `~/.vscode-server/data/User/mcp.json`
+
+Example configuration:
+
+```json
+{
+  "servers": {
+    "github": { "url": "http://localhost:19046/mcp", "type": "http" },
+    "fetch": { "url": "http://localhost:43832/mcp", "type": "http" },
+    "sqlite": { "url": "http://localhost:51712/sse#sqlite", "type": "sse" }
+  }
+}
+```
+
+When you register VS Code Server as a client, ToolHive automatically updates the
+global MCP configuration file whenever you run an MCP server.
 
 ### Cursor
 


### PR DESCRIPTION
## Summary

- Add VS Code Server to the supported clients table
- Document configuration file location (`~/.vscode-server/data/User/mcp.json`)
- Include example configuration and auto-configuration details

## Test plan

- [x] Verify markdown formatting with Prettier
- [x] Verify code quality with ESLint
- [ ] Review documentation accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)