### PR TITLE
Part 1: Update docs for ToolHive v0.17.0

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -676,9 +676,9 @@ spec:
       issuer: 'https://mcp.example.com'
 ```
 
-Both `authServerRef` and `externalAuthConfigRef` cannot point to an
-`embeddedAuthServer` type simultaneously. The same `authServerRef` field is
-available on MCPRemoteProxy resources.
+`authServerRef` and `externalAuthConfigRef` cannot both reference an
+`embeddedAuthServer` type. The same `authServerRef` field is available on
+MCPRemoteProxy resources.
 
 :::
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -652,6 +652,36 @@ spec:
 kubectl apply -f mcp-server-embedded-auth.yaml
 ```
 
+:::tip[Combining embedded auth with outgoing token exchange]
+
+If you need both an embedded auth server for incoming client authentication
+**and** an outgoing token exchange (such as AWS STS) on the same MCPServer, use
+the dedicated `authServerRef` field instead of `externalAuthConfigRef` for the
+embedded auth server. This separates the two configurations so they don't
+compete for the same field:
+
+```yaml
+spec:
+  # Dedicated field for the embedded auth server
+  authServerRef:
+    kind: MCPExternalAuthConfig
+    name: embedded-auth-server
+  # Outgoing token exchange (e.g., AWS STS)
+  externalAuthConfigRef:
+    name: aws-sts-config
+    kind: MCPExternalAuthConfig
+  oidcConfig:
+    type: inline
+    inline:
+      issuer: 'https://mcp.example.com'
+```
+
+Both `authServerRef` and `externalAuthConfigRef` cannot point to an
+`embeddedAuthServer` type simultaneously. The same `authServerRef` field is
+available on MCPRemoteProxy resources.
+
+:::
+
 :::note
 
 The `oidcConfig` issuer must match the `issuer` in your `MCPExternalAuthConfig`.

--- a/docs/toolhive/guides-k8s/intro.mdx
+++ b/docs/toolhive/guides-k8s/intro.mdx
@@ -70,25 +70,28 @@ or Gateway. To learn how to expose your MCP servers and connect clients, see
 The operator introduces resource types for MCP workloads. Choose based on where
 your MCP server runs and how many servers you need to manage:
 
-| Resource             | Use when                                                                                                          |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **MCPServer**        | Running an MCP server as a container inside your cluster                                                          |
-| **MCPRemoteProxy**   | Connecting to an MCP server hosted outside your cluster (SaaS tools, external APIs, remote endpoints)             |
-| **VirtualMCPServer** | Aggregating multiple MCPServer and/or MCPRemoteProxy resources behind a single endpoint for a team or application |
+| Resource             | Use when                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
+| **MCPServer**        | Running an MCP server as a container inside your cluster                                                 |
+| **MCPRemoteProxy**   | Connecting to an MCP server hosted outside your cluster (SaaS tools, external APIs, remote endpoints)    |
+| **MCPServerEntry**   | Declaring a remote MCP server as a lightweight catalog entry without deploying proxy pods                |
+| **VirtualMCPServer** | Aggregating multiple MCPServer, MCPRemoteProxy, and/or MCPServerEntry resources behind a single endpoint |
 
 Most teams start with `MCPServer` for container-based servers, add
 `MCPRemoteProxy` for external SaaS tools, and graduate to `VirtualMCPServer`
-when managing five or more servers or needing centralized authentication.
+when managing five or more servers or needing centralized authentication. Use
+`MCPServerEntry` instead of `MCPRemoteProxy` when you want to include a remote
+server in vMCP discovery without the overhead of running a proxy pod.
 
 The operator also provides shared configuration CRDs that you reference from
 workload resources:
 
-| Resource                                                                                         | Purpose                                                                                      |
-| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| [**MCPOIDCConfig**](./auth-k8s.mdx#set-up-shared-oidc-configuration-with-mcpoidcconfig)          | Shared OIDC authentication settings, referenced via `oidcConfigRef`                          |
-| [**MCPTelemetryConfig**](./telemetry-and-metrics.mdx#shared-telemetry-configuration-recommended) | Shared telemetry/observability settings, referenced via `telemetryConfigRef`                 |
-| [**MCPToolConfig**](./customize-tools.mdx)                                                       | Tool filtering and renaming, referenced via `toolConfigRef`                                  |
-| [**MCPExternalAuthConfig**](./auth-k8s.mdx#set-up-embedded-authorization-server-authentication)  | Token exchange or embedded auth server configuration, referenced via `externalAuthConfigRef` |
+| Resource                                                                                         | Purpose                                                                                                         |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [**MCPOIDCConfig**](./auth-k8s.mdx#set-up-shared-oidc-configuration-with-mcpoidcconfig)          | Shared OIDC authentication settings, referenced via `oidcConfigRef`                                             |
+| [**MCPTelemetryConfig**](./telemetry-and-metrics.mdx#shared-telemetry-configuration-recommended) | Shared telemetry/observability settings, referenced via `telemetryConfigRef`                                    |
+| [**MCPToolConfig**](./customize-tools.mdx)                                                       | Tool filtering and renaming, referenced via `toolConfigRef`                                                     |
+| [**MCPExternalAuthConfig**](./auth-k8s.mdx#set-up-embedded-authorization-server-authentication)  | Token exchange or embedded auth server configuration, referenced via `externalAuthConfigRef` or `authServerRef` |
 
 ## Installation
 

--- a/docs/toolhive/guides-k8s/quickstart.mdx
+++ b/docs/toolhive/guides-k8s/quickstart.mdx
@@ -171,8 +171,8 @@ kubectl get mcpservers -n toolhive-system
 You should see:
 
 ```text
-NAME    STATUS    URL                                                             AGE
-fetch   Running   http://mcp-fetch-proxy.toolhive-system.svc.cluster.local:8080   30s
+NAME    STATUS   URL                                                             AGE
+fetch   Ready    http://mcp-fetch-proxy.toolhive-system.svc.cluster.local:8080   30s
 ```
 
 If the status is "Pending", wait a few moments and check again. If it remains

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -146,6 +146,40 @@ spec:
       enabled: true
 ```
 
+#### Custom CA certificates for OTLP endpoints
+
+If your OTLP collector uses TLS with certificates signed by an internal or
+private CA, add a `caBundleRef` to your MCPTelemetryConfig. The operator mounts
+the referenced ConfigMap into the pod and configures the OTLP exporters to trust
+the custom CA alongside the system CA pool.
+
+```yaml title="telemetry-with-ca-bundle.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPTelemetryConfig
+metadata:
+  name: shared-otel
+  namespace: toolhive-system
+spec:
+  openTelemetry:
+    enabled: true
+    endpoint: otel-collector.internal:4318
+    caBundleRef:
+      configMapRef:
+        name: otel-ca-bundle
+        key: ca.crt
+    tracing:
+      enabled: true
+    metrics:
+      enabled: true
+```
+
+:::note
+
+`caBundleRef` cannot be used when `insecure` is set to `true` — they are
+mutually exclusive.
+
+:::
+
 ### Inline telemetry configuration
 
 :::warning[Deprecated]

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -175,7 +175,7 @@ spec:
 
 :::note
 
-`caBundleRef` cannot be used when `insecure` is set to `true` — they are
+`caBundleRef` cannot be used when `insecure` is set to `true` - they are
 mutually exclusive.
 
 :::

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -286,16 +286,16 @@ registries:
     sources: ['remote']
 ```
 
-The fields `file` and `url` are mutually exclusive.
+Within the `file` block, `path` and `url` are mutually exclusive.
 
 **Configuration options:**
 
-- `path` (required): Path to the registry file on the filesystem. Mutually
-  exclusive with `url`
-- `url` (required): URL is the HTTP/HTTPS URL to fetch the registry file from.
-  Mutually exclusive with `file`
-- `timeout` (optional): The timeout for HTTP requests when using URL, defaults
-  to 30s, ignored when `file` is specified
+- `file.path` (required): Path to the registry file on the filesystem. Mutually
+  exclusive with `file.url`
+- `file.url` (required): HTTP/HTTPS URL to fetch the registry file from.
+  Mutually exclusive with `file.path`
+- `file.timeout` (optional): The timeout for HTTP requests when using `url`,
+  defaults to 30s
 
 ### Managed registry
 

--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -9,12 +9,13 @@ pointing to a YAML configuration file.
 
 ## Configuration file structure
 
-```yaml title="config.yaml"
-# Registry name/identifier (optional, defaults to "default")
-registryName: my-registry
+The configuration file uses a v2 format that separates **data sources** (where
+registry data comes from) from **registry views** (logical registries that
+aggregate one or more sources).
 
-# Registries configuration (required, can have multiple registries)
-registries:
+```yaml title="config.yaml"
+# Data sources (required, at least one)
+sources:
   - name: toolhive
     # Data format: upstream or toolhive (see below)
     format: upstream
@@ -25,12 +26,12 @@ registries:
       branch: main
       path: pkg/catalog/toolhive/data/registry-upstream.json
 
-    # Per-registry automatic sync policy (required for synced registries)
+    # Per-source automatic sync policy (required for synced sources)
     syncPolicy:
       # Sync interval (e.g., "30m", "1h", "24h")
       interval: '30m'
 
-    # Optional: Per-registry server filtering
+    # Optional: Per-source server filtering
     filter:
       names:
         include: ['official/*']
@@ -38,6 +39,12 @@ registries:
       tags:
         include: ['production']
         exclude: ['experimental']
+
+# Registry views (required, at least one)
+# Each view references sources by name
+registries:
+  - name: default
+    sources: ['toolhive']
 
 # Authentication configuration (required)
 # See authentication.mdx for detailed configuration options
@@ -80,10 +87,11 @@ The `format` field specifies the JSON schema format for the registry data:
   [ToolHive-native format](../reference/registry-schema-toolhive.mdx), used by
   the built-in ToolHive registry.
 
-## Registries
+## Sources
 
-The server supports five registry types, each with its own configuration
-options. You can configure multiple registries in a single server instance.
+The server supports multiple source types, each with its own configuration
+options. You can configure multiple sources in a single server instance and
+aggregate them into registry views.
 
 ### Git repository source
 
@@ -99,7 +107,7 @@ on every container restart, adding startup latency and increasing network usage.
 :::
 
 ```yaml title="config-git.yaml"
-registries:
+sources:
   - name: toolhive
     format: toolhive
     git:
@@ -108,6 +116,9 @@ registries:
       path: pkg/catalog/toolhive/data/registry-legacy.json
     syncPolicy:
       interval: '30m'
+registries:
+  - name: default
+    sources: ['toolhive']
 ```
 
 **Configuration options:**
@@ -134,7 +145,7 @@ To access private Git repositories, configure the `auth` section with your
 credentials:
 
 ```yaml title="config-git-private.yaml"
-registries:
+sources:
   - name: private-registry
     format: toolhive
     git:
@@ -148,6 +159,9 @@ registries:
       # highlight-end
     syncPolicy:
       interval: '30m'
+registries:
+  - name: default
+    sources: ['private-registry']
 ```
 
 **Authentication options:**
@@ -214,13 +228,16 @@ Sync from upstream MCP Registry APIs. Supports federation and aggregation
 scenarios.
 
 ```yaml title="config-api.yaml"
-registries:
+sources:
   - name: mcp-upstream
     format: upstream
     api:
       endpoint: https://registry.modelcontextprotocol.io
     syncPolicy:
       interval: '1h'
+registries:
+  - name: default
+    sources: ['mcp-upstream']
 ```
 
 **Configuration options:**
@@ -241,19 +258,22 @@ etc.) to the endpoint URL.
 Read from filesystem. Ideal for local development and testing.
 
 ```yaml title="config-file.yaml"
-registries:
+sources:
   - name: local
     format: upstream
     file:
       path: /data/registry.json
     syncPolicy:
       interval: '15m'
+registries:
+  - name: default
+    sources: ['local']
 ```
 
 Alternatively, the source can be a custom URL.
 
-```yaml title="config-file.yaml"
-registries:
+```yaml title="config-url.yaml"
+sources:
   - name: remote
     format: upstream
     file:
@@ -261,6 +281,9 @@ registries:
       timeout: 5s
     syncPolicy:
       interval: '15m'
+registries:
+  - name: default
+    sources: ['remote']
 ```
 
 The fields `file` and `url` are mutually exclusive.
@@ -280,10 +303,13 @@ API-managed registry for directly publishing and deleting MCP servers via the
 API. Does not sync from external sources.
 
 ```yaml title="config-managed.yaml"
-registries:
+sources:
   - name: internal
     format: upstream
     managed: {}
+registries:
+  - name: default
+    sources: ['internal']
 ```
 
 **Configuration options:**
@@ -307,15 +333,11 @@ endpoint documentation and request/response examples.
 Discovers MCP servers from running Kubernetes deployments. Automatically creates
 registry entries for deployed MCP servers in your cluster.
 
-:::note[Operator-managed registry]
+:::note[Operator deployments]
 
-When using the ToolHive operator, a single Kubernetes registry named `default`
-is automatically created and managed. You cannot configure additional Kubernetes
-registries through the `MCPRegistry` CR or configuration file, as only one
-Kubernetes registry instance is supported per Registry Server instance.
-
-The configuration example below is for reference when running the Registry
-Server standalone (without the operator).
+When using the ToolHive operator with the `configYAML` path, you must explicitly
+declare Kubernetes discovery sources in your configuration. Only one Kubernetes
+source is supported per Registry Server instance.
 
 :::
 
@@ -326,10 +348,13 @@ By default, the Registry server discovers resources in all namespaces
 details and RBAC requirements.
 
 ```yaml title="config-kubernetes.yaml"
+sources:
+  - name: k8s
+    format: upstream
+    kubernetes: {}
 registries:
   - name: default
-    format: toolhive
-    kubernetes: {}
+    sources: ['k8s']
 ```
 
 **Configuration options:**
@@ -431,12 +456,12 @@ resources via a Service Account, check the details in the
 
 ## Sync policy
 
-Configure automatic synchronization of registry data on a per-registry basis.
-Only applicable to synced registries (Git, API, File). Not required for managed
-or Kubernetes registries.
+Configure automatic synchronization of registry data on a per-source basis. Only
+applicable to synced sources (Git, API, File). Not required for managed or
+Kubernetes sources.
 
 ```yaml
-registries:
+sources:
   - name: toolhive
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
@@ -448,22 +473,22 @@ registries:
 ```
 
 The `interval` field specifies how often the server should fetch updates from
-the registry. Use Go duration format (e.g., `"30m"`, `"1h"`, `"24h"`).
+the source. Use Go duration format (e.g., `"30m"`, `"1h"`, `"24h"`).
 
 :::note
 
-Sync policy is per-registry and must be specified within each registry
-configuration. Managed and Kubernetes registries do not require sync policies.
+Sync policy is per-source and must be specified within each source
+configuration. Managed and Kubernetes sources do not require sync policies.
 
 :::
 
 ## Server filtering
 
-Optionally filter which servers are exposed through the API on a per-registry
-basis. Only applicable to synced registries (Git, API, File).
+Optionally filter which servers are exposed through the API on a per-source
+basis. Only applicable to synced sources (Git, API, File).
 
 ```yaml
-registries:
+sources:
   - name: toolhive
     git:
       repository: https://github.com/stacklok/toolhive-catalog.git
@@ -489,7 +514,7 @@ registries:
 
 :::note
 
-Filters are per-registry and specified within each registry configuration.
+Filters are per-source and specified within each source configuration.
 
 :::
 

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -181,8 +181,8 @@ precedence over `branch`.
 
 ### ConfigMap source
 
-Read from a Kubernetes ConfigMap. Ideal for registry data managed within the
-cluster.
+Read from a Kubernetes ConfigMap. Mount the ConfigMap as a volume and reference
+the file path in `configYAML`.
 
 ```yaml title="registry-configmap.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
@@ -190,13 +190,20 @@ kind: MCPRegistry
 metadata:
   name: configmap-registry
 spec:
+  volumes:
+    - name: registry-data
+      configMap:
+        name: registry-data
+  volumeMounts:
+    - name: registry-data
+      mountPath: /data/registry
+      readOnly: true
   configYAML: |
     sources:
       - name: local
         format: upstream
-        configMapRef:
-          name: registry-data
-          key: registry.json
+        file:
+          path: /data/registry/registry.json
         syncPolicy:
           interval: '15m'
     registries:
@@ -273,8 +280,8 @@ spec:
     sources:
       - name: remote
         format: upstream
-        url:
-          endpoint: https://example.com/registry.json
+        file:
+          url: https://example.com/registry.json
         syncPolicy:
           interval: '1h'
     registries:

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -41,8 +41,9 @@ flowchart LR
     subgraph Sources["Registry Sources"]
       Git["Git Repository"]
       CM["ConfigMap"]
-      PVC["PVC"]
       API["Upstream API"]
+      URL["URL Source"]
+      K8sDisc["Kubernetes Discovery"]
     end
   end
 
@@ -61,8 +62,12 @@ See
 to learn about the different deployment modes.
 
 To create a registry, define an `MCPRegistry` resource and apply it to your
-cluster. This minimal example creates a registry that syncs from the ToolHive
-Git repository.
+cluster. The recommended approach uses the `configYAML` field, which passes the
+registry server's configuration directly without the operator parsing or
+transforming it.
+
+This minimal example creates a registry that syncs from the ToolHive Git
+repository.
 
 ```yaml title="my-registry.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
@@ -72,17 +77,21 @@ metadata:
   namespace: my-namespace # Update with your namespace
 spec:
   displayName: My MCP Registry
-  auth:
-    mode: anonymous
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
-      syncPolicy:
-        interval: '30m'
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
 ```
 
 Apply the resource:
@@ -105,33 +114,51 @@ When you apply an `MCPRegistry` resource, here's what happens:
 
 :::
 
-## Configuring source Registries
+## Configure registry sources
 
-The `MCPRegistry` resource supports multiple registry source types. You can
-configure one or more of them. Each type is mutually exclusive within a single
-registry configuration.
+The registry server's `configYAML` uses a v2 configuration format that separates
+**data sources** (where registry data comes from) from **registry views**
+(logical registries that aggregate one or more sources). Each source defines a
+data origin, and each registry view references sources by name.
+
+```yaml
+configYAML: |
+  sources:
+    - name: my-source
+      format: toolhive
+      git: { ... }
+  registries:
+    - name: default
+      sources: ["my-source"]
+```
+
+You must explicitly declare all sources, including Kubernetes discovery sources.
 
 ### Git repository source
 
 Clone and sync from Git repositories. Ideal for version-controlled registries.
 
-```yaml {9-14} title="registry-git.yaml"
+```yaml title="registry-git.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
   name: git-registry
 spec:
-  auth:
-    mode: anonymous
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
-      syncPolicy:
-        interval: '30m'
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
 ```
 
 **Git source fields:**
@@ -157,86 +184,109 @@ precedence over `branch`.
 Read from a Kubernetes ConfigMap. Ideal for registry data managed within the
 cluster.
 
-```yaml {7-11} title="registry-configmap.yaml"
+```yaml title="registry-configmap.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
   name: configmap-registry
 spec:
-  auth:
-    mode: anonymous
-  registries:
-    - name: local
-      format: upstream
-      configMapRef:
-        name: registry-data
-        key: registry.json
-      syncPolicy:
-        interval: '15m'
+  configYAML: |
+    sources:
+      - name: local
+        format: upstream
+        configMapRef:
+          name: registry-data
+          key: registry.json
+        syncPolicy:
+          interval: '15m'
+    registries:
+      - name: default
+        sources: ["local"]
+    auth:
+      mode: anonymous
 ```
 
 The ConfigMap must exist in the same namespace as the `MCPRegistry` resource.
-
-### PersistentVolumeClaim source
-
-Read from a PersistentVolumeClaim. Useful for large registry files or shared
-storage scenarios.
-
-```yaml {7-10} title="registry-pvc.yaml"
-apiVersion: toolhive.stacklok.dev/v1alpha1
-kind: MCPRegistry
-metadata:
-  name: pvc-registry
-spec:
-  auth:
-    mode: anonymous
-  registries:
-    - name: shared
-      format: upstream
-      pvcRef:
-        claimName: registry-data-pvc
-        path: registries/production.json
-      syncPolicy:
-        interval: '1h'
-```
-
-**PVC source fields:**
-
-| Field       | Required | Description                                                 |
-| ----------- | -------- | ----------------------------------------------------------- |
-| `claimName` | Yes      | Name of the PersistentVolumeClaim                           |
-| `path`      | No       | Path to registry file within PVC (default: `registry.json`) |
-
-The PVC must exist in the same namespace as the `MCPRegistry` resource.
 
 ### API source
 
 Sync from an upstream MCP Registry API. Supports federation and aggregation
 scenarios.
 
-```yaml {7-10} title="registry-api.yaml"
+```yaml title="registry-api.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
   name: api-registry
 spec:
-  auth:
-    mode: anonymous
-  registries:
-    - name: upstream
-      format: upstream
-      api:
-        endpoint: https://registry.example.com
-      syncPolicy:
-        interval: '1h'
+  configYAML: |
+    sources:
+      - name: upstream
+        format: upstream
+        api:
+          endpoint: https://registry.example.com
+        syncPolicy:
+          interval: '1h'
+    registries:
+      - name: default
+        sources: ["upstream"]
+    auth:
+      mode: anonymous
 ```
 
 The controller automatically appends the appropriate API paths to the endpoint
 URL.
 
+### Kubernetes discovery source
+
+Discover MCP servers from running Kubernetes resources in the cluster.
+
+```yaml title="registry-k8s-discovery.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPRegistry
+metadata:
+  name: k8s-registry
+spec:
+  configYAML: |
+    sources:
+      - name: k8s
+        format: upstream
+        kubernetes: {}
+    registries:
+      - name: default
+        sources: ["k8s"]
+    auth:
+      mode: anonymous
+```
+
+### URL source
+
+Fetch registry data from an HTTP/HTTPS URL.
+
+```yaml title="registry-url.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPRegistry
+metadata:
+  name: url-registry
+spec:
+  configYAML: |
+    sources:
+      - name: remote
+        format: upstream
+        url:
+          endpoint: https://example.com/registry.json
+        syncPolicy:
+          interval: '1h'
+    registries:
+      - name: default
+        sources: ["remote"]
+    auth:
+      mode: anonymous
+```
+
 ### Configure synchronization
 
-Each registry source can have its own sync policy that controls automatic
+Each source can have its own sync policy that controls automatic
 synchronization.
 
 ```yaml
@@ -247,112 +297,121 @@ syncPolicy:
 ### Filter registry content
 
 You can filter which servers are exposed through the API using name and tag
-patterns.
+patterns on individual sources.
 
-```yaml {13-20} title="registry-filtered.yaml"
+```yaml title="registry-filtered.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
   name: filtered-registry
 spec:
-  auth:
-    mode: anonymous
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
-      filter:
-        names:
-          include:
-            - 'official/*'
-          exclude:
-            - '*/deprecated'
-        tags:
-          include:
-            - production
-          exclude:
-            - experimental
-      syncPolicy:
-        interval: '30m'
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        filter:
+          names:
+            include:
+              - 'official/*'
+            exclude:
+              - '*/deprecated'
+          tags:
+            include:
+              - production
+            exclude:
+              - experimental
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
 ```
 
 ## Configure database storage
 
-Configure PostgreSQL database storage for the Registry server.
+Configure PostgreSQL database storage for the Registry server. With the
+`configYAML` approach, database settings go directly into the config and you use
+`pgpassSecretRef` for password management.
 
-```yaml {17-32} title="registry-with-database.yaml"
+```yaml title="registry-with-database.yaml"
 apiVersion: v1
 kind: Secret
 metadata:
-  name: registry-api-db-passwords
+  name: registry-pgpass
 type: Opaque
 stringData:
-  db-password: app_password
-  migration-password: migrator_password
+  .pgpass: |
+    postgres.database.svc.cluster.local:5432:registry:db_app:app_password
+    postgres.database.svc.cluster.local:5432:registry:db_migrator:migrator_password
 ---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
   name: production-registry
 spec:
-  auth:
-    mode: anonymous
-  databaseConfig:
-    host: postgres.database.svc.cluster.local
-    port: 5432
-    user: db_app
-    migrationUser: db_migrator
-    dbAppUserPasswordSecretRef:
-      name: registry-api-db-passwords
-      key: db-password
-    dbMigrationUserPasswordSecretRef:
-      name: registry-api-db-passwords
-      key: migration-password
-    database: registry
-    sslMode: verify-full
-    maxOpenConns: 25
-    maxIdleConns: 5
-    connMaxLifetime: '30m'
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
-      syncPolicy:
-        interval: '30m'
+  pgpassSecretRef:
+    name: registry-pgpass
+    key: .pgpass
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
+    database:
+      host: postgres.database.svc.cluster.local
+      port: 5432
+      user: db_app
+      migrationUser: db_migrator
+      database: registry
+      sslMode: verify-full
+      maxOpenConns: 25
+      maxIdleConns: 5
+      connMaxLifetime: '30m'
 ```
 
 **Database configuration fields:**
 
-| Field                              | Default       | Description                                       |
-| ---------------------------------- | ------------- | ------------------------------------------------- |
-| `host`                             | `postgres`    | Database server hostname                          |
-| `port`                             | `5432`        | Database server port                              |
-| `user`                             | `db_app`      | Application user (SELECT, INSERT, UPDATE, DELETE) |
-| `migrationUser`                    | `db_migrator` | Migration user (CREATE, ALTER, DROP)              |
-| `dbAppUserPasswordSecretRef`       | ``            | Password of application user                      |
-| `dbMigrationUserPasswordSecretRef` | ``            | Password of migration user                        |
-| `database`                         | `registry`    | Database name                                     |
-| `sslMode`                          | `prefer`      | SSL mode (disable, prefer, require, verify-full)  |
-| `maxOpenConns`                     | `10`          | Maximum open connections                          |
-| `maxIdleConns`                     | `2`           | Maximum idle connections                          |
-| `connMaxLifetime`                  | `30m`         | Maximum connection lifetime                       |
+| Field             | Default       | Description                                       |
+| ----------------- | ------------- | ------------------------------------------------- |
+| `host`            | `postgres`    | Database server hostname                          |
+| `port`            | `5432`        | Database server port                              |
+| `user`            | `db_app`      | Application user (SELECT, INSERT, UPDATE, DELETE) |
+| `migrationUser`   | `db_migrator` | Migration user (CREATE, ALTER, DROP)              |
+| `database`        | `registry`    | Database name                                     |
+| `sslMode`         | `prefer`      | SSL mode (disable, prefer, require, verify-full)  |
+| `maxOpenConns`    | `10`          | Maximum open connections                          |
+| `maxIdleConns`    | `2`           | Maximum idle connections                          |
+| `connMaxLifetime` | `30m`         | Maximum connection lifetime                       |
 
 :::tip
 
-Credentials are internally configured using a pgpass file mounted as a secret.
+Use `pgpassSecretRef` on the MCPRegistry resource to provide database
+credentials. The operator handles mounting and file permissions automatically.
+Create a Kubernetes Secret containing a
+[pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
+file and reference it in your MCPRegistry spec.
 
 :::
 
 ## Configure authentication
 
-You can configure authentication using the `authConfig` field in your
-`MCPRegistry` resource.
+You can configure authentication in the `auth` section within `configYAML`.
 
 ### Authentication modes
 
@@ -371,7 +430,7 @@ can set it to `anonymous`.
 ### OAuth authentication
 
 OAuth mode validates JWT tokens from one or more identity providers. Configure
-providers in the `authConfig.oauth.providers` array.
+providers in the `auth.oauth.providers` array within `configYAML`.
 
 ```yaml title="registry-oauth.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
@@ -381,24 +440,30 @@ metadata:
   namespace: toolhive-system
 spec:
   displayName: 'Authenticated MCP Server Registry'
-  authConfig:
-    mode: oauth
-    oauth:
-      providers:
-        - name: kubernetes
-          issuerUrl: https://kubernetes.default.svc.cluster.local
-          jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
-          audience: registry-server
-          caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-          allowPrivateIP: true
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: oauth
+      oauth:
+        providers:
+          - name: kubernetes
+            issuerUrl: https://kubernetes.default.svc.cluster.local
+            jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
+            audience: registry-server
+            caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+            allowPrivateIP: true
 ```
 
 ### OAuth configuration fields
@@ -436,17 +501,25 @@ kind: MCPRegistry
 metadata:
   name: registry
 spec:
-  authConfig:
-    mode: oauth
-    oauth:
-      providers:
-        - name: kubernetes
-          issuerUrl: https://kubernetes.default.svc.cluster.local
-          jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
-          audience: registry-server
-          caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-          allowPrivateIP: true
+  configYAML: |
+    sources:
+      - name: k8s
+        format: upstream
+        kubernetes: {}
+    registries:
+      - name: default
+        sources: ["k8s"]
+    auth:
+      mode: oauth
+      oauth:
+        providers:
+          - name: kubernetes
+            issuerUrl: https://kubernetes.default.svc.cluster.local
+            jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
+            audience: registry-server
+            caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+            allowPrivateIP: true
 ```
 
 :::tip[Kubernetes provider settings]
@@ -471,22 +544,30 @@ kind: MCPRegistry
 metadata:
   name: registry
 spec:
-  authConfig:
-    mode: oauth
-    oauth:
-      providers:
-        # Kubernetes service accounts (in-cluster workloads)
-        - name: kubernetes
-          issuerUrl: https://kubernetes.default.svc.cluster.local
-          jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
-          audience: registry-server
-          caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-          allowPrivateIP: true
-        # External identity provider
-        - name: okta
-          issuerUrl: https://YOUR_DOMAIN.okta.com/oauth2/default
-          audience: registry
+  configYAML: |
+    sources:
+      - name: k8s
+        format: upstream
+        kubernetes: {}
+    registries:
+      - name: default
+        sources: ["k8s"]
+    auth:
+      mode: oauth
+      oauth:
+        providers:
+          # Kubernetes service accounts (in-cluster workloads)
+          - name: kubernetes
+            issuerUrl: https://kubernetes.default.svc.cluster.local
+            jwksUrl: https://kubernetes.default.svc/openid/v1/jwks
+            audience: registry-server
+            caCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+            allowPrivateIP: true
+          # External identity provider
+          - name: okta
+            issuerUrl: https://YOUR_DOMAIN.okta.com/oauth2/default
+            audience: registry
 ```
 
 The server validates tokens against each provider in order until one succeeds.
@@ -501,15 +582,21 @@ kind: MCPRegistry
 metadata:
   name: registry
 spec:
-  authConfig:
-    mode: anonymous
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
 ```
 
 :::danger[No access control]
@@ -529,7 +616,7 @@ provider-specific examples for Keycloak, Auth0, Azure AD, and Okta, see the
 You can customize the Registry server pod using the `podTemplateSpec` field.
 This gives you full control over the pod specification.
 
-```yaml {6-15} title="registry-custom-pod.yaml"
+```yaml title="registry-custom-pod.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRegistry
 metadata:
@@ -546,17 +633,21 @@ spec:
             requests:
               cpu: '100m'
               memory: '128Mi'
-  auth:
-    mode: anonymous
-  registries:
-    - name: toolhive
-      format: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-legacy.json
-      syncPolicy:
-        interval: '30m'
+  configYAML: |
+    sources:
+      - name: toolhive
+        format: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-legacy.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ["toolhive"]
+    auth:
+      mode: anonymous
 ```
 
 :::info[Container name requirement]
@@ -566,7 +657,7 @@ When customizing containers in `podTemplateSpec`, you must use
 manage the Registry server. The container name is hardcoded to avoid conflict
 issues with user provided containers. Mandating a container name on the Operator
 side explicitly tells the Operator it is the main registry server container and
-any other containers provided by the use are sidecars/init containers.
+any other containers provided by the user are sidecars/init containers.
 
 :::
 
@@ -594,13 +685,18 @@ kubectl -n <NAMESPACE> describe mcpregistry <NAME>
 
 ### Registry phases
 
-| Phase         | Description                            |
-| ------------- | -------------------------------------- |
-| `Pending`     | The registry is being initialized      |
-| `Ready`       | The registry is ready and operational  |
-| `Syncing`     | The registry is currently syncing data |
-| `Failed`      | The registry has encountered an error  |
-| `Terminating` | The registry is being deleted          |
+| Phase         | Description                           |
+| ------------- | ------------------------------------- |
+| `Pending`     | The registry is being initialized     |
+| `Ready`       | The registry is ready and operational |
+| `Failed`      | The registry has encountered an error |
+| `Terminating` | The registry is being deleted         |
+
+You can also use `kubectl wait` to wait for the registry to be ready:
+
+```bash
+kubectl -n <NAMESPACE> wait --for=condition=Ready mcpregistry/<NAME>
+```
 
 ## Next steps
 
@@ -609,11 +705,6 @@ Learn how to configure authentication for the Registry server in the
 
 Configure additional registry sources and filtering options in the
 [Configuration](./configuration.mdx) guide.
-
-Discover your deployed MCP servers automatically using the
-[Kubernetes registry](./configuration.mdx#kubernetes-registry) feature. Note
-that the operator automatically creates a single Kubernetes registry named
-`default` - you cannot configure additional Kubernetes registries.
 
 ## Related information
 
@@ -659,9 +750,9 @@ Common causes include:
 </details>
 
 <details>
-<summary>Registry stuck in Pending or Syncing phase</summary>
+<summary>Registry stuck in Pending phase</summary>
 
-If the registry is stuck in `Pending` or `Syncing` phase:
+If the registry is stuck in `Pending` phase:
 
 ```bash
 # Check registry status
@@ -675,7 +766,7 @@ Common causes include:
 
 - **Git repository inaccessible**: Verify the repository URL is correct and
   accessible
-- **ConfigMap/PVC doesn't exist**: Ensure referenced resources exist in the same
+- **ConfigMap doesn't exist**: Ensure referenced resources exist in the same
   namespace
 - **Network policies**: Check if network policies are blocking external access
 - **Invalid registry file format**: Verify the registry JSON file is valid
@@ -708,13 +799,9 @@ Common causes include:
 If synchronization is failing:
 
 ```bash
-# Check sync status
-kubectl -n <NAMESPACE> get mcpregistry <NAME> -o jsonpath='{.status.syncStatus}'
-
-# Trigger manual sync to see immediate errors
-kubectl annotate mcpregistry <NAME> \
-  toolhive.stacklok.dev/sync-trigger="$(date +%s)" \
-  --overwrite
+# Check registry status and conditions
+kubectl -n <NAMESPACE> get mcpregistry <NAME> -o jsonpath='{.status.phase}'
+kubectl -n <NAMESPACE> get mcpregistry <NAME> -o jsonpath='{.status.conditions}'
 
 # Check logs
 kubectl -n <NAMESPACE> logs -l app.kubernetes.io/instance=<NAME>

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -11,8 +11,8 @@ VirtualMCPServer resource. For a complete field reference, see the
 
 Before creating a VirtualMCPServer, you need an
 [MCPGroup](../reference/crd-spec.md#apiv1alpha1mcpgroup) to organize the backend
-MCP servers. An MCPGroup is a logical container that groups related MCPServer
-and MCPRemoteProxy resources together.
+MCP servers. An MCPGroup is a logical container that groups related MCPServer,
+MCPRemoteProxy, and MCPServerEntry resources together.
 
 Create a basic MCPGroup:
 
@@ -140,12 +140,12 @@ spec:
 
 **When to use MCPServerEntry vs. MCPRemoteProxy:**
 
-|                     | MCPServerEntry                                                 | MCPRemoteProxy                                                                    |
-| ------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Infrastructure**  | No pods, services, or deployments                              | Creates a proxy pod and service                                                   |
-| **Use case**        | Lightweight catalog entries for well-known remote servers      | When you need request transformation, caching, or the full proxy middleware chain |
-| **Discovery**       | Discovered by VirtualMCPServer through MCPGroup membership     | Discovered by VirtualMCPServer through MCPGroup membership                        |
-| **SSRF protection** | Built-in URL validation blocks internal and metadata endpoints | N/A (proxy runs inside the cluster)                                               |
+|                     | MCPServerEntry                                                 | MCPRemoteProxy                                                                              |
+| ------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Infrastructure**  | No pods, services, or deployments                              | Creates a proxy pod and service                                                             |
+| **Use case**        | Lightweight catalog entries for well-known remote servers      | Proxied connections requiring request transformation, caching, or the full middleware chain |
+| **Discovery**       | Discovered by VirtualMCPServer through MCPGroup membership     | Discovered by VirtualMCPServer through MCPGroup membership                                  |
+| **SSRF protection** | Built-in URL validation blocks internal and metadata endpoints | N/A (proxy runs inside the cluster)                                                         |
 
 :::note
 

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -104,8 +104,10 @@ metadata:
 spec:
   groupRef: my-group # Reference to the MCPGroup
   remoteURL: https://mcp.example.com/mcp
-  transport: streamable-http
+  transport: streamable-http # or sse
 ```
+
+The `transport` field is required and accepts `streamable-http` or `sse`.
 
 MCPServerEntry supports optional configuration for authentication and TLS:
 

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -27,12 +27,12 @@ spec:
 ```
 
 The MCPGroup must exist in the same namespace as your VirtualMCPServer and be in
-a Ready state before the VirtualMCPServer can stafrt. Backend resources
-reference this group using the `groupRef` field in their spec.
+a Ready state before the VirtualMCPServer can start. Backend resources reference
+this group using the `groupRef` field in their spec.
 
 ## Add backends to a group
 
-vMCP supports two types of backends that can be added to an MCPGroup:
+vMCP supports three types of backends that can be added to an MCPGroup:
 
 ### MCPServer (local containers)
 
@@ -88,6 +88,73 @@ for details.
 For complete MCPRemoteProxy configuration options, see
 [Proxy remote MCP servers](../guides-k8s/remote-mcp-proxy.mdx).
 
+### MCPServerEntry (zero-infrastructure catalog entries)
+
+MCPServerEntry resources declare remote MCP servers as lightweight catalog
+entries without deploying proxy pods, services, or deployments. Use
+MCPServerEntry when you want to include a remote server in vMCP routing without
+the overhead of running a proxy.
+
+```yaml
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: my-remote-tool
+  namespace: toolhive-system
+spec:
+  groupRef: my-group # Reference to the MCPGroup
+  remoteURL: https://mcp.example.com/mcp
+  transport: streamable-http
+```
+
+MCPServerEntry supports optional configuration for authentication and TLS:
+
+```yaml
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: internal-tool
+  namespace: toolhive-system
+spec:
+  groupRef: my-group
+  remoteURL: https://internal-mcp.corp.example.com/mcp
+  transport: streamable-http
+
+  # Optional: token exchange for authenticating to the remote server
+  externalAuthConfigRef:
+    name: my-auth-config
+    kind: MCPExternalAuthConfig
+
+  # Optional: custom CA bundle for TLS verification
+  caBundleRef:
+    configMapRef:
+      name: internal-ca-bundle
+      key: ca.crt
+
+  # Optional: inject custom headers into requests
+  headerForward:
+    headers:
+      - name: X-Custom-Header
+        value: my-value
+```
+
+**When to use MCPServerEntry vs. MCPRemoteProxy:**
+
+|                     | MCPServerEntry                                                 | MCPRemoteProxy                                                                    |
+| ------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Infrastructure**  | No pods, services, or deployments                              | Creates a proxy pod and service                                                   |
+| **Use case**        | Lightweight catalog entries for well-known remote servers      | When you need request transformation, caching, or the full proxy middleware chain |
+| **Discovery**       | Discovered by VirtualMCPServer through MCPGroup membership     | Discovered by VirtualMCPServer through MCPGroup membership                        |
+| **SSRF protection** | Built-in URL validation blocks internal and metadata endpoints | N/A (proxy runs inside the cluster)                                               |
+
+:::note
+
+MCPServerEntry URLs are validated against SSRF patterns. URLs targeting
+loopback, link-local, cloud metadata, and private network addresses are
+rejected.
+
+:::
+
 ## Create a VirtualMCPServer
 
 At minimum, a VirtualMCPServer requires a reference to an MCPGroup (via
@@ -108,10 +175,10 @@ spec:
 
 The MCPGroup must exist in the same namespace and be in a Ready state before the
 VirtualMCPServer can start. By default, vMCP automatically discovers and
-aggregates all MCPServer and MCPRemoteProxy resources in the referenced group.
-You can also define backends explicitly in the configuration (inline mode). See
-[Backend discovery modes](./backend-discovery.mdx) for details on both
-approaches.
+aggregates all MCPServer, MCPRemoteProxy, and MCPServerEntry resources in the
+referenced group. You can also define backends explicitly in the configuration
+(inline mode). See [Backend discovery modes](./backend-discovery.mdx) for
+details on both approaches.
 
 ## Configure authentication
 

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -125,7 +125,6 @@ spec:
   # Optional: token exchange for authenticating to the remote server
   externalAuthConfigRef:
     name: my-auth-config
-    kind: MCPExternalAuthConfig
 
   # Optional: custom CA bundle for TLS verification
   caBundleRef:
@@ -133,11 +132,10 @@ spec:
       name: internal-ca-bundle
       key: ca.crt
 
-  # Optional: inject custom headers into requests
+  # Optional: inject plaintext headers into requests
   headerForward:
-    headers:
-      - name: X-Custom-Header
-        value: my-value
+    addPlaintextHeaders:
+      X-Custom-Header: my-value
 ```
 
 **When to use MCPServerEntry vs. MCPRemoteProxy:**

--- a/docs/toolhive/guides-vmcp/optimizer.mdx
+++ b/docs/toolhive/guides-vmcp/optimizer.mdx
@@ -80,7 +80,7 @@ spec: {}
 
 :::tip
 
-Wait for the EmbeddingServer to reach the `Running` phase before proceeding. The
+Wait for the EmbeddingServer to reach the `Ready` phase before proceeding. The
 first startup may take a few minutes while the model downloads.
 
 ```bash

--- a/docs/toolhive/guides-vmcp/quickstart.mdx
+++ b/docs/toolhive/guides-vmcp/quickstart.mdx
@@ -104,7 +104,7 @@ Apply the resources:
 kubectl apply -f mcpservers.yaml
 ```
 
-Wait for both servers to be running:
+Wait for both servers to be ready:
 
 ```bash
 kubectl get mcpservers -n toolhive-system -w

--- a/docs/toolhive/guides-vmcp/quickstart.mdx
+++ b/docs/toolhive/guides-vmcp/quickstart.mdx
@@ -110,7 +110,7 @@ Wait for both servers to be running:
 kubectl get mcpservers -n toolhive-system -w
 ```
 
-You should see both servers with `Running` status before continuing.
+You should see both servers with `Ready` status before continuing.
 
 ## Step 3: Create a VirtualMCPServer
 

--- a/docs/toolhive/integrations/okta.mdx
+++ b/docs/toolhive/integrations/okta.mdx
@@ -166,10 +166,10 @@ You should see output similar to:
 
 ```text
 NAME     STATUS   URL                                                              AGE
-github   Running  http://mcp-github-proxy.toolhive-system.svc.cluster.local:8080   30s
+github   Ready    http://mcp-github-proxy.toolhive-system.svc.cluster.local:8080   30s
 ```
 
-Wait until the status shows `Running` before continuing to the next step. If the
+Wait until the status shows `Ready` before continuing to the next step. If the
 server remains in a pending state, check the operator logs for errors:
 
 ```bash


### PR DESCRIPTION
## Summary

Updates documentation for the [ToolHive v0.17.0 release](https://github.com/stacklok/toolhive/releases/tag/v0.17.0).

### Breaking change updates
- **CRD phase `Running` → `Ready`**: Updated MCPServer and EmbeddingServer phase references in quickstarts, guides, and integration pages
- **MCPRegistry v2 config format**: Migrated all examples from flat `registries[]` to v2 `sources[]`/`registries[]` within `configYAML` (recommended path)
- **PVC source removed**: Removed PVC source section and references
- **MCPRegistry status simplified**: Removed `Syncing` phase, `syncStatus`/`apiStatus` references; added `kubectl wait --for=condition=Ready` example
- **Auto-injection removed**: Removed note about automatic Kubernetes registry creation

### New feature documentation
- **MCPServerEntry**: Zero-infrastructure catalog entries documented in K8s intro and vMCP configuration pages, with comparison table vs MCPRemoteProxy
- **`caBundleRef` for OTLP**: Custom CA certificate support for OTLP endpoints added to telemetry guide
- **`authServerRef`**: Dedicated auth server field documented in auth guide, enabling combined embedded auth + outgoing token exchange
- **Registry v2 config**: Standalone registry server config updated to v2 `sources[]`/`registries[]` format

### Files changed (10)
- `guides-k8s/quickstart.mdx` — Phase `Running` → `Ready`
- `guides-vmcp/quickstart.mdx` — Phase `Running` → `Ready`
- `integrations/okta.mdx` — Phase `Running` → `Ready`
- `guides-vmcp/optimizer.mdx` — EmbeddingServer phase `Running` → `Ready`
- `guides-registry/deploy-operator.mdx` — Major: v2 config format, configYAML, remove PVC, status updates
- `guides-registry/configuration.mdx` — v2 config format for standalone server
- `guides-k8s/intro.mdx` — Add MCPServerEntry to resource table
- `guides-vmcp/configuration.mdx` — Add MCPServerEntry backend type with examples
- `guides-k8s/telemetry-and-metrics.mdx` — Add `caBundleRef` for OTLP
- `guides-k8s/auth-k8s.mdx` — Add `authServerRef` for combined auth

### Not included (separate action needed)
- `reference/crd-spec.md` — Auto-generated file; needs regeneration from v0.17.0 tag

## Test plan

- [x] Prettier formatting passes on all changed files
- [x] ESLint passes on all MDX files
- [x] All YAML examples verified against v0.17.0 source code at tag
- [x] Phase value changes scoped correctly (K8s CRD phases only, not pod status or CLI/UI status)
- [ ] Full site build (blocked by pre-existing CLI conflict in local env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)