### PR TITLE
Add dash style guidance to style guide and review skill

### DIFF
--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -65,6 +65,7 @@ Watch for these telltale signs of AI-generated docs that need human intervention
 | Repetitive content | Same info in multiple sections | Deduplicate; single source of truth |
 | Over-explaining | Verbose descriptions of obvious things | Trust the reader; cut aggressively |
 | Hedging language | "may," "might," "could potentially" | Be direct or remove |
+| Em/en dashes | `—` or `–` used as inline separators | Rephrase naturally: use commas, split sentences, or restructure. Use spaced hyphens (`-`) only in list-style contexts |
 | Hedged lists | "such as," "including," "clients include" when listing supported items | Be definitive: state the full list, or link to a canonical reference |
 | Placeholder examples | `my-skill`, `example-org`, `my-app` instead of real values | Use real, working examples from the actual product |
 | Features without context | Introduces a flag/option without explaining why a reader would use it | Explain the user benefit and how it connects to concepts the reader already knows |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,8 @@ The project's official language is US English.
 
 - Use the Oxford comma (aka serial commas) when listing items in a series.
 - Use one space between sentences.
-- Use straight double quotes and apostrophes. Replace smart quotes (“ ”) and curly apostrophes (’ ’) with straight quotes (") and straight apostrophes (').
+- Use straight double quotes and apostrophes. Replace smart quotes (“ “) and curly apostrophes (‘ ‘) with straight quotes (“) and straight apostrophes (‘).
+- Avoid em dashes (`—`) and en dashes (`–`). They are hard to type, easy to miss in editors, and have proliferated with AI-generated content. Instead, rephrase naturally: use commas, split into two sentences, or restructure. If a separator is truly needed, use a spaced hyphen (`-`) in list-style contexts like “Related information” entries.
 
 ### Links
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -49,8 +49,8 @@ avoid overly complex jargon to make content accessible to a wide audience.
 ### Tone and voice
 
 Strive for a casual and conversational tone without becoming overly informal. We
-aim to be friendly and relatable while retaining credibility and professionalism
-– approachable yet polished.
+aim to be friendly and relatable while retaining credibility and
+professionalism, approachable yet polished.
 
 #### Active voice
 
@@ -101,6 +101,12 @@ a series.
 quotes" or "smart quotes" (the default in document editors like Word/Docs). This
 is especially important in code examples where smart quotes often cause syntax
 errors.
+
+**Dashes**: avoid em dashes (`—`) and en dashes (`–`). They are hard to type,
+easy to miss in editors, and have proliferated with AI-generated content.
+Instead, rephrase naturally: use commas, split into two sentences, or
+restructure. If a separator is truly needed (for example, between a link and its
+description in a list), use a spaced hyphen (`-`).
 
 Tip: if you are drafting in Google Docs, disable the "Use smart quotes" setting
 in the Tools → Preferences menu to avoid inadvertently copying smart quotes into


### PR DESCRIPTION
### Description

Adds guidance to avoid em dashes (`—`) and en dashes (`–`) in documentation. These are hard to type, easy to miss in editors, and have proliferated with AI-generated content. The preferred approach is to rephrase naturally (commas, sentence splits, restructuring) rather than mechanically replacing with hyphens.

Updates three files:
- **STYLE-GUIDE.md**: New "Dashes" entry under Punctuation, plus fixes an existing en dash on the page
- **AGENTS.md** (CLAUDE.md): Matching guidance in the Punctuation section
- **docs-review skill**: Added em/en dashes to the LLM-generated content patterns table

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)