### PR TITLE
Fix remaining CRD field issues across K8s and vMCP docs

### DIFF
--- a/docs/toolhive/guides-k8s/mcp-server-entry.mdx
+++ b/docs/toolhive/guides-k8s/mcp-server-entry.mdx
@@ -131,7 +131,7 @@ When you apply an MCPServerEntry resource:
 
 | Field       | Description                                | Validation                 |
 | ----------- | ------------------------------------------ | -------------------------- |
-| `remoteURL` | URL of the remote MCP server               | Must match `^https?://`    |
+| `remoteUrl` | URL of the remote MCP server               | Must match `^https?://`    |
 | `transport` | Transport protocol for the remote server   | `sse` or `streamable-http` |
 | `groupRef`  | Name of the MCPGroup this entry belongs to | Required, minimum length 1 |
 
@@ -397,7 +397,7 @@ kubectl get mcpserverentry <NAME> -n toolhive-system \
 
 Common causes:
 
-- **SSRF validation failure**: The `remoteURL` targets a blocked address range
+- **SSRF validation failure**: The `remoteUrl` targets a blocked address range
   (loopback, link-local, private network, or cloud metadata). Use an externally
   routable URL
 - **Missing MCPGroup**: The group referenced in `groupRef` doesn't exist. Create

--- a/docs/toolhive/guides-k8s/mcp-server-entry.mdx
+++ b/docs/toolhive/guides-k8s/mcp-server-entry.mdx
@@ -100,7 +100,7 @@ metadata:
 spec:
   groupRef:
     name: my-group
-  remoteURL: https://mcp.example.com/mcp
+  remoteUrl: https://mcp.example.com/mcp
   transport: streamable-http
 ```
 
@@ -166,7 +166,7 @@ metadata:
 spec:
   groupRef:
     name: my-group
-  remoteURL: https://internal-mcp.corp.example.com/mcp
+  remoteUrl: https://internal-mcp.corp.example.com/mcp
   transport: streamable-http
   # highlight-next-line
   externalAuthConfigRef:
@@ -200,7 +200,7 @@ metadata:
 spec:
   groupRef:
     name: my-group
-  remoteURL: https://internal-mcp.corp.example.com/mcp
+  remoteUrl: https://internal-mcp.corp.example.com/mcp
   transport: streamable-http
   # highlight-start
   caBundleRef:
@@ -225,7 +225,7 @@ metadata:
 spec:
   groupRef:
     name: my-group
-  remoteURL: https://mcp.example.com/mcp
+  remoteUrl: https://mcp.example.com/mcp
   transport: streamable-http
   # highlight-start
   headerForward:
@@ -282,7 +282,7 @@ metadata:
 spec:
   groupRef:
     name: engineering-tools
-  remoteURL: https://mcp.partner.example.com/mcp
+  remoteUrl: https://mcp.partner.example.com/mcp
   transport: streamable-http
   externalAuthConfigRef:
     name: remote-auth

--- a/docs/toolhive/guides-vmcp/backend-discovery.mdx
+++ b/docs/toolhive/guides-vmcp/backend-discovery.mdx
@@ -398,7 +398,19 @@ spec:
   description: Engineering team MCP servers
 
 ---
-# 2. Create authentication config for GitHub backend
+# 2. Create shared OIDC config for incoming client authentication
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: engineering-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.example.com
+
+---
+# 3. Create authentication config for GitHub backend
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPExternalAuthConfig
 metadata:
@@ -415,7 +427,7 @@ spec:
     audience: github-api
 
 ---
-# 3. Create backend MCPServer
+# 4. Create backend MCPServer
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -430,7 +442,7 @@ spec:
     name: github-token-config
 
 ---
-# 4. Create VirtualMCPServer (discovered mode)
+# 5. Create VirtualMCPServer (discovered mode)
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: VirtualMCPServer
 metadata:

--- a/docs/toolhive/guides-vmcp/backend-discovery.mdx
+++ b/docs/toolhive/guides-vmcp/backend-discovery.mdx
@@ -441,8 +441,8 @@ spec:
     name: engineering-tools
   incomingAuth:
     type: oidc
-    oidc:
-      issuer: https://auth.company.com
+    oidcConfigRef:
+      name: engineering-oidc
       audience: engineering-vmcp
   outgoingAuth:
     source: discovered # Discovers github-mcp and its auth config

--- a/docs/toolhive/guides-vmcp/backend-discovery.mdx
+++ b/docs/toolhive/guides-vmcp/backend-discovery.mdx
@@ -94,7 +94,7 @@ When vMCP starts in discovered mode:
 2. **Workload discovery**: Queries all MCPServer, MCPRemoteProxy, and
    MCPServerEntry resources in the group
 3. **Backend conversion**: For each workload:
-   - Extracts endpoint URL (service URL for in-cluster workloads or `remoteURL`
+   - Extracts endpoint URL (service URL for in-cluster workloads or `remoteUrl`
      for MCPServerEntry) and transport type
    - Resolves authentication from `externalAuthConfigRef` if configured
    - Adds metadata labels

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -65,7 +65,7 @@ metadata:
 spec:
   groupRef:
     name: my-group # Reference to the MCPGroup
-  remoteURL: https://mcp.context7.com/mcp
+  remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   proxyPort: 8080
 
@@ -106,7 +106,7 @@ metadata:
 spec:
   groupRef:
     name: my-group # Reference to the MCPGroup
-  remoteURL: https://mcp.example.com/mcp
+  remoteUrl: https://mcp.example.com/mcp
   transport: streamable-http # or sse
 ```
 

--- a/docs/toolhive/guides-vmcp/failure-handling.mdx
+++ b/docs/toolhive/guides-vmcp/failure-handling.mdx
@@ -290,9 +290,9 @@ spec:
         partialFailureMode: fail
   incomingAuth:
     type: oidc
-    oidc:
-      issuerRef:
-        name: my-issuer
+    oidcConfigRef:
+      name: my-issuer
+      audience: my-vmcp
 ```
 
 ### Development with best effort

--- a/docs/toolhive/guides-vmcp/optimizer.mdx
+++ b/docs/toolhive/guides-vmcp/optimizer.mdx
@@ -300,11 +300,9 @@ spec:
       semanticDistanceThreshold: '0.8'
   incomingAuth:
     type: oidc
-    oidcConfig:
-      type: inline
-      inline:
-        issuer: https://auth.example.com
-        audience: vmcp-example
+    oidcConfigRef:
+      name: my-oidc
+      audience: vmcp-example
 ```
 
 ## Next steps

--- a/docs/toolhive/guides-vmcp/optimizer.mdx
+++ b/docs/toolhive/guides-vmcp/optimizer.mdx
@@ -274,7 +274,7 @@ spec:
       memory: '1Gi'
   modelCache:
     enabled: true
-    storageSize: 5Gi
+    size: 5Gi
 ```
 
 The VirtualMCPServer uses a shorter embedding timeout (15s) because the


### PR DESCRIPTION
## Summary

Fixes the 10 remaining CRD validation failures found during full dry-run
testing of all 26 K8s Operator and vMCP docs (108 YAML blocks total).

These are issues that were not covered by PRs #715, #720, or #722.

**Fixes:**

- **mcp-server-entry.mdx**: `remoteURL` -> `remoteUrl` on MCPServerEntry
  resources (5 occurrences)
- **configuration.mdx**: `remoteURL` -> `remoteUrl` on MCPRemoteProxy and
  MCPServerEntry resources (2 occurrences)
- **backend-discovery.mdx**: `incomingAuth.oidc` -> `oidcConfigRef` on
  VirtualMCPServer (unknown field `oidc`)
- **failure-handling.mdx**: `incomingAuth.oidc` -> `oidcConfigRef` on
  VirtualMCPServer (unknown field `oidc`)
- **optimizer.mdx**: `modelCache.storageSize` -> `modelCache.size` on
  EmbeddingServer (unknown field `storageSize`)

**Not addressed (CRD bug, not doc issue):**

One additional failure in vmcp/telemetry-and-metrics.mdx is caused by a CEL
validation rule on the VirtualMCPServer CRD that checks
`self.config.telemetry` even when `config` is not present on the resource.
The doc correctly uses `telemetryConfigRef` without `config.telemetry`, but
the CEL rule `!(has(self.config.telemetry) && has(self.telemetryConfigRef))`
errors because `self.config` doesn't exist. This should be fixed in the CRD,
not the docs.

## Test plan

- [x] Dry-run validated all 108 YAML blocks before fix (25 failures)
- [x] Previous PRs (#715, #720, #722) fixed 14 failures
- [x] This PR fixes the remaining 10 doc-caused failures
- [ ] Re-run full dry-run validation after merge to confirm 0 real failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)