### PR TITLE
Expand vMCP two-boundary auth diagram and descriptions

### DIFF
--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -40,8 +40,8 @@ flowchart LR
 **Boundary 1 (Incoming):** Clients authenticate to vMCP using OAuth 2.1
 authorization as defined in the
 [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
-The vMCP validates the token — checking issuer, audience, expiry, and signature
-for JWTs, or using token introspection for opaque tokens — and then evaluates
+The vMCP validates the token by checking issuer, audience, expiry, and signature
+for JWTs, or by using token introspection for opaque tokens. It then evaluates
 Cedar policies before forwarding the request. This all happens inside the single
 `vmcp` process, unlike a plain MCPServer deployment where a separate ToolHive
 proxy handles this step. When using shared OIDC configuration via

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -18,8 +18,11 @@ flowchart LR
     end
 
     subgraph vMCP["Virtual MCP Server (vMCP)"]
-        Auth[Token validation]
-        Backend[Backend auth]
+        direction TB
+        Auth["Token validation<br>(issuer, audience, expiry)"]
+        Authz["Authorization<br>(Cedar policies)"]
+        Proxy[Backend proxy]
+        Auth --> Authz --> Proxy
     end
 
     subgraph Boundary2[" "]
@@ -30,19 +33,24 @@ flowchart LR
     end
 
     Client -->|"vMCP-scoped<br>token"| Auth
-    Auth --> Backend
-    Backend -->|"Backend-scoped<br>token"| GitHub
-    Backend -->|"Backend-scoped<br>token"| Jira
+    Proxy -->|"Backend-scoped<br>token"| GitHub
+    Proxy -->|"Backend-scoped<br>token"| Jira
 ```
 
 **Boundary 1 (Incoming):** Clients authenticate to vMCP using OAuth 2.1
 authorization as defined in the
 [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
-This is your organization's identity layer.
+The vMCP validates the token — checking issuer, audience, expiry, and signature
+for JWTs, or using token introspection for opaque tokens — and then evaluates
+Cedar policies before forwarding the request. This all happens inside the single
+`vmcp` process, unlike a plain MCPServer deployment where a separate ToolHive
+proxy handles this step. The audience value must be explicitly set in
+`incomingAuth` (see [OIDC authentication](#oidc-authentication) below).
 
-**Boundary 2 (Outgoing):** vMCP obtains appropriate credentials for each
-backend. Each backend API receives a token or credential scoped to its
-requirements.
+**Boundary 2 (Outgoing):** vMCP obtains credentials for each backend API using
+the configured outgoing auth strategy. See
+[Outgoing authentication](#outgoing-authentication) for the available
+strategies.
 
 ## Incoming authentication
 

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -19,7 +19,7 @@ flowchart LR
 
     subgraph vMCP["Virtual MCP Server (vMCP)"]
         direction TB
-        Auth["Token validation<br>(issuer, audience, expiry)"]
+        Auth["Token validation<br>(issuer, audience, expiry,<br>signature/introspection)"]
         Authz["Authorization<br>(Cedar policies)"]
         Proxy[Backend proxy]
         Auth --> Authz --> Proxy
@@ -44,8 +44,10 @@ The vMCP validates the token — checking issuer, audience, expiry, and signatur
 for JWTs, or using token introspection for opaque tokens — and then evaluates
 Cedar policies before forwarding the request. This all happens inside the single
 `vmcp` process, unlike a plain MCPServer deployment where a separate ToolHive
-proxy handles this step. The audience value must be explicitly set in
-`incomingAuth` (see [OIDC authentication](#oidc-authentication) below).
+proxy handles this step. When using shared OIDC configuration via
+`oidcConfigRef`, the audience value must be explicitly set. For inline OIDC
+configuration, it is optional but recommended. See
+[OIDC authentication](#oidc-authentication) below.
 
 **Boundary 2 (Outgoing):** vMCP obtains credentials for each backend API using
 the configured outgoing auth strategy. See


### PR DESCRIPTION
### Description

Addresses user feedback that the two-boundary authentication model diagram was too abstract. Specifically:

- The vMCP box now shows the three internal steps (token validation → Cedar policy authorization → backend proxy) instead of a single unlabeled node
- Token validation labels clarify that the check covers issuer, audience, expiry, and signature for JWTs, or token introspection for opaque tokens
- Boundary 1 description explains that this all happens inside the single `vmcp` process, unlike a plain MCPServer deployment where a separate ToolHive proxy handles auth
- Boundary 1 notes that the audience must be explicitly configured for vMCP
- Boundary 2 description links to the Outgoing authentication section rather than listing an incomplete set of strategies

### Type of change

- Documentation update

### Related issues/PRs

<!-- None -->

### Screenshots

<!-- Diagram change is in Mermaid source; visible in Vercel preview -->

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)