### PR TITLE
Fix CRD field and version issues in K8s guides

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -99,18 +99,21 @@ To install the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you plan to use:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
-Replace `v0.12.1` in the commands above with your target CRD version.
+Replace `v0.20.0` in the commands above with your target CRD version.
 
 </TabItem>
 </Tabs>
@@ -334,21 +337,24 @@ To upgrade the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you want:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.12.1/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
 </TabItem>
 </Tabs>
 
-Replace `v0.12.1` in the commands above with your target CRD version.
+Replace `v0.20.0` in the commands above with your target CRD version.
 
 ### Upgrade the operator Helm release
 
@@ -419,11 +425,14 @@ To remove the CRDs using `kubectl`, run the following:
 ```bash
 kubectl delete crd embeddingservers.toolhive.stacklok.dev
 kubectl delete crd mcpexternalauthconfigs.toolhive.stacklok.dev
-kubectl delete crd mcptoolconfigs.toolhive.stacklok.dev
-kubectl delete crd mcpremoteproxies.toolhive.stacklok.dev
-kubectl delete crd mcpservers.toolhive.stacklok.dev
 kubectl delete crd mcpgroups.toolhive.stacklok.dev
+kubectl delete crd mcpoidcconfigs.toolhive.stacklok.dev
 kubectl delete crd mcpregistries.toolhive.stacklok.dev
+kubectl delete crd mcpremoteproxies.toolhive.stacklok.dev
+kubectl delete crd mcpserverentries.toolhive.stacklok.dev
+kubectl delete crd mcpservers.toolhive.stacklok.dev
+kubectl delete crd mcptelemetryconfigs.toolhive.stacklok.dev
+kubectl delete crd mcptoolconfigs.toolhive.stacklok.dev
 kubectl delete crd virtualmcpcompositetooldefinitions.toolhive.stacklok.dev
 kubectl delete crd virtualmcpservers.toolhive.stacklok.dev
 ```

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -394,8 +394,8 @@ metadata:
 spec:
   type: tokenExchange
   tokenExchange:
-    tokenURL: https://auth.company.com/protocol/openid-connect/token
-    clientID: token-exchange-client
+    tokenUrl: https://auth.company.com/protocol/openid-connect/token
+    clientId: token-exchange-client
     clientSecretRef:
       name: token-exchange-creds
       key: client-secret
@@ -783,7 +783,8 @@ metadata:
   name: context7-proxy
   namespace: toolhive-system
 spec:
-  groupRef: my-group # Reference to an MCPGroup
+  groupRef:
+    name: my-group # Reference to an MCPGroup
   remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   proxyPort: 8080

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -741,8 +741,8 @@ To test connectivity between components:
 # Port-forward to test direct access to the proxy
 kubectl -n <NAMESPACE> port-forward service/<MCPSERVER_NAME> 8080:8080
 
-# Test the connection locally
-curl http://localhost:8080/health
+# Test the connection locally (should return {"status":"healthy",...})
+curl -s http://localhost:8080/health | jq .status
 
 # Check service endpoints
 kubectl -n <NAMESPACE> get endpoints


### PR DESCRIPTION
## Summary

Fixes doc issues found by testing K8s guides against ToolHive v0.20.0
on a kind cluster.

- **remote-mcp-proxy**: Fix `tokenURL`/`clientID` casing to
  `tokenUrl`/`clientId` in MCPExternalAuthConfig example (lines 397-398)
- **remote-mcp-proxy**: Fix `groupRef` from string to object format
  `{name: ...}` (line 786)
- **deploy-operator**: Update kubectl CRD install/upgrade/uninstall
  lists from v0.12.1 to v0.20.0 and add 3 missing CRDs
  (`mcpoidcconfigs`, `mcpserverentries`, `mcptelemetryconfigs`)
- **run-mcp-k8s**: Update health check in troubleshooting to show JSON
  response format (`curl -s ... | jq .status`)

## Test plan

- [x] Tested deploy-operator end-to-end (Helm install CRDs + operator)
- [x] Tested run-mcp-k8s end-to-end (apply MCPServer, status, health)
- [x] Dry-run validated all connect-clients YAML (no issues found)
- [x] Dry-run validated all remote-mcp-proxy YAML (3 blocking issues fixed)

Full test results in `TEST_RESULTS_K8S_GUIDES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)