### PR TITLE
Pin serialize-javascript to fix high-severity vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21792,15 +21792,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -23231,12 +23222,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "npm": "^11.7.0"
   },
   "overrides": {
-    "webpackbar": "^7.0.0"
+    "webpackbar": "^7.0.0",
+    "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `serialize-javascript: ">=7.0.5"` to the `overrides` block in `package.json`, forcing all transitive dependents to use the patched version
- Resolves 21 high-severity advisories (GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v) that `npm audit fix` couldn't address without a breaking downgrade

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after the change
- [x] No direct dependencies changed; this is a transitive override only

🤖 Generated with [Claude Code](https://claude.com/claude-code)