### PR TITLE
Clarify auto-generated reference docs PR description

### DIFF
--- a/.github/workflows/update-toolhive-reference.yml
+++ b/.github/workflows/update-toolhive-reference.yml
@@ -90,7 +90,24 @@ jobs:
           title: |
             Update ToolHive reference docs for ${{ steps.imports.outputs.version }}
           body: |
-            This PR updates the ToolHive CLI and API reference documentation for release: ${{ steps.imports.outputs.version }}.
+            This PR was auto-generated from ToolHive release **${{ steps.imports.outputs.version }}**.${{ steps.get-reviewer.outputs.assign_to != '' && format(' @{0} is tagged as the person who cut this release.', steps.get-reviewer.outputs.assign_to) || '' }}
+
+            ## What's in this PR
+
+            Only machine-generated reference files that are built from the ToolHive source code during the release process:
+
+            - **CLI reference** (`docs/toolhive/reference/cli/`) - help text for every `thv` command
+            - **REST API spec** (`static/api-specs/toolhive-api.yaml`) - OpenAPI/Swagger spec
+            - **CRD API spec** (`docs/toolhive/reference/crd-spec.md`) - Kubernetes CRD reference
+            - **Registry JSON schemas** (`static/api-specs/*.schema.json`) - registry validation schemas
+
+            ## What's NOT in this PR
+
+            This PR does **not** contain guide, tutorial, or conceptual content. Any documentation updates beyond reference files are handled in separate, manually authored PRs.
+
+            ## Review guidance
+
+            These files are generated directly from the ToolHive source and are not hand-edited. A quick scan for obvious issues is sufficient - this is intended to be merged shortly after the release is cut so the docs stay in sync.
           commit-message: |
             Update ToolHive reference docs for ${{ steps.imports.outputs.version }}
           labels: |


### PR DESCRIPTION
## Summary

- Expand the auto-generated PR body to list exactly which files are included (CLI reference, API spec, CRD spec, registry schemas) and explicitly call out what's NOT included (guides, tutorials, conceptual docs)
- Tag the release cutter with an @-mention in the PR description so reviewers know who triggered it
- Add review guidance setting expectations for a quick rubber-stamp merge