### PR TITLE
Update toolhive-registry repo links

### DIFF
--- a/docs/toolhive/concepts/registry-criteria.mdx
+++ b/docs/toolhive/concepts/registry-criteria.mdx
@@ -11,10 +11,10 @@ high-quality MCP servers through clear, observable, and objective criteria.
 
 If you have an MCP server that you'd like to add to the ToolHive registry, you
 can
-[open an issue](https://github.com/stacklok/toolhive-registry/issues/new?template=add-an-mcp-server.md)
+[open an issue](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md)
 or submit a pull request to the
-[ToolHive-registry](https://github.com/stacklok/toolhive-registry) repository.
-The ToolHive team will review your submission and consider adding it to the
+[toolhive-catalog](https://github.com/stacklok/toolhive-catalog) repository. The
+ToolHive team will review your submission and consider adding it to the
 registry.
 
 Criteria for adding an MCP server to the ToolHive registry are outlined below.
@@ -22,7 +22,7 @@ These criteria ensure that the servers in the registry meet the standards of
 security, quality, and usability that ToolHive aims to uphold.
 
 Registry entries are defined in the
-[ToolHive-registry](https://github.com/stacklok/toolhive-registry) repository.
+[toolhive-catalog](https://github.com/stacklok/toolhive-catalog) repository.
 
 ## Criteria for MCP servers
 

--- a/docs/toolhive/contributing.mdx
+++ b/docs/toolhive/contributing.mdx
@@ -86,14 +86,14 @@ ToolHive. If you want to add a new MCP server to the registry, this is the
 repository to contribute to.
 
 **Repository**:
-[stacklok/toolhive-registry](https://github.com/stacklok/toolhive-registry)
+[stacklok/toolhive-catalog](https://github.com/stacklok/toolhive-catalog)
 
 **Key resources**:
 
-- [Contributing guide](https://github.com/stacklok/toolhive-registry/blob/main/CONTRIBUTING.md)
+- [Contributing guide](https://github.com/stacklok/toolhive-catalog/blob/main/CONTRIBUTING.md)
 - [Registry inclusion criteria](./concepts/registry-criteria.mdx)
-- [Submit a new MCP server](https://github.com/stacklok/toolhive-registry/issues/new?template=add-an-mcp-server.md)
-- [Issue tracker](https://github.com/stacklok/toolhive-registry/issues)
+- [Submit a new MCP server](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md)
+- [Issue tracker](https://github.com/stacklok/toolhive-catalog/issues)
 
 ### Dockyard
 

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -199,7 +199,7 @@ The ToolHive registry has specific
 [inclusion criteria](./concepts/registry-criteria.mdx), such as being open
 source, following good security practices, and maintaining code quality. Review
 the criteria and
-[submit your server for consideration](https://github.com/stacklok/toolhive-registry/issues/new?template=add-an-mcp-server.md).
+[submit your server for consideration](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md).
 
 ### Can I use ToolHive behind a corporate firewall?
 


### PR DESCRIPTION
### Description

The toolhive-registry repo is now toolhive-catalog. This updates references to the repo.

### Type of change

- Documentation update

### Related issues/PRs

- https://github.com/stacklok/toolhive/pull/3907

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>