### PR TITLE
Add CRD namespace consistency note for operator deployment

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -33,38 +33,34 @@ Choose an installation method based on your needs:
 <Tabs groupId="method" queryString="method">
 <TabItem value="helm" label="Helm" default>
 
-```bash
-helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
-```
-
-:::warning[Namespace consistency]
-
-When you install this chart, Helm stamps all CRDs with a
-`meta.helm.sh/release-namespace` annotation set to the namespace used at install
-time. This annotation **cannot be changed** by subsequent `helm upgrade`
-commands targeting a different namespace.
-
-You can install this chart in any namespace, but you **must use the same
-namespace consistently** for all future upgrades. If you plan to install the
-operator in `toolhive-system`, install the CRD chart there too:
+This command installs the latest version of the ToolHive operator CRDs Helm
+chart:
 
 ```bash
 helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
   -n toolhive-system --create-namespace
 ```
 
-If you do want to install into a separate namespace, you'll need to modify the
-annotations of the existing installed CRDs. See below in the Troubleshooting
-section for example `kubectl annotate` commands.
+:::warning[Namespace consistency]
+
+When you install this chart, Helm stamps all CRDs with a
+`meta.helm.sh/release-namespace` annotation set to the namespace used at install
+time and is fixed for that release. You must continue to use the same namespace
+on all future `helm upgrade` commands for the CRDs. If you decide to specify a
+different namespace, an error will occur due to ownership issues.
+
+If you need to migrate to a different namespace, see the
+[CRD namespace mismatch troubleshooting](#crd-upgrade-fails-with-namespace-mismatch)
+section.
 
 :::
 
-This command installs the latest version of the ToolHive operator CRDs Helm
-chart. To install a specific version, append `--version <VERSION>` to the
-command, for example:
+To install a specific version, append `--version <VERSION>` to the command, for
+example:
 
 ```bash
-helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.8.3
+helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
+  -n toolhive-system --version 0.8.3
 ```
 
 #### CRD configuration options
@@ -84,7 +80,7 @@ For example, to install only server-related CRDs without vMCP support:
 
 ```bash
 helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
-  --set crds.install.virtualMcp=false
+  -n toolhive-system --set crds.install.virtualMcp=false
 ```
 
 :::note
@@ -502,7 +498,7 @@ Common causes include:
 
 </details>
 
-<details>
+<details id="crd-upgrade-fails-with-namespace-mismatch">
 <summary>CRD upgrade fails with namespace mismatch</summary>
 
 If you see an error like the following when upgrading the CRD chart:


### PR DESCRIPTION
## Summary

- Adds a warning admonition to the Helm CRD install section explaining that Helm stamps CRDs with a `meta.helm.sh/release-namespace` annotation, which requires consistent namespace usage across installs and upgrades
- Adds a troubleshooting entry for the namespace mismatch error with the `kubectl annotate` fix

Upstream: https://github.com/stacklok/toolhive/pull/4022

## Test plan

- [ ] Verify the site builds successfully
- [ ] Review the warning renders correctly on the deploy operator page

🤖 Generated with [Claude Code](https://claude.com/claude-code)