### PR TITLE
Part 2: Update Registry Server docs for v1.0.0–v1.1.0

### DIFF
--- a/docs/toolhive/contributing.mdx
+++ b/docs/toolhive/contributing.mdx
@@ -70,8 +70,9 @@ actively being developed and tested.
 ### Registry server
 
 The Registry Server is an API server that implements the official MCP Registry
-API. It provides standardized access to MCP servers from multiple backends,
-including file-based and other API-compliant registries.
+API. It provides standardized access to MCP servers and skills from multiple
+backends, including Git repositories, API endpoints, files, managed sources, and
+Kubernetes clusters.
 
 **Repository**:
 [stacklok/toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -801,7 +801,7 @@ Learn how to customize MCP tools using
 [filters and overrides](./customize-tools.mdx).
 
 Discover your deployed MCP servers automatically using the
-[Kubernetes registry](../guides-registry/configuration.mdx#kubernetes-registry)
+[Kubernetes source](../guides-registry/configuration.mdx#kubernetes-source)
 feature in the ToolHive Registry Server.
 
 ## Related information

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -175,7 +175,7 @@ spec:
 
 :::note
 
-`caBundleRef` cannot be used when `insecure` is set to `true` - they are
+`caBundleRef` cannot be used when `insecure` is set to `true` — they are
 mutually exclusive.
 
 :::

--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -354,11 +354,13 @@ anonymous mode in production.**
 The following endpoints are **always accessible without authentication**,
 regardless of the auth mode:
 
-- `/health` - Health check endpoint
-- `/readiness` - Readiness probe endpoint
-- `/version` - Version information
 - `/openapi.json` - OpenAPI specification
 - `/.well-known/*` - OAuth discovery endpoints (RFC 9728)
+
+The `/health`, `/readiness`, and `/version` endpoints are served on a separate
+internal server (default port 8081) and are not exposed on the main API port.
+See the [command-line flags](./configuration.mdx#command-line-flags) for the
+`--internal-address` option.
 
 You can configure additional public paths using the `publicPaths` field in your
 OAuth configuration. See the

--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -10,6 +10,14 @@ OAuth mode to protect your registry. You can configure authentication to fit
 different deployment scenarios, from development environments to production
 deployments with enterprise identity providers.
 
+:::tip[Looking for authorization?]
+
+This page covers **authentication** (verifying caller identity). For
+**authorization** (controlling what callers can do), including role-based access
+control and claims-based scoping, see [Authorization](./authorization.mdx).
+
+:::
+
 ## Authentication modes
 
 The server supports two authentication modes configured via the required `auth`
@@ -349,6 +357,7 @@ regardless of the auth mode:
 - `/health` - Health check endpoint
 - `/readiness` - Readiness probe endpoint
 - `/version` - Version information
+- `/openapi.json` - OpenAPI specification
 - `/.well-known/*` - OAuth discovery endpoints (RFC 9728)
 
 You can configure additional public paths using the `publicPaths` field in your
@@ -499,6 +508,14 @@ providers:
     caCertPath: /etc/ssl/certs/internal-ca.crt
 ```
 
+## Next steps
+
+- [Configure authorization](./authorization.mdx) to set up role-based access
+  control and claims-based scoping
+- [Set up the database](./database.mdx) for production storage and migrations
+- [Configure telemetry](./telemetry-metrics.mdx) for distributed tracing and
+  metrics collection
+
 ## Troubleshooting
 
 ### 401 Unauthorized errors
@@ -544,9 +561,3 @@ If tokens from some providers work but others don't:
 4. Review server logs to identify which specific provider validation is failing
 5. Test each provider's JWKS endpoint accessibility:
    `curl ${issuerUrl}/.well-known/openid-configuration`
-
-## Next steps
-
-- [Set up the database](./database.mdx) for production storage and migrations
-- [Configure telemetry](./telemetry-metrics.mdx) for distributed tracing and
-  metrics collection

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -10,7 +10,9 @@ who can manage sources, registries, and entries. Authorization builds on top of
 [authentication](./authentication.mdx) — you need OAuth authentication enabled
 before configuring authorization.
 
-Claims operate at three layers, checked in order when a client reads entries:
+## How authorization works
+
+When a client accesses registry data, the server checks three layers in order:
 
 1. **Registry claims** (access gate) — can the caller access this registry at
    all? If the registry has claims and the caller's JWT doesn't satisfy them,
@@ -22,17 +24,6 @@ Claims operate at three layers, checked in order when a client reads entries:
 3. **Role checks** (admin operations) — can the caller perform this write
    operation? Publishing, deleting, and managing sources/registries require
    specific [roles](#configure-roles).
-
-## How authorization works
-
-Authorization in the Registry server operates at two levels:
-
-1. **Role-based access control (RBAC)**: Determines which admin operations a
-   caller can perform (manage sources, manage registries, publish/delete
-   entries).
-2. **Claims-based scoping**: Limits visibility and access to specific sources,
-   registries, and entries based on key-value claims attached to both resources
-   and callers.
 
 When a caller makes an API request, the server:
 
@@ -221,15 +212,20 @@ caller's claims must be a superset of the resource's claims. For example:
 | `{org: "acme"}`                   | `{org: "contoso"}`                | Denied  |
 
 Registries and sources with no claims are accessible to all authenticated
-callers. However, **entries** with no claims behave differently: they are
-visible in anonymous mode and [auth-only mode](#auth-only-mode), but invisible
-when full authorization is enabled. With authorization, the per-entry filter
-requires both sides to have claims for a match — so entries without claims are
-filtered out. To make entries visible to authorized callers, attach claims to
-the source (for synced sources) or to individual entries (via the publish
+callers.
+
+:::warning[Entries without claims are invisible when authorization is enabled]
+
+Entries with no claims are visible in anonymous mode and
+[auth-only mode](#auth-only-mode), but **invisible** when full authorization is
+enabled. The per-entry filter requires both sides to have claims for a match —
+entries without claims are filtered out. To make entries visible, attach claims
+to the source (for synced sources) or to individual entries (via the publish
 payload or the
 [`authz-claims` annotation](./configuration.mdx#per-entry-claims-via-annotation)
 for Kubernetes sources).
+
+:::
 
 ## Claims on published entries
 

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -1,8 +1,8 @@
 ---
 title: Authorization
 description:
-  How to configure role-based access control and claims-based authorization for
-  the Registry Server
+  Configure role-based access control and claims-based authorization for the
+  Registry Server
 ---
 
 The Registry server provides a claims-based authorization model that controls

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -221,12 +221,13 @@ caller's claims must be a superset of the resource's claims. For example:
 | `{org: "acme"}`                   | `{org: "contoso"}`                | Denied  |
 
 Registries and sources with no claims are accessible to all authenticated
-callers. However, **entries** with no claims behave differently: they are only
-visible in anonymous mode. When authorization is enabled, an authenticated
-caller's per-entry filter requires both sides to have claims for a match — so
-entries without claims are invisible. To make entries visible to authenticated
-callers, attach claims to the source (for synced sources) or to individual
-entries (via the publish payload or the
+callers. However, **entries** with no claims behave differently: they are
+visible in anonymous mode and [auth-only mode](#auth-only-mode), but invisible
+when full authorization is enabled. With authorization, the per-entry filter
+requires both sides to have claims for a match — so entries without claims are
+filtered out. To make entries visible to authorized callers, attach claims to
+the source (for synced sources) or to individual entries (via the publish
+payload or the
 [`authz-claims` annotation](./configuration.mdx#per-entry-claims-via-annotation)
 for Kubernetes sources).
 

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -140,7 +140,7 @@ on each CRD. Managed source entries get claims from the publish request payload.
 ```yaml title="config-source-claims.yaml"
 sources:
   - name: platform-tools
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/acme/platform-tools.git
       branch: main
@@ -154,7 +154,7 @@ sources:
     # highlight-end
 
   - name: data-tools
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/acme/data-tools.git
       branch: main
@@ -336,7 +336,7 @@ This example shows a multi-team setup with full RBAC and claims-based scoping:
 ```yaml title="config-multi-tenant.yaml"
 sources:
   - name: platform-tools
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/acme/platform-tools.git
       branch: main
@@ -348,7 +348,7 @@ sources:
       team: 'platform'
 
   - name: data-tools
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/acme/data-tools.git
       branch: main

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -111,7 +111,7 @@ authz:
 ```
 
 Claim values can be strings or arrays. When a JWT claim is an array (for
-example, `roles: ["admin", "writer"]`), the server checks whether any element
+example, `role: ["admin", "writer"]`), the server checks whether any element
 matches the required value. A rule with `role: "admin"` would match this JWT
 because `"admin"` is one of the array elements.
 
@@ -274,10 +274,34 @@ registries are also scoped by claims:
 - **Get source/registry by name**: Returns `404 Not Found` (not `403`) when the
   caller's claims don't match — this prevents information disclosure about
   resources the caller cannot access.
+- **List source/registry entries**: `GET /v1/sources/{name}/entries` and
+  `GET /v1/registries/{name}/entries` return the raw entries (servers and skills
+  with versions and claims) in a source or registry. These endpoints follow the
+  same claim scoping — the parent source or registry must be accessible to the
+  caller.
 - **Create source/registry**: The request claims must be a subset of the
   caller's JWT claims.
 - **Update/delete source/registry**: The caller's JWT claims must satisfy the
   existing resource's claims.
+
+## Auth-only mode
+
+When OAuth authentication is enabled but the `auth.authz` block is omitted from
+your configuration, the server runs in **auth-only mode**. In this mode:
+
+- Callers must still authenticate with a valid JWT token
+- All claims-based filtering is disabled — every authenticated caller sees all
+  entries regardless of source or registry claims
+- Role checks are not enforced (no roles are resolved)
+- The server logs a warning at startup:
+  `Authorization not configured, per-entry claims filtering disabled (auth-only mode)`
+
+Auth-only mode is useful when you need identity verification without
+multi-tenant visibility controls — for example, a single-team deployment where
+all authenticated users should have the same access.
+
+To enable full authorization, add the `auth.authz` block with
+[role definitions](#configure-roles).
 
 ## Anonymous mode
 

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -1,0 +1,408 @@
+---
+title: Authorization
+description:
+  How to configure role-based access control and claims-based authorization for
+  the Registry Server
+---
+
+The Registry server provides a claims-based authorization model that controls
+who can manage sources, registries, and entries. Authorization builds on top of
+[authentication](./authentication.mdx) — you need OAuth authentication enabled
+before configuring authorization.
+
+Claims operate at three layers, checked in order when a client reads entries:
+
+1. **Registry claims** (access gate) — can the caller access this registry at
+   all? If the registry has claims and the caller's JWT doesn't satisfy them,
+   the server returns `403 Forbidden` before any data is returned.
+2. **Entry claims** (visibility filter) — which entries can the caller see? Each
+   entry can carry claims inherited from its source (for synced sources) or set
+   explicitly (via publish payload or Kubernetes annotation). Only entries whose
+   claims the caller's JWT satisfies are included in the response.
+3. **Role checks** (admin operations) — can the caller perform this write
+   operation? Publishing, deleting, and managing sources/registries require
+   specific [roles](#configure-roles).
+
+## How authorization works
+
+Authorization in the Registry server operates at two levels:
+
+1. **Role-based access control (RBAC)**: Determines which admin operations a
+   caller can perform (manage sources, manage registries, publish/delete
+   entries).
+2. **Claims-based scoping**: Limits visibility and access to specific sources,
+   registries, and entries based on key-value claims attached to both resources
+   and callers.
+
+When a caller makes an API request, the server:
+
+1. Extracts the caller's claims from their JWT token
+2. Resolves the caller's roles based on those claims and the `authz`
+   configuration
+3. Checks whether the caller's role permits the operation
+4. Checks whether the caller's claims satisfy the resource's claims
+
+```mermaid
+flowchart LR
+  JWT["JWT token"] --> Claims["Extract claims"]
+  Claims --> Roles["Resolve roles"]
+  Roles --> RoleCheck{"Role\npermitted?"}
+  RoleCheck -->|Yes| ClaimCheck{"Claims\nsatisfied?"}
+  RoleCheck -->|No| Deny403["403 Forbidden"]
+  ClaimCheck -->|Yes| Allow["Allow"]
+  ClaimCheck -->|No| Deny403
+```
+
+## Configure roles
+
+Define roles in the `auth.authz.roles` section of your configuration file. Each
+role maps to a list of claim rules — if a caller's JWT claims match any rule in
+the list, they are granted that role.
+
+```yaml title="config-authz.yaml"
+auth:
+  mode: oauth
+  oauth:
+    resourceUrl: https://registry.example.com
+    providers:
+      - name: keycloak
+        issuerUrl: https://keycloak.example.com/realms/mcp
+        audience: registry-api
+  # highlight-start
+  authz:
+    roles:
+      superAdmin:
+        - role: 'super-admin'
+      manageSources:
+        - org: 'acme'
+          role: 'admin'
+      manageRegistries:
+        - org: 'acme'
+          role: 'admin'
+      manageEntries:
+        - role: 'writer'
+  # highlight-end
+```
+
+### Available roles
+
+| Role               | Grants access to                                              |
+| ------------------ | ------------------------------------------------------------- |
+| `superAdmin`       | All operations; bypasses all claim checks                     |
+| `manageSources`    | Create, update, delete, and list sources via the admin API    |
+| `manageRegistries` | Create, update, delete, and list registries via the admin API |
+| `manageEntries`    | Publish and delete MCP server versions and skills             |
+
+### Role rule matching
+
+Each role is defined as a list of claim maps. A caller is granted the role if
+their JWT claims match **any** map in the list (OR logic). Within a single map,
+**all** key-value pairs must match (AND logic).
+
+```yaml title="Example: grant manageSources to org admins OR platform leads"
+authz:
+  roles:
+    manageSources:
+      # Rule 1: any admin in the acme org
+      - org: 'acme'
+        role: 'admin'
+      # Rule 2: anyone with the platform-lead role
+      - role: 'platform-lead'
+```
+
+Claim values can be strings or arrays. When a JWT claim is an array (for
+example, `roles: ["admin", "writer"]`), the server checks whether any element
+matches the required value. A rule with `role: "admin"` would match this JWT
+because `"admin"` is one of the array elements.
+
+### Super-admin role
+
+The `superAdmin` role bypasses **all** claim checks across the entire server. A
+super-admin can:
+
+- Access any registry regardless of its claims
+- See all entries regardless of source or entry claims
+- Manage any source or registry, even those with claims outside their JWT
+- Publish and delete entries without claim validation
+
+Use this role sparingly and only for platform operators who need unrestricted
+access.
+
+## Configure claims on sources and registries
+
+Claims are key-value pairs attached to sources and registries in your
+configuration file. They act as access boundaries — only callers whose JWT
+claims satisfy the resource's claims can access it.
+
+### Source claims
+
+For synced sources (Git, API, File), claims on a source are **inherited by all
+entries** during sync. Every MCP server or skill ingested from that source
+carries the source's claims.
+
+For Kubernetes and managed sources, source claims control who can manage the
+source via the admin API but are **not** inherited by entries. Kubernetes
+entries get claims from the
+[`authz-claims` annotation](./configuration.mdx#per-entry-claims-via-annotation)
+on each CRD. Managed source entries get claims from the publish request payload.
+
+```yaml title="config-source-claims.yaml"
+sources:
+  - name: platform-tools
+    format: toolhive
+    git:
+      repository: https://github.com/acme/platform-tools.git
+      branch: main
+      path: registry.json
+    syncPolicy:
+      interval: '30m'
+    # highlight-start
+    claims:
+      org: 'acme'
+      team: 'platform'
+    # highlight-end
+
+  - name: data-tools
+    format: toolhive
+    git:
+      repository: https://github.com/acme/data-tools.git
+      branch: main
+      path: registry.json
+    syncPolicy:
+      interval: '30m'
+    claims:
+      org: 'acme'
+      team: 'data'
+```
+
+With this configuration:
+
+- Entries from `platform-tools` are visible only to callers with `org: "acme"`
+  **and** `team: "platform"` in their JWT
+- Entries from `data-tools` are visible only to callers with `org: "acme"`
+  **and** `team: "data"` in their JWT
+- A super-admin sees all entries regardless of claims
+
+### Registry claims
+
+Claims on a registry act as an **access gate** for the consumer API. Before
+returning any data from a registry's endpoints, the server checks that the
+caller's JWT claims satisfy the registry's claims.
+
+```yaml title="config-registry-claims.yaml"
+registries:
+  - name: platform
+    sources: ['platform-tools']
+    # highlight-start
+    claims:
+      org: 'acme'
+      team: 'platform'
+    # highlight-end
+
+  - name: public
+    sources: ['community-tools']
+    # No claims — accessible to all authenticated users
+```
+
+A caller who requests `GET /platform/v0.1/servers` must have JWT claims that
+include `org: "acme"` and `team: "platform"`. Otherwise, the server returns
+`403 Forbidden`.
+
+### Claim containment
+
+The server uses **containment** (superset check) for claim validation: the
+caller's claims must be a superset of the resource's claims. For example:
+
+| Resource claims                   | Caller JWT claims                 | Result  |
+| --------------------------------- | --------------------------------- | ------- |
+| `{org: "acme"}`                   | `{org: "acme", team: "platform"}` | Allowed |
+| `{org: "acme", team: "platform"}` | `{org: "acme"}`                   | Denied  |
+| `{}` (no claims)                  | `{org: "acme"}`                   | Allowed |
+| `{org: "acme"}`                   | `{org: "contoso"}`                | Denied  |
+
+Registries and sources with no claims are accessible to all authenticated
+callers. However, **entries** with no claims behave differently: they are only
+visible in anonymous mode. When authorization is enabled, an authenticated
+caller's per-entry filter requires both sides to have claims for a match — so
+entries without claims are invisible. To make entries visible to authenticated
+callers, attach claims to the source (for synced sources) or to individual
+entries (via the publish payload or the
+[`authz-claims` annotation](./configuration.mdx#per-entry-claims-via-annotation)
+for Kubernetes sources).
+
+## Claims on published entries
+
+When you publish an MCP server version or skill to a managed source, you can
+attach claims to the entry. The server enforces two rules:
+
+1. **Publish claims must be a subset of the publisher's JWT claims.** Every
+   claim key in the publish request must exist in the publisher's JWT with a
+   matching value. For example, if your JWT has
+   `{org: "acme", team: "platform"}`, you can publish entries with
+   `{org: "acme"}`, `{org: "acme", team: "platform"}`, or no claims at all — but
+   not with `{org: "contoso"}` (a value your JWT doesn't have).
+
+2. **Subsequent versions must have the same claims as the first.** Once you
+   publish the first version of an entry with specific claims, all future
+   versions must carry the exact same claims. This prevents accidentally
+   narrowing or broadening visibility across versions.
+
+```bash title="Publish a server with claims"
+curl -X POST \
+  https://registry.example.com/default/v0.1/publish \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-server",
+    "version": "1.0.0",
+    "url": "https://mcp.example.com/my-server",
+    "description": "Team-scoped MCP server",
+    "claims": {
+      "org": "acme",
+      "team": "platform"
+    }
+  }'
+```
+
+## Admin API claim scoping
+
+When authorization is enabled, the admin API endpoints for managing sources and
+registries are also scoped by claims:
+
+- **List sources/registries**: Only returns resources whose claims the caller's
+  JWT satisfies.
+- **Get source/registry by name**: Returns `404 Not Found` (not `403`) when the
+  caller's claims don't match — this prevents information disclosure about
+  resources the caller cannot access.
+- **Create source/registry**: The request claims must be a subset of the
+  caller's JWT claims.
+- **Update/delete source/registry**: The caller's JWT claims must satisfy the
+  existing resource's claims.
+
+## Anonymous mode
+
+When authentication is set to `anonymous`, all authorization checks are
+bypassed. There are no JWT claims to validate, so all sources, registries, and
+entries are accessible without restriction. This is suitable for development and
+testing environments only.
+
+## Check your identity and permissions
+
+Use the `GET /v1/me` endpoint to verify your authenticated identity and resolved
+roles:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  https://registry.example.com/v1/me
+```
+
+```json title="Example response"
+{
+  "subject": "user@example.com",
+  "roles": ["manageSources", "manageEntries"]
+}
+```
+
+This is useful for debugging authorization issues — you can confirm which roles
+your JWT grants and whether the expected claims are present. The endpoint
+returns `401 Unauthorized` in anonymous mode since there is no identity to
+report.
+
+## Complete example
+
+This example shows a multi-team setup with full RBAC and claims-based scoping:
+
+```yaml title="config-multi-tenant.yaml"
+sources:
+  - name: platform-tools
+    format: toolhive
+    git:
+      repository: https://github.com/acme/platform-tools.git
+      branch: main
+      path: registry.json
+    syncPolicy:
+      interval: '30m'
+    claims:
+      org: 'acme'
+      team: 'platform'
+
+  - name: data-tools
+    format: toolhive
+    git:
+      repository: https://github.com/acme/data-tools.git
+      branch: main
+      path: registry.json
+    syncPolicy:
+      interval: '30m'
+    claims:
+      org: 'acme'
+      team: 'data'
+
+  - name: shared
+    managed: {}
+
+registries:
+  - name: platform
+    sources: ['platform-tools', 'shared']
+    claims:
+      org: 'acme'
+      team: 'platform'
+
+  - name: data
+    sources: ['data-tools', 'shared']
+    claims:
+      org: 'acme'
+      team: 'data'
+
+auth:
+  mode: oauth
+  oauth:
+    resourceUrl: https://registry.example.com
+    providers:
+      - name: keycloak
+        issuerUrl: https://keycloak.example.com/realms/mcp
+        audience: registry-api
+  authz:
+    roles:
+      superAdmin:
+        - role: 'super-admin'
+      manageSources:
+        - org: 'acme'
+          role: 'admin'
+      manageRegistries:
+        - org: 'acme'
+          role: 'admin'
+      manageEntries:
+        - role: 'writer'
+```
+
+With this configuration:
+
+- **Platform team members** (JWT with `org: "acme"`, `team: "platform"`) can
+  access the `platform` registry and see entries from `platform-tools` and
+  `shared`.
+- **Data team members** (JWT with `org: "acme"`, `team: "data"`) can access the
+  `data` registry and see entries from `data-tools` and `shared`.
+- **Writers** (JWT with `role: "writer"`) can publish to the `shared` managed
+  source.
+- **Admins** (JWT with `org: "acme"`, `role: "admin"`) can manage sources and
+  registries within the `acme` org.
+- **Super-admins** (JWT with `role: "super-admin"`) can access and manage
+  everything.
+
+Entries published to the `shared` source without claims are visible through any
+registry that includes it, subject only to the registry-level claims gate. To
+restrict visibility further, attach claims when
+[publishing entries](#claims-on-published-entries).
+
+## Next steps
+
+- [Configure authentication](./authentication.mdx) to set up OAuth providers
+- [Configure sources and registries](./configuration.mdx) to set up your data
+  sources
+- [Manage skills](./skills.mdx) to publish and discover reusable skills
+
+## Related information
+
+- [Registry server introduction](./intro.mdx) - architecture and features
+  overview

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -429,16 +429,12 @@ is fixed.
 See [Authorization](./authorization.mdx) for how claims control entry
 visibility.
 
-:::info[How does it work?]
+#### Workload annotations
 
-Kubernetes workload discovery works by looking for annotations in a specific set
-of workloads. The types being watched are
+Kubernetes workload discovery watches for annotations on
 [`MCPServer`](../guides-k8s/run-mcp-k8s.mdx),
 [`MCPRemoteProxy`](../guides-k8s/remote-mcp-proxy.mdx), and
-[`VirtualMCPServer`](../guides-vmcp/configuration.mdx).
-
-The Registry server will receive events when a resource among those listed above
-is annotated with the following annotations:
+[`VirtualMCPServer`](../guides-vmcp/configuration.mdx) resources.
 
 ```yaml {7-16}
 apiVersion: toolhive.stacklok.dev/v1alpha1
@@ -472,7 +468,7 @@ spec:
 | `toolhive.stacklok.dev/tool-definitions`     | No       | JSON array of tool definitions with MCP tool metadata (name, description, schema) |
 | `toolhive.stacklok.dev/authz-claims`         | No       | JSON object of authorization claims for per-entry visibility control              |
 
-**Tool definitions format:**
+#### Tool definitions format
 
 The `tool-definitions` annotation accepts a JSON array containing tool metadata
 that follows the MCP specification. Each tool definition can include:
@@ -511,8 +507,6 @@ structure.
 This feature requires the Registry server to be granted access to those
 resources via a Service Account. See the
 [deployment section](./deploy-manual.mdx#workload-discovery) for details.
-
-:::
 
 **Use cases:**
 

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -1,8 +1,8 @@
 ---
 title: Configuration
 description:
-  How to configure the ToolHive Registry Server with sources, registries, and
-  sync policies
+  Configure the ToolHive Registry Server with sources, registries, and sync
+  policies
 ---
 
 All configuration is done via YAML files. The server requires a `--config` flag

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -89,11 +89,12 @@ Kubernetes lease name suffixes for leader election.
 
 ## Command-line flags
 
-| Flag          | Description                                 | Required | Default |
-| ------------- | ------------------------------------------- | -------- | ------- |
-| `--config`    | Path to YAML configuration file             | Yes      | -       |
-| `--address`   | Server listen address                       | No       | `:8080` |
-| `--auth-mode` | Override auth mode (`anonymous` or `oauth`) | No       | -       |
+| Flag                 | Description                                                        | Required | Default |
+| -------------------- | ------------------------------------------------------------------ | -------- | ------- |
+| `--config`           | Path to YAML configuration file                                    | Yes      | -       |
+| `--address`          | Server listen address for the main API                             | No       | `:8080` |
+| `--internal-address` | Listen address for internal endpoints (health, readiness, version) | No       | `:8081` |
+| `--auth-mode`        | Override auth mode (`anonymous` or `oauth`)                        | No       | -       |
 
 ## Registry data formats
 
@@ -551,10 +552,12 @@ configuration. Managed and Kubernetes sources do not require sync policies.
 
 :::
 
-## Server filtering
+## Entry filtering
 
-Optionally filter which servers are exposed through the API on a per-source
-basis. Only applicable to synced sources (Git, API, File).
+Optionally filter which entries are exposed through the API on a per-source
+basis. Only applicable to synced sources (Git, API, File). Filters apply to both
+MCP servers and skills — skills are matched using `namespace/name` against the
+name patterns.
 
 ```yaml
 sources:

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -417,8 +417,9 @@ spec:
 
 Entry claims come exclusively from the annotation — source-level claims are
 **not** inherited. Entries without the annotation have no claims, which means
-they are visible in anonymous mode but invisible when authorization is
-configured.
+they are visible in anonymous mode and
+[auth-only mode](./authorization.mdx#auth-only-mode) but invisible when full
+authorization is configured.
 
 If the annotation contains invalid JSON or unsupported claim value types
 (anything other than strings or arrays of strings), the entry is **skipped

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -1,7 +1,8 @@
 ---
 title: Configuration
 description:
-  How to configure the ToolHive Registry Server with registry and sync policies
+  How to configure the ToolHive Registry Server with sources, registries, and
+  sync policies
 ---
 
 All configuration is done via YAML files. The server requires a `--config` flag
@@ -9,29 +10,22 @@ pointing to a YAML configuration file.
 
 ## Configuration file structure
 
-The configuration file uses a v2 format that separates **data sources** (where
-registry data comes from) from **registry views** (logical registries that
-aggregate one or more sources).
+The configuration file has two main sections: **sources** (where data comes
+from) and **registries** (named API surfaces that aggregate one or more
+sources).
 
 ```yaml title="config.yaml"
-# Data sources (required, at least one)
+# Sources define where registry data comes from
 sources:
   - name: toolhive
-    # Data format: upstream or toolhive (see below)
-    format: upstream
-
-    # Git repository configuration
+    format: toolhive
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-upstream.json
-
-    # Per-source automatic sync policy (required for synced sources)
+      path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
-      # Sync interval (e.g., "30m", "1h", "24h")
       interval: '30m'
-
-    # Optional: Per-source server filtering
+    # Optional: filter which entries are synced
     filter:
       names:
         include: ['official/*']
@@ -39,12 +33,17 @@ sources:
       tags:
         include: ['production']
         exclude: ['experimental']
+    # Optional: claims inherited by entries during sync (for authorization)
+    claims:
+      org: 'acme'
 
-# Registry views (required, at least one)
-# Each view references sources by name
+# Registries aggregate sources into named API endpoints
 registries:
   - name: default
     sources: ['toolhive']
+    # Optional: claims for access gating (caller JWT must satisfy these)
+    claims:
+      org: 'acme'
 
 # Authentication configuration (required)
 # See authentication.mdx for detailed configuration options
@@ -68,6 +67,26 @@ database:
   #     region: us-east-1
 ```
 
+### Sources vs. registries
+
+- A **source** defines where data comes from and how to sync it. Each source has
+  a type (Git, API, file, managed, or Kubernetes), sync policy, optional
+  filters, and optional claims.
+- A **registry** is a named API surface that aggregates one or more sources.
+  Clients access entries through a registry name in the URL (for example,
+  `/{registryName}/v0.1/servers`). A registry can also have claims that act as
+  an access gate — only callers whose JWT claims satisfy the registry's claims
+  can access its entries.
+
+You can create multiple registries from the same sources to serve different
+audiences. For example, a `public` registry with no claims and a `team-internal`
+registry with team-scoped claims — both backed by the same source data.
+
+Source names must be valid DNS subdomain labels: lowercase alphanumeric
+characters and hyphens, maximum 63 characters (for example, `toolhive`,
+`platform-tools`, `k8s-prod`). This is required because source names are used as
+Kubernetes lease name suffixes for leader election.
+
 ## Command-line flags
 
 | Flag          | Description                                 | Required | Default |
@@ -78,7 +97,8 @@ database:
 
 ## Registry data formats
 
-The `format` field specifies the JSON schema format for the registry data:
+The `format` field on a source specifies the JSON schema format for the registry
+data:
 
 - **`upstream`**: The official
   [upstream MCP registry format](../reference/registry-schema-upstream.mdx),
@@ -87,11 +107,10 @@ The `format` field specifies the JSON schema format for the registry data:
   [ToolHive-native format](../reference/registry-schema-toolhive.mdx), used by
   the built-in ToolHive registry.
 
-## Sources
+## Registry sources
 
-The server supports multiple source types, each with its own configuration
-options. You can configure multiple sources in a single server instance and
-aggregate them into registry views.
+The server supports five source types, each with its own configuration options.
+You can configure multiple sources in a single server instance.
 
 ### Git repository source
 
@@ -116,6 +135,7 @@ sources:
       path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: '30m'
+
 registries:
   - name: default
     sources: ['toolhive']
@@ -124,7 +144,8 @@ registries:
 **Configuration options:**
 
 - `repository` (required): Git repository URL
-- `branch` (optional): Branch name to use (defaults to `main`)
+- `branch` (optional): Branch name to use (defaults to the repository's default
+  branch)
 - `tag` (optional): Tag name to pin to a specific version
 - `commit` (optional): Commit SHA to pin to a specific commit
 - `path` (optional): Path to the registry file within the repository (defaults
@@ -134,8 +155,8 @@ registries:
 :::tip
 
 You can use `branch`, `tag`, or `commit` to pin to a specific version. If
-multiple are specified, `commit` takes precedence over `tag`, which takes
-precedence over `branch`.
+multiple are specified, `commit` takes precedence over `branch`, which takes
+precedence over `tag`.
 
 :::
 
@@ -159,6 +180,7 @@ sources:
       # highlight-end
     syncPolicy:
       interval: '30m'
+
 registries:
   - name: default
     sources: ['private-registry']
@@ -235,6 +257,7 @@ sources:
       endpoint: https://registry.modelcontextprotocol.io
     syncPolicy:
       interval: '1h'
+
 registries:
   - name: default
     sources: ['mcp-upstream']
@@ -244,7 +267,8 @@ registries:
 
 - `endpoint` (required): Base URL of the upstream MCP Registry API (without
   path)
-- `format` (required): Must be `upstream` for API sources
+- `format` (optional): Must be `upstream` if specified (API sources only support
+  the upstream format)
 
 :::note
 
@@ -265,6 +289,7 @@ sources:
       path: /data/registry.json
     syncPolicy:
       interval: '15m'
+
 registries:
   - name: default
     sources: ['local']
@@ -272,7 +297,7 @@ registries:
 
 Alternatively, the source can be a custom URL.
 
-```yaml title="config-url.yaml"
+```yaml title="config-file-url.yaml"
 sources:
   - name: remote
     format: upstream
@@ -281,32 +306,33 @@ sources:
       timeout: 5s
     syncPolicy:
       interval: '15m'
+
 registries:
   - name: default
     sources: ['remote']
 ```
 
-Within the `file` block, `path` and `url` are mutually exclusive.
+The fields `path` and `url` are mutually exclusive.
 
 **Configuration options:**
 
-- `file.path` (required): Path to the registry file on the filesystem. Mutually
-  exclusive with `file.url`
-- `file.url` (required): HTTP/HTTPS URL to fetch the registry file from.
-  Mutually exclusive with `file.path`
-- `file.timeout` (optional): The timeout for HTTP requests when using `url`,
-  defaults to 30s
+- `path`: Path to the registry file on the filesystem. Required when `url` is
+  not specified
+- `url`: HTTP/HTTPS URL to fetch the registry file from. Required when `path` is
+  not specified
+- `timeout` (optional): The timeout for HTTP requests when using URL, defaults
+  to 30s, ignored when `path` is specified
 
-### Managed registry
+### Managed source
 
-API-managed registry for directly publishing and deleting MCP servers via the
-API. Does not sync from external sources.
+API-managed source for directly publishing and deleting MCP servers and skills
+via the API. Does not sync from external sources.
 
 ```yaml title="config-managed.yaml"
 sources:
   - name: internal
-    format: upstream
     managed: {}
+
 registries:
   - name: default
     sources: ['internal']
@@ -314,8 +340,8 @@ registries:
 
 **Configuration options:**
 
-- `managed` (required): Empty object to indicate managed registry type
-- No sync policy required (managed registries are updated via API, not synced)
+- `managed` (required): Empty object to indicate managed source type
+- No sync policy required (managed sources are updated via API, not synced)
 
 **Supported operations:**
 
@@ -328,41 +354,78 @@ registries:
 See the [Registry API reference](../reference/registry-api.mdx) for complete
 endpoint documentation and request/response examples.
 
-### Kubernetes registry
+### Kubernetes source
 
 Discovers MCP servers from running Kubernetes deployments. Automatically creates
 registry entries for deployed MCP servers in your cluster.
 
-:::note[Operator deployments]
+:::note[Operator-managed source]
 
-When using the ToolHive operator with the `configYAML` path, you must explicitly
-declare Kubernetes discovery sources in your configuration. Only one Kubernetes
-source is supported per Registry Server instance.
+When using the ToolHive operator, a Kubernetes source named `default` is
+automatically created and managed. The configuration examples below are for
+reference when running the Registry Server standalone (without the operator).
 
 :::
 
-By default, the Registry server discovers resources in all namespaces
-(cluster-wide). You can restrict discovery to specific namespaces using the
-`THV_REGISTRY_WATCH_NAMESPACE` environment variable. See
-[Workload discovery](./deploy-manual.mdx#workload-discovery) for configuration
-details and RBAC requirements.
+You can configure multiple Kubernetes sources, each watching different
+namespaces. By default, a Kubernetes source discovers resources in all
+namespaces (cluster-wide). You can restrict discovery to specific namespaces
+using the `namespaces` field or the `THV_REGISTRY_WATCH_NAMESPACE` environment
+variable. See [Workload discovery](./deploy-manual.mdx#workload-discovery) for
+RBAC requirements.
 
 ```yaml title="config-kubernetes.yaml"
 sources:
-  - name: k8s
-    format: upstream
+  - name: default
+    format: toolhive
     kubernetes: {}
+
 registries:
   - name: default
-    sources: ['k8s']
+    sources: ['default']
 ```
 
 **Configuration options:**
 
-- `kubernetes` (required): Empty object to indicate Kubernetes registry type
-- No sync policy required (Kubernetes registries query live deployments
-  on-demand)
-- Only one Kubernetes registry is supported per Registry Server instance
+- `kubernetes` (required): Empty object or namespace configuration (see below)
+- `kubernetes.namespaces` (optional): List of Kubernetes namespaces to watch. If
+  empty, falls back to the `THV_REGISTRY_WATCH_NAMESPACE` environment variable,
+  or all namespaces if neither is set
+- No sync policy required (Kubernetes sources query live deployments on-demand)
+
+#### Per-entry claims via annotation
+
+You can set authorization claims on individual Kubernetes workloads using the
+`toolhive.stacklok.dev/authz-claims` JSON annotation. This controls which
+authenticated callers can see each entry.
+
+```yaml title="mcp-server-with-claims.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: deploy-helper
+  annotations:
+    toolhive.stacklok.dev/registry-export: 'true'
+    toolhive.stacklok.dev/registry-url: 'https://mcp.example.com/deploy-helper'
+    toolhive.stacklok.dev/registry-description: 'Deployment assistant'
+    # highlight-next-line
+    toolhive.stacklok.dev/authz-claims: '{"org": "acme", "team": "platform"}'
+spec:
+  # ...
+```
+
+Entry claims come exclusively from the annotation — source-level claims are
+**not** inherited. Entries without the annotation have no claims, which means
+they are visible in anonymous mode but invisible when authorization is
+configured.
+
+If the annotation contains invalid JSON or unsupported claim value types
+(anything other than strings or arrays of strings), the entry is **skipped
+entirely** and a warning is logged. The entry will not sync until the annotation
+is fixed.
+
+See [Authorization](./authorization.mdx) for how claims control entry
+visibility.
 
 :::info[How does it work?]
 
@@ -405,6 +468,7 @@ spec:
 | `toolhive.stacklok.dev/registry-title`       | No       | Human-friendly display name for the registry entry (overrides the generated name) |
 | `toolhive.stacklok.dev/tools`                | No       | JSON array of tool name strings (e.g., `["get_weather","get_forecast"]`)          |
 | `toolhive.stacklok.dev/tool-definitions`     | No       | JSON array of tool definitions with MCP tool metadata (name, description, schema) |
+| `toolhive.stacklok.dev/authz-claims`         | No       | JSON object of authorization claims for per-entry visibility control              |
 
 **Tool definitions format:**
 
@@ -443,8 +507,8 @@ The registry URL from the `registry-url` annotation becomes a key in the JSON
 structure.
 
 This feature requires the Registry server to be granted access to those
-resources via a Service Account, check the details in the
-[deployment section](./deploy-manual.mdx#workload-discovery).
+resources via a Service Account. See the
+[deployment section](./deploy-manual.mdx#workload-discovery) for details.
 
 :::
 
@@ -463,6 +527,7 @@ Kubernetes sources.
 ```yaml
 sources:
   - name: toolhive
+    format: toolhive
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
@@ -474,6 +539,10 @@ sources:
 
 The `interval` field specifies how often the server should fetch updates from
 the source. Use Go duration format (e.g., `"30m"`, `"1h"`, `"24h"`).
+
+The server also triggers a sync when filter configuration changes, even if the
+upstream data has not changed. This ensures that updated filter rules take
+effect without waiting for the next scheduled sync.
 
 :::note
 
@@ -490,6 +559,7 @@ basis. Only applicable to synced sources (Git, API, File).
 ```yaml
 sources:
   - name: toolhive
+    format: toolhive
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
@@ -518,6 +588,50 @@ Filters are per-source and specified within each source configuration.
 
 :::
 
+## Multiple sources and registries
+
+You can configure multiple sources and combine them into one or more registries.
+This enables scenarios like aggregating data from different upstream registries,
+or serving different audiences from the same data with different access
+controls.
+
+```yaml title="config-multi-source.yaml"
+sources:
+  - name: toolhive-catalog
+    format: toolhive
+    git:
+      repository: https://github.com/stacklok/toolhive-catalog.git
+      branch: main
+      path: pkg/catalog/toolhive/data/registry-legacy.json
+    syncPolicy:
+      interval: '30m'
+
+  - name: upstream-mcp
+    format: upstream
+    api:
+      endpoint: https://registry.modelcontextprotocol.io
+    syncPolicy:
+      interval: '1h'
+
+  - name: internal
+    managed: {}
+
+registries:
+  # Public registry with all sources
+  - name: public
+    sources: ['toolhive-catalog', 'upstream-mcp', 'internal']
+
+  # Team-scoped registry with access control
+  - name: platform-team
+    sources: ['toolhive-catalog', 'internal']
+    claims:
+      org: 'acme'
+      team: 'platform'
+```
+
+When a registry aggregates multiple sources, entries from earlier sources in the
+list take precedence over entries with the same name from later sources.
+
 ## Authentication configuration
 
 The server supports multiple authentication modes to fit different deployment
@@ -532,6 +646,15 @@ Available modes:
 
 See the [Authentication configuration](./authentication.mdx) guide for detailed
 information on configuring each mode.
+
+## Authorization configuration
+
+When authentication is enabled, you can configure role-based access control
+(RBAC) and claims-based authorization to control who can manage sources,
+registries, and entries.
+
+See the [Authorization](./authorization.mdx) guide for detailed information on
+configuring roles and claims.
 
 ## Database configuration
 
@@ -549,4 +672,6 @@ distributed tracing and metrics collection. See the
 
 - [Configure authentication](./authentication.mdx) to secure access to your
   registry
+- [Set up authorization](./authorization.mdx) to control access with roles and
+  claims
 - [Set up the database](./database.mdx) for production storage

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -18,11 +18,11 @@ sources).
 # Sources define where registry data comes from
 sources:
   - name: toolhive
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-legacy.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       interval: '30m'
     # Optional: filter which entries are synced
@@ -129,11 +129,11 @@ on every container restart, adding startup latency and increasing network usage.
 ```yaml title="config-git.yaml"
 sources:
   - name: toolhive
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-legacy.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       interval: '30m'
 
@@ -169,7 +169,7 @@ credentials:
 ```yaml title="config-git-private.yaml"
 sources:
   - name: private-registry
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/my-org/private-registry.git
       branch: main
@@ -378,7 +378,7 @@ RBAC requirements.
 ```yaml title="config-kubernetes.yaml"
 sources:
   - name: default
-    format: toolhive
+    format: upstream
     kubernetes: {}
 
 registries:
@@ -523,11 +523,11 @@ Kubernetes sources.
 ```yaml
 sources:
   - name: toolhive
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-legacy.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       # Sync interval (e.g., "30m", "1h", "24h")
       interval: '30m'
@@ -557,11 +557,11 @@ name patterns.
 ```yaml
 sources:
   - name: toolhive
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-legacy.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       interval: '30m'
     filter:
@@ -596,11 +596,11 @@ controls.
 ```yaml title="config-multi-source.yaml"
 sources:
   - name: toolhive-catalog
-    format: toolhive
+    format: upstream
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
       branch: main
-      path: pkg/catalog/toolhive/data/registry-legacy.json
+      path: pkg/catalog/toolhive/data/registry-upstream.json
     syncPolicy:
       interval: '30m'
 

--- a/docs/toolhive/guides-registry/deploy-manual.mdx
+++ b/docs/toolhive/guides-registry/deploy-manual.mdx
@@ -2,6 +2,7 @@
 title: Deploy manually
 description:
   How to deploy the ToolHive Registry Server in Kubernetes using raw manifests
+  and RBAC configuration
 ---
 
 :::info
@@ -111,9 +112,8 @@ metadata:
   namespace: toolhive-system
 data:
   config.yaml: |
-    registryName: my-registry
-    registries:
-    - name: git-registry
+    sources:
+    - name: toolhive
       format: toolhive
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
@@ -121,6 +121,9 @@ data:
         path: pkg/catalog/toolhive/data/registry-legacy.json
       syncPolicy:
         interval: "15m"
+    registries:
+    - name: default
+      sources: ["toolhive"]
     auth:
       mode: oauth
       oauth:
@@ -363,8 +366,10 @@ this automatically.
 
 ## Next steps
 
-- [Configure registry sources](./configuration.mdx) to set up your data sources
-  and sync policies
+- [Configure sources and registries](./configuration.mdx) to set up your data
+  sources and sync policies
 - [Set up authentication](./authentication.mdx) to secure access to your
   registry
+- [Set up authorization](./authorization.mdx) to control access with roles and
+  claims
 - [Configure telemetry](./telemetry-metrics.mdx) to monitor your deployment

--- a/docs/toolhive/guides-registry/deploy-manual.mdx
+++ b/docs/toolhive/guides-registry/deploy-manual.mdx
@@ -116,11 +116,11 @@ data:
   config.yaml: |
     sources:
     - name: toolhive
-      format: toolhive
+      format: upstream
       git:
         repository: https://github.com/stacklok/toolhive-catalog.git
         branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
+        path: pkg/catalog/toolhive/data/registry-upstream.json
       syncPolicy:
         interval: "15m"
     registries:

--- a/docs/toolhive/guides-registry/deploy-manual.mdx
+++ b/docs/toolhive/guides-registry/deploy-manual.mdx
@@ -73,6 +73,8 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+            - containerPort: 8081
+              name: internal-http
           volumeMounts:
             - name: thv
               mountPath: /thv
@@ -80,13 +82,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readiness
-              port: 8080
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -80,11 +80,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:
@@ -125,7 +125,7 @@ and each registry references sources by name.
 configYAML: |
   sources:
     - name: my-source
-      format: toolhive
+      format: upstream
       git: { ... }
   registries:
     - name: default
@@ -147,11 +147,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:
@@ -315,11 +315,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         filter:
           names:
             include:
@@ -368,11 +368,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:
@@ -450,11 +450,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:
@@ -592,11 +592,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:
@@ -643,11 +643,11 @@ spec:
   configYAML: |
     sources:
       - name: toolhive
-        format: toolhive
+        format: upstream
         git:
           repository: https://github.com/stacklok/toolhive-catalog.git
           branch: main
-          path: pkg/catalog/toolhive/data/registry-legacy.json
+          path: pkg/catalog/toolhive/data/registry-upstream.json
         syncPolicy:
           interval: '30m'
     registries:

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -174,8 +174,8 @@ spec:
 :::tip
 
 You can use `branch`, `tag`, or `commit` to pin to a specific version. If
-multiple are specified, `commit` takes precedence over `tag`, which takes
-precedence over `branch`.
+multiple are specified, `commit` takes precedence over `branch`, which takes
+precedence over `tag`.
 
 :::
 

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -119,7 +119,7 @@ When you apply an `MCPRegistry` resource, here's what happens:
 The registry server's `configYAML` uses a v2 configuration format that separates
 **data sources** (where registry data comes from) from **registries** (named API
 surfaces that aggregate one or more sources). Each source defines a data origin,
-and each registry view references sources by name.
+and each registry references sources by name.
 
 ```yaml
 configYAML: |

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -117,9 +117,9 @@ When you apply an `MCPRegistry` resource, here's what happens:
 ## Configure registry sources
 
 The registry server's `configYAML` uses a v2 configuration format that separates
-**data sources** (where registry data comes from) from **registry views**
-(logical registries that aggregate one or more sources). Each source defines a
-data origin, and each registry view references sources by name.
+**data sources** (where registry data comes from) from **registries** (named API
+surfaces that aggregate one or more sources). Each source defines a data origin,
+and each registry view references sources by name.
 
 ```yaml
 configYAML: |
@@ -429,8 +429,8 @@ You can configure authentication in the `auth` section within `configYAML`.
 
 :::info[Secure by default]
 
-Configuring an authentication mode is mandatory, if you're not interested you
-can set it to `anonymous`.
+Configuring an authentication mode is mandatory. If you don't need
+authentication, set it to `anonymous`.
 
 :::
 
@@ -707,11 +707,12 @@ kubectl -n <NAMESPACE> wait --for=condition=Ready mcpregistry/<NAME>
 
 ## Next steps
 
-Learn how to configure authentication for the Registry server in the
-[Authentication configuration](./authentication.mdx) guide.
-
-Configure additional registry sources and filtering options in the
-[Configuration](./configuration.mdx) guide.
+- [Configure authentication](./authentication.mdx) to secure access to your
+  registry
+- [Set up authorization](./authorization.mdx) to control access with roles and
+  claims
+- [Configure sources and registries](./configuration.mdx) for standalone
+  configuration reference
 
 ## Related information
 

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -1,6 +1,8 @@
 ---
 title: Deploy the Registry Server
-description: Deployment options for the ToolHive Registry Server in Kubernetes
+description:
+  Deployment options for the ToolHive Registry Server in Kubernetes using the
+  operator, Helm, or raw manifests
 ---
 
 The Registry server can be deployed in Kubernetes using three methods. Choose
@@ -35,8 +37,10 @@ See [Deploy manually](./deploy-manual.mdx) for instructions.
 
 ## Next steps
 
-- [Configure registry sources](./configuration.mdx) to set up your data sources
-  and sync policies
+- [Configure sources and registries](./configuration.mdx) to set up your data
+  sources and sync policies
 - [Set up authentication](./authentication.mdx) to secure access to your
   registry
+- [Set up authorization](./authorization.mdx) to control access with roles and
+  claims
 - [Configure telemetry](./telemetry-metrics.mdx) to monitor your deployment

--- a/docs/toolhive/guides-registry/index.mdx
+++ b/docs/toolhive/guides-registry/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: ToolHive Registry Server
 description:
-  How-to guides for using the ToolHive Registry Server to discover and access
-  MCP servers and skills.
+  Deploy, configure, and secure the ToolHive Registry Server for MCP server and
+  skill discovery
 ---
 
 import DocCardList from '@theme/DocCardList';
@@ -30,8 +30,9 @@ yourself. Looking for the built-in registry instead? See
   architecture, features, and supported registry source types.
 - **Ready to deploy?** See [Deployment overview](./deployment.mdx) to choose
   between Kubernetes Operator and manual deployment methods.
-- **Already running?** Jump to [Configuration](./configuration.mdx) or
-  [Authentication](./authentication.mdx).
+- **Already running?** Jump to [Configuration](./configuration.mdx),
+  [Authentication](./authentication.mdx), or
+  [Authorization](./authorization.mdx).
 
 ## Contents
 

--- a/docs/toolhive/guides-registry/intro.mdx
+++ b/docs/toolhive/guides-registry/intro.mdx
@@ -1,8 +1,8 @@
 ---
 title: Introduction
 description:
-  How to use the ToolHive Registry Server to discover and access MCP servers and
-  skills
+  Architecture, features, and registry source types for the ToolHive Registry
+  Server
 ---
 
 The ToolHive Registry Server is a standards-compliant implementation of the MCP
@@ -21,6 +21,21 @@ MCP servers from the default catalog. That's a different feature: see
 
 :::
 
+## Key concepts
+
+The Registry Server is built around three core concepts:
+
+- A **source** is where data comes from — a Git repository, an upstream API, a
+  local file, a Kubernetes cluster, or a managed API endpoint. Each source syncs
+  or receives MCP servers and skills.
+- An **entry** is an individual MCP server or skill stored in the database.
+  Sources produce entries; each entry belongs to exactly one source.
+- A **registry** is a named API surface that aggregates entries from one or more
+  sources. Clients access entries through a registry name in the URL (for
+  example, `GET /default/v0.1/servers`). You can create multiple registries from
+  the same sources to serve different audiences or apply different access
+  controls.
+
 ## How the Registry Server works
 
 The Registry server aggregates MCP server metadata from various sources and
@@ -29,37 +44,34 @@ exposes it through a standardized API. When you start the server, it:
 1. Loads configuration from a YAML file
 2. Runs database migrations automatically
 3. Immediately fetches registry data from the configured sources
-4. Starts background sync coordinator for automatic updates (for synced
-   registries)
+4. Starts background sync coordinator for automatic updates (for synced sources)
 5. Serves MCP Registry API endpoints on the configured address
 
 ```mermaid
 flowchart LR
-  subgraph Sources["Registry sources"]
+  subgraph Sources["Sources"]
     direction LR
-    Managed["Managed registry"]
-    API["Upstream registry"]
-    Kubernetes["Kubernetes cluster"]
-    Git["Git repository"]
-    File["Local file"]
+    Managed["Managed"]
+    API["Upstream API"]
+    Kubernetes["Kubernetes"]
+    Git["Git"]
+    File["File"]
   end
   subgraph Server["Registry server"]
     direction TB
-    Config["Configuration"]
     Sync["Sync manager"]
-    Storage["Storage layer"]
-    APIHandler["API handler"]
+    Entries[("Entries")]
+    Registries["Registries"]
   end
   subgraph Clients["Clients"]
     direction LR
     ToolHive["ToolHive"]
     MCPClient["MCP clients"]
   end
-  Sources -->|sync| Server
-  Config --> Sync
-  Sync --> Storage
-  Storage --> APIHandler
-  Server -->|REST API| Clients
+  Sources -->|"sync / publish"| Sync
+  Sync --> Entries
+  Entries --> Registries
+  Registries -->|"REST API"| Clients
 ```
 
 ## Features
@@ -67,7 +79,7 @@ flowchart LR
 - **Standards-compliant**: Implements the official MCP Registry API
   specification
 - **Multiple registry sources**: Git repositories, API endpoints, local files,
-  managed registries, and Kubernetes discovery
+  managed sources, and Kubernetes discovery
 - **Automatic synchronization**: Background sync with configurable intervals and
   retry logic for Git, API, and File sources
 - **Container-ready**: Designed for deployment in Kubernetes clusters, but can
@@ -78,46 +90,49 @@ flowchart LR
   status persistence
 - **Kubernetes-aware**: Automatic discovery of MCP servers deployed via ToolHive
   Operator
+- **Multi-tenant authorization**: Claims-based access control with role-based
+  administration, enabling team-scoped registries and entry visibility
 - **Skills registry**: Publish and discover reusable
-  [skills](../concepts/skills.mdx) through the extensions API
+  [skills](../concepts/skills.mdx) via the extensions API and synced sources
 
 ## Registry sources
 
-The server supports five registry source types:
+The server supports five source types:
 
-1. **Managed Registry** - A fully-managed MCP Registry
-   - Ideal for private repositories
+1. **Managed** - A fully-managed MCP source
+   - Ideal for hosting private MCP server catalogs
    - Automatically exposes entries following upstream MCP Registry format
    - Supports adding new MCP servers via `/publish` endpoint
 
-2. **Upstream Registry** - Sync from upstream MCP Registry APIs
+2. **Upstream API** - Sync from upstream MCP Registry APIs
    - Supports federation and aggregation scenarios
-   - Format conversion from upstream to ToolHive format
+   - Syncs both MCP servers and skills from upstream sources
    - Does not support publishing
 
-3. **Kubernetes Cluster** - Automatically creates registry entries for running
-   workloads
+3. **Kubernetes** - Automatically creates registry entries for running workloads
    - Ideal to quickly grant access to running MCP servers to knowledge workers
    - Useful for bigger organizations where MCP server developers differ from
      users
    - Does not support publishing
 
-4. **Git Repository** - Clone and sync from Git repositories
+4. **Git** - Clone and sync from Git repositories
    - Supports branch, tag, or commit pinning
-   - Ideal for version-controlled registries
+   - Syncs both MCP servers and skills (upstream format)
    - Does not support publishing
 
-5. **Local File** - Read from filesystem
+5. **File** - Read from filesystem
    - Ideal for local development and testing
-   - Supports mounted volumes in containers
+   - Syncs both MCP servers and skills (upstream format)
    - Does not support publishing
 
 ## Next steps
 
-- [Configure registry sources](./configuration.mdx) to set up your data sources,
-  sync policies, and server filtering
+- [Configure sources and registries](./configuration.mdx) to set up your data
+  sources, sync policies, and server filtering
 - [Set up authentication](./authentication.mdx) to secure access to your
   registry
+- [Configure authorization](./authorization.mdx) to control access with roles
+  and claims
 - [Manage skills](./skills.mdx) to publish and discover reusable skills
 - [View the API reference](../reference/registry-api.mdx) for endpoint
   documentation

--- a/docs/toolhive/guides-registry/intro.mdx
+++ b/docs/toolhive/guides-registry/intro.mdx
@@ -44,7 +44,8 @@ exposes it through a standardized API. When you start the server, it:
 1. Loads configuration from a YAML file
 2. Runs database migrations automatically
 3. Immediately fetches registry data from the configured sources
-4. Starts background sync coordinator for automatic updates (for synced sources)
+4. Starts a background sync coordinator for automatic updates (for synced
+   sources)
 5. Serves MCP Registry API endpoints on the configured address
 
 ```mermaid
@@ -128,7 +129,7 @@ The server supports five source types:
 ## Next steps
 
 - [Configure sources and registries](./configuration.mdx) to set up your data
-  sources, sync policies, and server filtering
+  sources, sync policies, and entry filtering
 - [Set up authentication](./authentication.mdx) to secure access to your
   registry
 - [Configure authorization](./authorization.mdx) to control access with roles

--- a/docs/toolhive/guides-registry/skills.mdx
+++ b/docs/toolhive/guides-registry/skills.mdx
@@ -2,17 +2,21 @@
 title: Manage skills
 description:
   How to publish, list, retrieve, and delete skills using the ToolHive Registry
-  server extensions API.
+  server extensions API
 ---
 
 The Registry server provides an extensions API for managing
 [skills](../concepts/skills.mdx). This guide covers the full lifecycle:
 publishing, listing, retrieving, and deleting skills.
 
+Skills can come from two paths: **publishing** to a managed source via the API,
+or **syncing** from external sources (Git, API, File) that contain skills in the
+upstream registry format.
+
 ## Prerequisites
 
-- A running Registry server with at least one **managed** registry configured
-  (skills can only be published to managed registries)
+- A running Registry server with at least one **managed** source configured
+  (required for publishing; synced sources provide skills automatically)
 - `curl` or another HTTP client
 - If authentication is enabled, a valid bearer token (see
   [Authentication](./authentication.mdx))
@@ -31,43 +35,66 @@ config has `registries: [{name: my-registry, ...}]`).
 
 ## Publish a skill
 
-To publish a new skill version, send a `POST` request with the skill metadata:
+To publish a new skill version, send a `POST` request to the `/v1/entries`
+endpoint with the skill metadata wrapped in a `skill` object:
 
 ```bash title="Publish a skill"
 curl -X POST \
-  https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills \
+  https://registry.example.com/v1/entries \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <TOKEN>" \
   -d '{
-    "namespace": "io.github.acme",
-    "name": "code-review",
-    "description": "Performs structured code reviews using best practices",
-    "version": "1.0.0",
-    "status": "active",
-    "title": "Code Review Assistant",
-    "license": "Apache-2.0",
-    "packages": [
-      {
-        "registryType": "git",
+    "skill": {
+      "namespace": "io.github.acme",
+      "name": "code-review",
+      "description": "Performs structured code reviews using best practices",
+      "version": "1.0.0",
+      "status": "active",
+      "title": "Code Review Assistant",
+      "license": "Apache-2.0",
+      "packages": [
+        {
+          "registryType": "git",
+          "url": "https://github.com/acme/skills",
+          "ref": "v1.0.0",
+          "subfolder": "code-review"
+        }
+      ],
+      "repository": {
         "url": "https://github.com/acme/skills",
-        "ref": "v1.0.0",
-        "subfolder": "code-review"
+        "type": "git"
       }
-    ],
-    "repository": {
-      "url": "https://github.com/acme/skills",
-      "type": "git"
     }
   }'
 ```
 
-**Required fields:** `namespace`, `name`, `description`, `version`
+**Required fields:** `namespace`, `name`, `version`
 
 A successful response returns `201 Created` with the published skill. If the
 version already exists, the server returns `409 Conflict`.
 
 The `status` field accepts `active`, `deprecated`, or `archived` (case
 insensitive). The server normalizes status values to uppercase internally.
+
+### Claims
+
+When [authorization](./authorization.mdx) is enabled, you can attach claims to
+published skills to control visibility. Include a `claims` object in the request
+body:
+
+```json
+{
+  "namespace": "io.github.acme",
+  "name": "code-review",
+  "version": "1.0.0",
+  "claims": { "org": "acme", "team": "platform" }
+}
+```
+
+The publish claims must be a subset of your JWT claims, and all subsequent
+versions of the same skill must carry the same claims as the first version. See
+[Claims on published entries](./authorization.mdx#claims-on-published-entries)
+for details.
 
 ### Versioning behavior
 
@@ -86,12 +113,11 @@ curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills
 
 ### Query parameters
 
-| Parameter | Type   | Default | Description                                        |
-| --------- | ------ | ------- | -------------------------------------------------- |
-| `search`  | string | -       | Filter by name or description substring            |
-| `status`  | string | -       | Filter by status (comma-separated, e.g., `active`) |
-| `limit`   | int    | 50      | Maximum results per page (1-100)                   |
-| `cursor`  | string | -       | Pagination cursor from a previous response         |
+| Parameter | Type   | Default | Description                                |
+| --------- | ------ | ------- | ------------------------------------------ |
+| `search`  | string | -       | Filter by name or description substring    |
+| `limit`   | int    | 50      | Maximum results per page (1-100)           |
+| `cursor`  | string | -       | Pagination cursor from a previous response |
 
 ### Search example
 
@@ -158,11 +184,11 @@ curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills/io.gith
 
 ## Delete a skill version
 
-To delete a specific version:
+To delete a specific version, use the `/v1/entries` endpoint:
 
 ```bash title="Delete a skill version"
 curl -X DELETE \
-  https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review/versions/1.0.0 \
+  https://registry.example.com/v1/entries/skill/code-review/versions/1.0.0 \
   -H "Authorization: Bearer <TOKEN>"
 ```
 
@@ -172,7 +198,8 @@ returns `404 Not Found`.
 :::warning
 
 Deleting a skill version is permanent. If the deleted version was the latest,
-the latest pointer is not automatically reassigned to a previous version.
+the server automatically reassigns the latest pointer to the next-highest
+remaining version.
 
 :::
 
@@ -184,7 +211,7 @@ The API returns standard HTTP status codes:
 | ---- | ------------------------------------------------------------- |
 | 400  | Invalid request (missing required fields, invalid parameters) |
 | 401  | Authentication required                                       |
-| 403  | Registry is not a managed registry (read-only registries)     |
+| 403  | Insufficient permissions or claims, or registry is read-only  |
 | 404  | Registry, skill, or version not found                         |
 | 409  | Version already exists                                        |
 | 500  | Internal server error                                         |
@@ -202,3 +229,5 @@ The API returns standard HTTP status codes:
   model
 - [Registry server introduction](./intro.mdx)
 - [Authentication](./authentication.mdx) - configuring API access
+- [Authorization](./authorization.mdx) - role-based access control and
+  claims-based scoping

--- a/docs/toolhive/guides-registry/skills.mdx
+++ b/docs/toolhive/guides-registry/skills.mdx
@@ -21,13 +21,13 @@ upstream registry format.
 - If authentication is enabled, a valid bearer token (see
   [Authentication](./authentication.mdx))
 
-## API base path
+## API paths
 
-All skills endpoints use the following base path:
+Skills use two API path families:
 
-```text
-/{registryName}/v0.1/x/dev.toolhive/skills
-```
+- **Browse endpoints** (list, get, search) use the registry-scoped path:
+  `/{registryName}/v0.1/x/dev.toolhive/skills`
+- **Admin endpoints** (publish, delete) use the `/v1/entries` path
 
 Replace `{registryName}` with the `name` of the registry as defined in your
 [configuration file](./configuration.mdx) (for example, `my-registry` if your

--- a/docs/toolhive/guides-registry/skills.mdx
+++ b/docs/toolhive/guides-registry/skills.mdx
@@ -113,11 +113,12 @@ curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills
 
 ### Query parameters
 
-| Parameter | Type   | Default | Description                                |
-| --------- | ------ | ------- | ------------------------------------------ |
-| `search`  | string | -       | Filter by name or description substring    |
-| `limit`   | int    | 50      | Maximum results per page (1-100)           |
-| `cursor`  | string | -       | Pagination cursor from a previous response |
+| Parameter | Type   | Default | Description                                                      |
+| --------- | ------ | ------- | ---------------------------------------------------------------- |
+| `search`  | string | -       | Filter by name or description substring                          |
+| `status`  | string | -       | Filter by status (comma-separated: active, deprecated, archived) |
+| `limit`   | int    | 50      | Maximum results per page (1-100)                                 |
+| `cursor`  | string | -       | Pagination cursor from a previous response                       |
 
 ### Search example
 

--- a/docs/toolhive/guides-registry/telemetry-metrics.mdx
+++ b/docs/toolhive/guides-registry/telemetry-metrics.mdx
@@ -85,6 +85,7 @@ identification.
 | `thv_reg_srv_http_requests_total`           | Counter       | `method`, `route`, `status_code` | Total number of HTTP requests  |
 | `thv_reg_srv_http_active_requests`          | UpDownCounter | -                                | Number of in-flight requests   |
 | `thv_reg_srv_servers_total`                 | Gauge         | `registry`                       | Number of servers per registry |
+| `thv_reg_srv_skills_total`                  | Gauge         | `registry`                       | Number of skills per registry  |
 | `thv_reg_srv_sync_duration_seconds`         | Histogram     | `registry`, `success`            | Duration of sync operations    |
 
 ### Histogram buckets
@@ -171,12 +172,10 @@ sufficient data for identifying issues.
 
 ## Excluded endpoints
 
-The `/health` and `/readiness` endpoints are intentionally excluded from
-tracing.
-
-These endpoints generate a high volume of nearly identical spans that provide
-minimal diagnostic value while significantly increasing storage costs. HTTP
-metrics still capture latency and error rates for these endpoints.
+The `/health`, `/readiness`, and `/version` endpoints are served on a separate
+internal server (default port 8081) and are not included in distributed tracing
+or HTTP metrics from the main API server. This separates Kubernetes probe
+traffic from application telemetry.
 
 ## Next steps
 

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -109,7 +109,6 @@ spec:
 
 The `transport` field is required and accepts `streamable-http` or `sse`.
 
-
 MCPServerEntry supports optional configuration for authentication and TLS:
 
 ```yaml

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -109,6 +109,7 @@ spec:
 
 The `transport` field is required and accepts `streamable-http` or `sse`.
 
+
 MCPServerEntry supports optional configuration for authentication and TLS:
 
 ```yaml

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -201,6 +201,7 @@ const sidebars: SidebarsConfig = {
         'toolhive/guides-registry/deploy-manual',
         'toolhive/guides-registry/configuration',
         'toolhive/guides-registry/authentication',
+        'toolhive/guides-registry/authorization',
         'toolhive/guides-registry/database',
         'toolhive/guides-registry/skills',
         'toolhive/guides-registry/telemetry-metrics',


### PR DESCRIPTION
## Summary

Updates the Registry Server documentation to reflect the v1.0.0, v1.0.1, and v1.1.0 releases, which introduced a new configuration model, claims-based authorization, skills sync, an internal probe server, and auth-only mode.

### Configuration model (v1.0.0)

- **Rewrite `configuration.mdx`** for the new two-level config model: `sources` (data origins with sync/filter/claims) + `registries` (named API surfaces referencing sources)
- Update all YAML examples across `deploy-manual.mdx` and related pages
- Add DNS subdomain naming requirement for source names
- Rename "Server filtering" to "Entry filtering" — filters now apply to both servers and skills

### Authorization (v1.0.0)

- **New `authorization.mdx` page** covering RBAC roles (`superAdmin`, `manageSources`, `manageRegistries`, `manageEntries`), claims-based access control, claim containment logic, publish claim validation, admin API scoping, and a complete multi-tenant example
- Document `GET /v1/sources/{name}/entries` and `GET /v1/registries/{name}/entries` admin endpoints
- Add `authz` cross-references from authentication, configuration, deployment, intro, skills, and index pages
- Add to sidebar between authentication and database

### Per-entry Kubernetes claims (v1.0.1)

- Replace removed `claimMapping` config with `toolhive.stacklok.dev/authz-claims` annotation documentation
- Add `authz-claims` to the Kubernetes annotation table
- Document that annotation claims replace (not merge with) source claims, and entries without the annotation have no claims
- Document multiple Kubernetes sources support

### Skills (v1.0.0–v1.0.1)

- Document that skills now sync from upstream-format Git, API, and File sources (not only managed sources)
- Add missing `status` query parameter to skills listing endpoint
- Add `thv_reg_srv_skills_total` Prometheus metric to telemetry docs
- Update intro, skills, and configuration pages

### Internal probe server (v1.1.0)

- Document new `--internal-address` CLI flag (default `:8081`) in configuration
- Update `deploy-manual.mdx` Kubernetes manifest: probes now target port 8081
- Update `authentication.mdx` public paths: `/health`, `/readiness`, `/version` moved to internal server
- Update `telemetry-metrics.mdx` excluded endpoints section

### Auth-only mode (v1.1.0)

- **New section in `authorization.mdx`** documenting auth-only mode (OAuth enabled, `auth.authz` omitted): all authenticated callers see all entries, startup warning logged

### Other

- Document `GET /v1/me` endpoint in authorization page
- Fix `roles` vs `role` claim key mismatch in authorization example
- Fix missing article in intro.mdx
- Fix broken `#kubernetes-registry` anchor in `remote-mcp-proxy.mdx`
- Fix terminology: "registry views" → "registries", "managed registry" → "managed source"
- Fix front matter descriptions and heading capitalization
- Update stale Registry Server description in `contributing.mdx`

## Changed files

| File | Change |
| --- | --- |
| `guides-registry/authorization.mdx` | **New** — RBAC, claims, auth-only mode, admin entry endpoints, `/v1/me` |
| `guides-registry/configuration.mdx` | Rewrite for sources/registries, claims, K8s annotations, `--internal-address` flag, entry filtering |
| `guides-registry/authentication.mdx` | Add authorization callout, update public paths for internal server |
| `guides-registry/intro.mdx` | Add authorization feature, skills sync, fix grammar |
| `guides-registry/skills.mdx` | Add claims section, `status` query param, skills sync from external sources |
| `guides-registry/deploy-operator.mdx` | Fix terminology, heading, Next steps |
| `guides-registry/deploy-manual.mdx` | Update probes to port 8081, add internal-http port |
| `guides-registry/telemetry-metrics.mdx` | Add `skills_total` metric, update excluded endpoints for internal server |
| `guides-registry/deployment.mdx` | Add authorization link |
| `guides-registry/index.mdx` | Add authorization link, fix description |
| `sidebars.ts` | Add authorization page entry |
| `guides-k8s/remote-mcp-proxy.mdx` | Fix broken anchor link |
| `contributing.mdx` | Update stale Registry Server description |

## Test plan

- [x] Prettier formatting passes on all changed files
- [x] ESLint passes on all changed MDX files
- [x] Multiple rounds of docs-review skill with all issues addressed
- [x] All factual claims verified against source code at v1.0.1 and v1.1.0 tags
- [x] PR review comments addressed (2 valid fixes, 2 rejected with source code evidence)
- [ ] Verify site builds successfully (blocked by missing `thv` CLI in local env — CI will validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)