### PR TITLE
Un-nest configmap data

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -162,13 +162,10 @@ metadata:
   name: shared-oidc-config
   namespace: toolhive-system
 data:
-  oidc.json: |
-    {
-      "issuer": "https://auth.example.com",
-      "audience": "https://mcp.example.com",
-      "clientId": "shared-client-id",
-      "jwksUrl": "https://auth.example.com/.well-known/jwks.json"
-    }
+  issuer: 'https://auth.example.com'
+  audience: 'https://mcp.example.com'
+  clientId: 'shared-client-id'
+  jwksUrl: 'https://auth.example.com/.well-known/jwks.json'
 ```
 
 ```bash
@@ -197,7 +194,6 @@ spec:
     type: configMap
     configMap:
       name: shared-oidc-config
-      key: oidc.json
   resources:
     limits:
       cpu: '100m'

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -226,19 +226,16 @@ endpoint (`/.well-known/openid-configuration`).
 For more complex configurations or when you need to share OIDC settings across
 multiple proxies, use a ConfigMap:
 
-```yaml {21-25} title="oidc-config.yaml"
+```yaml {21-24} title="oidc-config.yaml"
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: company-oidc-config
   namespace: toolhive-system
 data:
-  oidc.json: |
-    {
-      "issuer": "https://auth.company.com/realms/production",
-      "audience": "mcp-proxy",
-      "clientId": "mcp-proxy-client"
-    }
+  issuer: 'https://auth.company.com/realms/production'
+  audience: 'mcp-proxy'
+  clientId: 'mcp-proxy-client'
 ---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
@@ -251,7 +248,6 @@ spec:
     type: configMap
     configMap:
       name: company-oidc-config
-      key: oidc.json
 ```
 
 </TabItem>


### PR DESCRIPTION
### Description
Updated the OIDC configmap examples to use the top level structure, instead of nested JSON.

### Type of change

- Bug fix (typo, broken link, etc.)

### Submitter checklist

#### Content and formatting

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
