### PR TITLE
removes --reuse-values flag and updates version

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -60,7 +60,7 @@ example:
 
 ```bash
 helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
-  -n toolhive-system --version 0.8.3
+  -n toolhive-system --version 0.12.1
 ```
 
 #### CRD configuration options
@@ -99,18 +99,18 @@ To install the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you plan to use:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
-Replace `v0.8.3` in the commands above with your target CRD version.
+Replace `v0.12.1` in the commands above with your target CRD version.
 
 </TabItem>
 </Tabs>
@@ -131,7 +131,7 @@ chart. To install a specific version, append `--version <VERSION>` to the
 command, for example:
 
 ```bash
-helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --version 0.8.3
+helm upgrade --install toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --create-namespace --version 0.12.1
 ```
 
 Verify the installation:
@@ -324,7 +324,7 @@ To upgrade the ToolHive operator to a new version, upgrade the CRDs first by
 upgrading with the desired CRDs chart:
 
 ```bash
-helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.8.3
+helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds --version 0.12.1
 ```
 
 </TabItem>
@@ -334,21 +334,21 @@ To upgrade the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you want:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.8.3/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
 </TabItem>
 </Tabs>
 
-Replace `v0.8.3` in the commands above with your target CRD version.
+Replace `v0.12.1` in the commands above with your target CRD version.
 
 ### Upgrade the operator Helm release
 
@@ -357,20 +357,20 @@ Then, upgrade the operator installation using Helm.
 ![Latest Operator Helm chart release](https://img.shields.io/github/v/release/stacklok/toolhive?style=for-the-badge&logo=helm&label=Latest%20Operator%20chart&color=bddfc2)
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system
 ```
 
 This upgrades the operator to the latest version available in the OCI registry.
 To upgrade to a specific version, add the `--version` flag:
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values --version 0.8.3
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --version 0.12.1
 ```
 
 If you have a custom `values.yaml` file, include it with the `-f` flag:
 
 ```bash
-helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system --reuse-values -f values.yaml
+helm upgrade -i toolhive-operator oci://ghcr.io/stacklok/toolhive/toolhive-operator -n toolhive-system -f values.yaml
 ```
 
 ## Uninstall the operator


### PR DESCRIPTION
### Description
We don't want to recommend users use `--reuse-values` because its a footgun for Helm and causes issues when updating Charts as it leaves the images on older versions.

Also updates the ToolHive version to a more recent version.

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
