### PR TITLE
Document nested Kubernetes metadata in registry extensions

### DIFF
--- a/docs/toolhive/reference/registry-schema-upstream.mdx
+++ b/docs/toolhive/reference/registry-schema-upstream.mdx
@@ -60,13 +60,24 @@ The available properties vary by server type:
 - **All servers**: `status`, `tier`, `tools`, `tags`, `metadata`, and
   `custom_metadata`
 
+:::note Read-only metadata
+
+The `metadata` object can include an optional `kubernetes` nested object with
+fields like `kind`, `namespace`, `name`, `uid`, `image`, and `transport`. This
+metadata is automatically added by the ToolHive Registry Server for servers that
+were auto-discovered from Kubernetes deployments (typically remote servers
+accessed via Kubernetes-exposed URLs). You should not manually add this field
+when creating custom registry files.
+
+:::
+
 <JSONSchemaViewer schema={PublisherProvidedSchema} />
 
 ## Full example
 
-The following example shows a complete registry file with both a container
-server and a remote server, demonstrating the different ToolHive extensions
-available for each type:
+The following example shows a complete custom registry file with both a
+container server and a remote server, demonstrating the different ToolHive
+extensions you can use when building your own registry:
 
 ```json title="Example registry file with ToolHive extensions"
 {


### PR DESCRIPTION
Updates the ToolHive extensions schema documentation to document the nested kubernetes metadata structure.                                                                                                                   

**Details:**
- Add explanation that `metadata` can include an optional `kubernetes` nested object
- Document that this metadata only appears for servers auto-discovered from Kubernetes deployments

### Description
<!-- Explain what has changed and why -->

### Type of change
<!-- Keep the one that applies and delete the others -->

- Documentation update


### Related issues/PRs
<!-- Reference related issues the PR is related to or will resolve -->
<!-- If documenting a new feature, link to the related PR in the main project's repo -->

### Screenshots
<!-- Optionally include screenshots if needed to show new formatting or sidebar structure -->

### Submitter checklist

#### Content and formatting

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

#### Navigation
<!-- If you added, deleted, renamed, or reordered pages, please check the following -->
<!-- If you did not, you can delete this section -->

- [ ] New pages include a frontmatter section with title and description at a minimum
- [ ] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [ ] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)
  <!-- Rationale: 404's are the enemy! You can test these in the Vercel preview build (push your branch or run `vercel`) -->

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Related to https://github.com/stacklok/toolhive-registry-server/issues/490