### PR TITLE
Switch analytics to Stape server-side GTM

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -80,11 +80,16 @@ const config: Config = {
             headTags: [
               {
                 tagName: 'script',
+                // Server-side GTM loader script.
+                // Source: Generated from the Stape dashboard for Stacklok.
+                // The snippet is intentionally kept minified and should not be edited manually.
+                // To update, re-generate from the Stape dashboard and replace the string verbatim.
                 innerHTML:
                   '!function(){"use strict";function l(e){for(var t=e,r=0,n=document.cookie.split(";");r<n.length;r++){var o=n[r].split("=");if(o[0].trim()===t)return o[1]}}function s(e){return localStorage.getItem(e)}function u(e){return window[e]}function A(e,t){e=document.querySelector(e);return t?null==e?void 0:e.getAttribute(t):null==e?void 0:e.textContent}var e=window,t=document,r="script",n="dataLayer",o="https://mm.stacklok.com",a="",i="3ghsgqgovzfj",c="2ng=AwJHMTsqXDBTKyIxOyFIQRxbSFheQRUJVxUOFwwMHQgBSBkZAg%3D%3D",g="cookie",v="user_id",E="",d=!1;try{var d=!!g&&(m=navigator.userAgent,!!(m=new RegExp("Version/([0-9._]+)(.*Mobile)?.*Safari.*").exec(m)))&&16.4<=parseFloat(m[1]),f="stapeUserId"===g,I=d&&!f?function(e,t,r){void 0===t&&(t="");var n={cookie:l,localStorage:s,jsVariable:u,cssSelector:A},t=Array.isArray(t)?t:[t];if(e&&n[e])for(var o=n[e],a=0,i=t;a<i.length;a++){var c=i[a],c=r?o(c,r):o(c);if(c)return c}else console.warn("invalid uid source",e)}(g,v,E):void 0;d=d&&(!!I||f)}catch(e){console.error(e)}var m=e,g=(m[n]=m[n]||[],m[n].push({"gtm.start":(new Date).getTime(),event:"gtm.js"}),t.getElementsByTagName(r)[0]),v=I?"&bi="+encodeURIComponent(I):"",E=t.createElement(r),f=(d&&(i=8<i.length?i.replace(/([a-z]{8}$)/,"kp$1"):"kp"+i),!d&&a?a:o);E.async=!0,E.src=f+"/"+i+".js?"+c+v,null!=(e=g.parentNode)&&e.insertBefore(E,g)}();',
               },
             ],
             preBodyTags: [
+              // Server-side GTM noscript fallback.
               `<!-- Google Tag Manager (noscript) --><noscript><iframe src="https://mm.stacklok.com/ns.html?id=GTM-W9MXGTF9" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- End Google Tag Manager (noscript) -->`,
             ],
           };


### PR DESCRIPTION
## Description

Migrates site analytics from client-side Google Tag Manager to [Stape's server-side GTM service](https://stape.io). Rather than loading scripts directly from Google's servers, analytics requests are proxied through a Stape-hosted endpoint aliased under the `stacklok.com` domain (`mm.stacklok.com`). Server-side GTM is a more privacy-friendly approach, as it reduces direct data exposure to third-party scripts in the browser.

Because the new integration uses an inline loader script rather than an external script URL, the implementation moves from the `scripts` config array (which only supports `src` URLs) to a Docusaurus inline plugin using `injectHtmlTags`. This also allows the required GTM `<noscript>` fallback tag to be injected correctly into `<body>`.

## Type of change

- Other: backend/internal update

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>
