### PR TITLE
Bump SPDX headings copyright year

### DIFF
--- a/plugins/mcp-metadata-plugin/src/index.ts
+++ b/plugins/mcp-metadata-plugin/src/index.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path';

--- a/plugins/mcp-metadata-plugin/src/types.ts
+++ b/plugins/mcp-metadata-plugin/src/types.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 export interface PluginOptions {

--- a/plugins/mcp-metadata-plugin/src/utils.ts
+++ b/plugins/mcp-metadata-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import { execSync } from 'child_process';

--- a/scripts/bundle-upstream-schema.mjs
+++ b/scripts/bundle-upstream-schema.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 /**

--- a/scripts/install-thv.sh
+++ b/scripts/install-thv.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+# SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # This script installs the ToolHive CLI (thv) in a portable way that works

--- a/scripts/update-toolhive-reference.sh
+++ b/scripts/update-toolhive-reference.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+# SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/src/components/MCPMetadata/index.tsx
+++ b/src/components/MCPMetadata/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ProductCard/index.tsx
+++ b/src/components/ProductCard/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ProductCard/styles.module.css
+++ b/src/components/ProductCard/styles.module.css
@@ -1,5 +1,5 @@
 /*
-  SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+  SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
   SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/components/ProductGrid/index.tsx
+++ b/src/components/ProductGrid/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/components/ProductGrid/styles.module.css
+++ b/src/components/ProductGrid/styles.module.css
@@ -1,5 +1,5 @@
 /*
-  SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+  SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
   SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,5 +1,5 @@
 /*
-  SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+  SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
   SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/css/footer.css
+++ b/src/css/footer.css
@@ -1,5 +1,5 @@
 /*
-  SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+  SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
   SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,5 +1,5 @@
 /*
-  SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+  SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
   SPDX-License-Identifier: Apache-2.0
 */
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';

--- a/src/theme/NotFound/Content/index.tsx
+++ b/src/theme/NotFound/Content/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { type ReactNode } from 'react';

--- a/src/theme/NotFound/index.tsx
+++ b/src/theme/NotFound/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { type ReactNode } from 'react';

--- a/src/utils/buildHierarchicalSidebar.ts
+++ b/src/utils/buildHierarchicalSidebar.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from 'fs';


### PR DESCRIPTION
### Description

Bump the copyright year to 2026 in SPDX headers.

### Type of change

- Other / internal