### PR TITLE
Add documentation for ToolHive v0.21.0

### DIFF
--- a/docs/toolhive/_partials/_basic-cedar-config.mdx
+++ b/docs/toolhive/_partials/_basic-cedar-config.mdx
@@ -19,10 +19,17 @@ Here's an example in JSON format:
       "permit(principal, action == Action::\"call_tool\", resource) when { principal.claim_roles.contains(\"premium\") };",
       "permit(principal, action == Action::\"call_tool\", resource == Tool::\"calculator\") when { resource.arg_operation == \"add\" || resource.arg_operation == \"subtract\" };"
     ],
-    "entities_json": "[]"
+    "entities_json": "[]",
+    "group_claim_name": "",
+    "role_claim_name": ""
   }
 }
 ```
+
+Set `group_claim_name` to extract group membership from a custom JWT claim, and
+`role_claim_name` to extract role membership from a separate claim (for example,
+Entra ID `roles`). Leave both empty to use the
+[default claim resolution order](../reference/authz-policy-reference.mdx#how-groups-are-resolved).
 
 You can also define custom resource attributes in `entities_json` for per-tool
 ownership or sensitivity labels.

--- a/docs/toolhive/concepts/cedar-policies.mdx
+++ b/docs/toolhive/concepts/cedar-policies.mdx
@@ -110,6 +110,10 @@ cedar:
   - `entities_json`: A JSON string representing Cedar entities
   - `group_claim_name`: Optional custom JWT claim name for group membership (for
     example, `https://example.com/groups`)
+  - `role_claim_name`: Optional custom JWT claim name for role membership,
+    separate from group claims. Use this when your identity provider provides
+    roles in a different claim than groups (for example, Entra ID `roles`
+    claim). If not set, roles are extracted from the same claims as groups.
 
 ## Writing effective policies
 
@@ -182,6 +186,35 @@ permit(
 For details on how groups are resolved from JWT claims, see
 [Group membership](../reference/authz-policy-reference.mdx#group-membership) in
 the policy reference.
+
+### Server-scoped policies
+
+The Cedar authorizer automatically sets the server name for each MCP server,
+enabling policies that apply only to specific servers. Use the `MCP` entity type
+with the server name to scope policies:
+
+```text
+// Only allow the "data-team" group to call tools on the analytics server
+permit(
+  principal in THVGroup::"data-team",
+  action == Action::"call_tool",
+  resource in MCP::"analytics-server"
+);
+```
+
+```text
+// Deny all tool calls on the production server except for admins
+forbid(
+  principal,
+  action == Action::"call_tool",
+  resource in MCP::"production-server"
+) unless {
+  principal in THVGroup::"admins"
+};
+```
+
+Server-scoped policies are useful when a single Cedar policy set is shared
+across multiple MCP servers but you need different access levels per server.
 
 ### Attribute-based access control (ABAC)
 
@@ -503,6 +536,33 @@ configuration:
 When `group_claim_name` is set, it takes priority over the well-known defaults.
 When it is empty (the default), ToolHive checks `groups`, `roles`, and
 `cognito:groups` in order.
+
+### Configuring a custom role claim
+
+If your identity provider issues role claims in a separate JWT field from group
+claims, configure the `role_claim_name` field. This is common with providers
+like Microsoft Entra ID, which uses a dedicated `roles` claim for application
+roles:
+
+```json
+{
+  "version": "1.0",
+  "type": "cedarv1",
+  "cedar": {
+    "policies": [
+      "permit(principal in THVGroup::\"tool-users\", action, resource);"
+    ],
+    "entities_json": "[]",
+    "group_claim_name": "groups",
+    "role_claim_name": "roles"
+  }
+}
+```
+
+With both fields configured, ToolHive extracts group membership from the
+`groups` claim and role membership from the `roles` claim. Both are mapped to
+`THVGroup` parent entities, so you can write policies that reference either
+groups or roles using the same `principal in THVGroup::"..."` syntax.
 
 ### How it works
 

--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -374,23 +374,18 @@ Notice how the `devops-toolkit` group contains multiple servers that work
 together—GitHub for repository management and Heroku for
 deployment—demonstrating how groups can bundle related functionality.
 
-### Run registry groups
+### Use registry servers with groups
 
-You can run entire groups using the group command:
+You can organize registry servers into runtime groups after running them:
 
 ```bash
-# Run all servers in the devops-toolkit group (GitHub + Heroku)
-thv group run devops-toolkit
-
-# Run all servers in the testing-suite group
-thv group run testing-suite
-
-# You can also pass environment variables and secrets to specific servers in the group
-thv group run devops-toolkit --secret github-token,target=github.GITHUB_PERSONAL_ACCESS_TOKEN --secret heroku-key,target=heroku.HEROKU_API_KEY
+thv group create dev-toolkit
+thv run --group dev-toolkit github
+thv run --group dev-toolkit heroku
 ```
 
-Groups provide a convenient way to start multiple related servers with a single
-command.
+See [Group management](./group-management.mdx) for more details on creating and
+managing groups.
 
 ## Next steps
 

--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -384,8 +384,16 @@ thv run --group dev-toolkit github
 thv run --group dev-toolkit heroku
 ```
 
-See [Group management](./group-management.mdx) for more details on creating and
-managing groups.
+You can pass environment variables and secrets to each server individually:
+
+```bash
+thv run --group dev-toolkit --secret github-token,target=GITHUB_PERSONAL_ACCESS_TOKEN github
+thv run --group dev-toolkit --secret heroku-key,target=HEROKU_API_KEY heroku
+```
+
+Groups provide a convenient way to start multiple related servers with a single
+command. See [Group management](./group-management.mdx) for more details on
+creating and managing groups.
 
 ## Next steps
 

--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -67,26 +67,19 @@ Use `thv search <NAME>` or `thv registry list` to discover available servers.
 
 :::
 
-### Run registry groups
+### Run servers in a group
 
-If you use a [custom registry](./registry.mdx#use-a-custom-registry) that
-includes groups, you can run multiple related servers together as a unit. This
-is useful when you need several servers for a specific workflow or project:
-
-```bash
-thv group run <GROUP_NAME>
-```
-
-For example, to run all servers in a group called `dev-toolkit`:
+You can organize MCP servers into groups using `thv group create` and then run
+servers within a group:
 
 ```bash
-thv group run dev-toolkit
+thv group create my-group
+thv run --group my-group fetch
+thv run --group my-group github
 ```
 
-Running a group starts all servers defined within that group simultaneously,
-saving you from running each server individually. See
-[Registry groups](./registry.mdx#organize-servers-with-registry-groups) for more
-information about organizing servers into groups in your custom registry.
+See [Group management](./group-management.mdx) for more details on creating and
+managing groups.
 
 :::info[What's happening?]
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -200,32 +200,42 @@ column confirms validation passed.
 - **Lifecycle management**: deletion is blocked while workloads reference the
   config
 
-:::info[Inline oidcConfig deprecation]
+:::warning[Inline oidcConfig removed]
 
-The inline `spec.oidcConfig` field on MCPServer is deprecated and will be
-removed in `v1beta1`. Use `oidcConfigRef` to reference a shared MCPOIDCConfig
-resource instead. You cannot set both fields on the same MCPServer.
+The inline `spec.oidcConfig` field on MCPServer was removed in v0.21.0. Use
+`oidcConfigRef` to reference a shared MCPOIDCConfig resource instead.
 
 :::
 
 ## Set up external identity provider authentication
 
-:::note[Consider MCPOIDCConfig]
+:::info
 
-For new deployments, consider using `oidcConfigRef` with a shared MCPOIDCConfig
-resource instead of inline `oidcConfig`. See
+Create an MCPOIDCConfig resource and reference it with `oidcConfigRef`. See
 [Set up shared OIDC configuration](#set-up-shared-oidc-configuration-with-mcpoidcconfig)
 above.
 
 :::
 
-**Step 1: Create an MCPServer with external OIDC**
+**Step 1: Create an MCPOIDCConfig and MCPServer with external OIDC**
 
-Create an `MCPServer` resource configured to accept tokens from your external
-identity provider. The ToolHive proxy will handle authentication before
-forwarding requests to the MCP server.
+Create an `MCPOIDCConfig` resource with your external identity provider
+settings, and an `MCPServer` resource that references it. The ToolHive proxy
+handles authentication before forwarding requests to the MCP server.
 
 ```yaml title="mcp-server-external-auth.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: external-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: 'https://your-oidc-issuer.com'
+    clientId: 'your-client-id'
+    jwksUrl: 'https://your-oidc-issuer.com/path/to/jwks'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -239,13 +249,9 @@ spec:
     type: builtin
     name: network
   # Authentication configuration for external IdP
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: 'https://your-oidc-issuer.com'
-      audience: 'your-audience'
-      clientId: 'your-client-id'
-      jwksUrl: 'https://your-oidc-issuer.com/path/to/jwks'
+  oidcConfigRef:
+    name: external-oidc
+    audience: 'your-audience'
   resources:
     limits:
       cpu: '100m'
@@ -257,7 +263,7 @@ spec:
 
 Replace the OIDC placeholders with your actual identity provider configuration.
 
-**Step 2: Apply the MCPServer resource**
+**Step 2: Apply the resources**
 
 ```bash
 kubectl apply -f mcp-server-external-auth.yaml
@@ -284,34 +290,32 @@ For Kubernetes service accounts, tokens are automatically mounted at
 
 :::
 
-## Set up shared OIDC configuration with ConfigMap
+## Set up shared OIDC configuration
 
-**Step 1: Create OIDC ConfigMap**
-
-Create a ConfigMap containing the OIDC configuration:
+Create an MCPOIDCConfig resource to share OIDC settings across multiple
+MCPServer resources:
 
 ```yaml title="shared-oidc-config.yaml"
-apiVersion: v1
-kind: ConfigMap
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
 metadata:
-  name: shared-oidc-config
+  name: shared-oidc
   namespace: toolhive-system
-data:
-  issuer: 'https://auth.example.com'
-  audience: 'https://mcp.example.com'
-  clientId: 'shared-client-id'
-  jwksUrl: 'https://auth.example.com/.well-known/jwks.json'
+spec:
+  type: inline
+  inline:
+    issuer: 'https://auth.example.com'
+    clientId: 'shared-client-id'
+    jwksUrl: 'https://auth.example.com/.well-known/jwks.json'
 ```
 
 ```bash
 kubectl apply -f shared-oidc-config.yaml
 ```
 
-**Step 2: Reference ConfigMap in MCPServer**
+Reference the MCPOIDCConfig in your MCPServer resources:
 
-Create MCPServer resources that reference the shared configuration:
-
-```yaml title="mcp-server-with-configmap-oidc.yaml"
+```yaml title="mcp-server-with-shared-oidc.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -324,11 +328,9 @@ spec:
   permissionProfile:
     type: builtin
     name: network
-  # Reference shared OIDC configuration
-  oidcConfig:
-    type: configMap
-    configMap:
-      name: shared-oidc-config
+  oidcConfigRef:
+    name: shared-oidc
+    audience: 'https://mcp.example.com'
   resources:
     limits:
       cpu: '100m'
@@ -339,15 +341,16 @@ spec:
 ```
 
 ```bash
-kubectl apply -f mcp-server-with-configmap-oidc.yaml
+kubectl apply -f mcp-server-with-shared-oidc.yaml
 ```
 
-### Benefits of ConfigMap approach
+### Benefits of shared MCPOIDCConfig
 
-- **Centralized management**: Update OIDC settings in one place
-- **Consistency**: Ensure all MCPServers use identical authentication config
-- **GitOps friendly**: Manage configuration separately from MCPServer resources
-- **Multi-server deployments**: Deploy multiple servers with same auth easily
+- **Centralized management**: update OIDC settings in one place
+- **Consistency**: ensure all MCPServers use identical authentication config
+- **Built-in validation**: CEL rules catch misconfiguration at admission time
+- **Status tracking**: see which workloads reference the config
+- **Lifecycle management**: deletion is blocked while workloads reference it
 
 ## Set up Kubernetes service-to-service authentication
 
@@ -370,12 +373,23 @@ metadata:
 kubectl apply -f client-service-account.yaml
 ```
 
-**Step 2: Create MCPServer for service-to-service auth**
+**Step 2: Create MCPOIDCConfig and MCPServer for service-to-service auth**
 
-Create an `MCPServer` resource configured to accept Kubernetes service account
-tokens:
+Create an `MCPOIDCConfig` resource for Kubernetes service account authentication
+and an `MCPServer` that references it:
 
 ```yaml title="mcp-server-k8s-auth.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: k8s-sa-oidc
+  namespace: toolhive-system
+spec:
+  type: kubernetesServiceAccount
+  kubernetesServiceAccount:
+    serviceAccount: 'mcp-client'
+    namespace: 'client-apps'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -389,14 +403,9 @@ spec:
     type: builtin
     name: network
   # Authentication configuration for Kubernetes service accounts
-  oidcConfig:
-    type: kubernetes
-    kubernetes:
-      serviceAccount: 'mcp-client'
-      namespace: 'client-apps'
-      audience: 'toolhive'
-      issuer: 'https://kubernetes.default.svc'
-      jwksUrl: 'https://kubernetes.default.svc/openid/v1/jwks'
+  oidcConfigRef:
+    name: k8s-sa-oidc
+    audience: 'toolhive'
   resources:
     limits:
       cpu: '100m'
@@ -607,16 +616,27 @@ kubectl apply -f embedded-auth-config.yaml
 | `tokenLifespans`       | Configurable durations for access tokens (default: 1h), refresh tokens (default: 168h), and auth codes (default: 10m).                                                        |
 | `upstreamProviders`    | Configuration for upstream identity providers. MCPServer and MCPRemoteProxy support one provider; VirtualMCPServer supports multiple providers for sequential authentication. |
 
-**Step 5: Create the MCPServer resource**
+**Step 5: Create the MCPOIDCConfig and MCPServer resources**
 
 The MCPServer needs two configuration references: `authServerRef` enables the
-embedded authorization server, and `oidcConfig` validates the JWTs that the
-embedded authorization server issues. Unlike approaches 1-3 where `oidcConfig`
-points to an external identity provider, here it points to the embedded
-authorization server itself. The `oidcConfig` issuer must match the `issuer` in
+embedded authorization server, and `oidcConfigRef` validates the JWTs that the
+embedded authorization server issues. Unlike approaches 1-3 where the OIDC
+config points to an external identity provider, here it points to the embedded
+authorization server itself. The MCPOIDCConfig issuer must match the `issuer` in
 your `MCPExternalAuthConfig`.
 
 ```yaml title="mcp-server-embedded-auth.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: embedded-auth-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    # This must match the embedded authorization server issuer url
+    issuer: 'https://mcp.example.com'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -636,12 +656,9 @@ spec:
     name: embedded-auth-server
   # highlight-end
   # Validate JWTs issued by the embedded authorization server
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: embedded-auth-oidc
     resourceUrl: 'https://mcp.example.com/mcp'
-    inline:
-      # This must match the embedded authorization server issuer url
-      issuer: 'https://mcp.example.com'
   resources:
     limits:
       cpu: '100m'
@@ -672,10 +689,8 @@ spec:
   # Outgoing token exchange (e.g., AWS STS)
   externalAuthConfigRef:
     name: aws-sts-config
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: 'https://mcp.example.com'
+  oidcConfigRef:
+    name: embedded-auth-oidc
 ```
 
 For a complete example, see
@@ -685,11 +700,11 @@ For a complete example, see
 
 :::note
 
-The `oidcConfig` issuer must match the `issuer` in your `MCPExternalAuthConfig`.
-The embedded authorization server exposes a JWKS endpoint that the proxy uses to
-validate the JWTs it issues. The proxy also exposes OAuth discovery endpoints
-(`/.well-known/oauth-authorization-server`) so MCP clients can discover the
-authorization endpoints automatically.
+The MCPOIDCConfig issuer must match the `issuer` in your
+`MCPExternalAuthConfig`. The embedded authorization server exposes a JWKS
+endpoint that the proxy uses to validate the JWTs it issues. The proxy also
+exposes OAuth discovery endpoints (`/.well-known/oauth-authorization-server`) so
+MCP clients can discover the authorization endpoints automatically.
 
 :::
 
@@ -841,6 +856,17 @@ Add the authorization configuration to your `MCPServer` resources:
 
 ```yaml title="mcp-server-with-authz.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: k8s-sa-authz-oidc
+  namespace: toolhive-system
+spec:
+  type: kubernetesServiceAccount
+  kubernetesServiceAccount:
+    serviceAccount: 'mcp-client'
+    namespace: 'client-apps'
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: weather-server-with-authz
@@ -853,14 +879,9 @@ spec:
     type: builtin
     name: network
   # Authentication configuration
-  oidcConfig:
-    type: kubernetes
-    kubernetes:
-      serviceAccount: 'mcp-client'
-      namespace: 'client-apps'
-      audience: 'toolhive'
-      issuer: 'https://kubernetes.default.svc'
-      jwksUrl: 'https://kubernetes.default.svc/openid/v1/jwks'
+  oidcConfigRef:
+    name: k8s-sa-authz-oidc
+    audience: 'toolhive'
   # Authorization configuration
   authzConfig:
     type: configMap
@@ -992,6 +1013,8 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/name=weather-server-k8s
 - For external IdP: Ensure the issuer URL is accessible from within the cluster
 - For Kubernetes auth: Ensure the Kubernetes API server has OIDC enabled
 - Check that the JWKS URL returns valid keys
+- Verify the MCPOIDCConfig resource is valid:
+  `kubectl get mcpoidc -n toolhive-system`
 
 **Network connectivity:**
 
@@ -1047,9 +1070,9 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/name=weather-server-k8s
 
 **OIDC configuration mismatch:**
 
-- Ensure the `oidcConfig.inline.issuer` on your `MCPServer` matches the `issuer`
-  in your `MCPExternalAuthConfig`
-- Verify the `resourceUrl` in `oidcConfig` matches the external URL of the MCP
-  server
+- Ensure the MCPOIDCConfig issuer matches the `issuer` in your
+  `MCPExternalAuthConfig`
+- Verify the `resourceUrl` in `oidcConfigRef` matches the external URL of the
+  MCP server
 
 </details>

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -200,13 +200,6 @@ column confirms validation passed.
 - **Lifecycle management**: deletion is blocked while workloads reference the
   config
 
-:::warning[Inline oidcConfig removed]
-
-The inline `spec.oidcConfig` field on MCPServer was removed in v0.21.0. Use
-`oidcConfigRef` to reference a shared MCPOIDCConfig resource instead.
-
-:::
-
 ## Set up external identity provider authentication
 
 :::info

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -283,68 +283,6 @@ For Kubernetes service accounts, tokens are automatically mounted at
 
 :::
 
-## Set up shared OIDC configuration
-
-Create an MCPOIDCConfig resource to share OIDC settings across multiple
-MCPServer resources:
-
-```yaml title="shared-oidc-config.yaml"
-apiVersion: toolhive.stacklok.dev/v1alpha1
-kind: MCPOIDCConfig
-metadata:
-  name: shared-oidc
-  namespace: toolhive-system
-spec:
-  type: inline
-  inline:
-    issuer: 'https://auth.example.com'
-    clientId: 'shared-client-id'
-    jwksUrl: 'https://auth.example.com/.well-known/jwks.json'
-```
-
-```bash
-kubectl apply -f shared-oidc-config.yaml
-```
-
-Reference the MCPOIDCConfig in your MCPServer resources:
-
-```yaml title="mcp-server-with-shared-oidc.yaml"
-apiVersion: toolhive.stacklok.dev/v1alpha1
-kind: MCPServer
-metadata:
-  name: weather-server-shared-oidc
-  namespace: toolhive-system
-spec:
-  image: ghcr.io/stackloklabs/weather-mcp/server
-  transport: sse
-  proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
-  oidcConfigRef:
-    name: shared-oidc
-    audience: 'https://mcp.example.com'
-  resources:
-    limits:
-      cpu: '100m'
-      memory: '128Mi'
-    requests:
-      cpu: '50m'
-      memory: '64Mi'
-```
-
-```bash
-kubectl apply -f mcp-server-with-shared-oidc.yaml
-```
-
-### Benefits of shared MCPOIDCConfig
-
-- **Centralized management**: update OIDC settings in one place
-- **Consistency**: ensure all MCPServers use identical authentication config
-- **Built-in validation**: CEL rules catch misconfiguration at admission time
-- **Status tracking**: see which workloads reference the config
-- **Lifecycle management**: deletion is blocked while workloads reference it
-
 ## Set up Kubernetes service-to-service authentication
 
 This approach is ideal when you have client applications running in the same

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -658,6 +658,7 @@ spec:
   # Validate JWTs issued by the embedded authorization server
   oidcConfigRef:
     name: embedded-auth-oidc
+    audience: 'https://mcp.example.com/mcp'
     resourceUrl: 'https://mcp.example.com/mcp'
   resources:
     limits:

--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -232,21 +232,20 @@ authentication since the OAuth flow requires access to the `.well-known`
 endpoint for discovery.
 
 First, in the MCPServer spec for each server, ensure the `resourceUrl` property
-is set to the full client-facing URL:
+is set to the full client-facing URL via `oidcConfigRef`:
 
 ```yaml title="fetch-server-oauth.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 # ...
 spec:
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: my-oidc
     resourceUrl: https://mcp.example.com/<SERVER_NAME>/mcp
-    inline:
-      # ... other OIDC config ...
+    audience: my-audience
 ```
 
-The `inline.audience` value should match the audience expected by your identity
+The `audience` value should match the audience expected by your identity
 provider, and is likely the same for all servers using the same authorization
 server. See [Authentication and authorization](./auth-k8s.mdx) for full OIDC
 setup instructions.
@@ -491,21 +490,20 @@ authentication since the OAuth flow requires access to the `.well-known`
 endpoint for discovery.
 
 First, in the MCPServer spec for each server, ensure the `resourceUrl` property
-is set to the full client-facing URL:
+is set to the full client-facing URL via `oidcConfigRef`:
 
 ```yaml title="fetch-server-oauth.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 # ...
 spec:
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: my-oidc
     resourceUrl: https://mcp.example.com/<SERVER_NAME>/mcp
-    inline:
-      # ... other OIDC config ...
+    audience: my-audience
 ```
 
-The `inline.audience` value should match the audience expected by your identity
+The `audience` value should match the audience expected by your identity
 provider, and is likely the same for all servers using the same authorization
 server. See [Authentication and authorization](./auth-k8s.mdx) for full OIDC
 setup instructions.
@@ -972,7 +970,7 @@ curl https://mcp.example.com/.well-known/oauth-protected-resource/fetch/mcp
 kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
 
 # Verify the MCPServer OIDC configuration
-kubectl get mcpserver -n toolhive-system fetch -o yaml | grep -A15 oidcConfig
+kubectl get mcpserver -n toolhive-system fetch -o yaml | grep -A15 oidcConfigRef
 ```
 
 Common causes:
@@ -982,7 +980,7 @@ Common causes:
   `.well-known` path to the backend. See the "Path-based routing with OAuth" tab
   in the Ingress or Gateway API sections above for configuration examples.
 - **Missing or incorrect `resourceUrl`**: Ensure the `resourceUrl` in your
-  MCPServer's `oidcConfig` matches the client-facing URL (e.g.,
+  MCPServer's `oidcConfigRef` matches the client-facing URL (e.g.,
   `https://mcp.example.com/fetch/mcp` for path-based routing).
 - **Token validation failure**: The token's `aud` claim must match the
   configured audience in your MCPServer's OIDC configuration.

--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -99,18 +99,18 @@ To install the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you plan to use:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
 Replace `v0.21.0` in the commands above with your target CRD version.
@@ -337,18 +337,18 @@ To upgrade the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you want:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
 </TabItem>

--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -99,21 +99,21 @@ To install the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you plan to use:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
-Replace `v0.20.0` in the commands above with your target CRD version.
+Replace `v0.21.0` in the commands above with your target CRD version.
 
 </TabItem>
 </Tabs>
@@ -337,24 +337,24 @@ To upgrade the CRDs using `kubectl`, run the following, ensuring you only apply
 the CRDs you need for the features you want:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.20.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_embeddingservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpexternalauthconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpgroups.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpoidcconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpregistries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpremoteproxies.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpserverentries.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcpservers.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptelemetryconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_mcptoolconfigs.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpcompositetooldefinitions.yaml
+kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/crds/toolhive.stacklok.dev_virtualmcpservers.yaml
 ```
 
 </TabItem>
 </Tabs>
 
-Replace `v0.20.0` in the commands above with your target CRD version.
+Replace `v0.21.0` in the commands above with your target CRD version.
 
 ### Upgrade the operator Helm release
 

--- a/docs/toolhive/guides-k8s/intro.mdx
+++ b/docs/toolhive/guides-k8s/intro.mdx
@@ -87,12 +87,12 @@ server in vMCP discovery without the overhead of running a proxy pod.
 The operator also provides shared configuration CRDs that you reference from
 workload resources:
 
-| Resource                                                                                         | Purpose                                                                                                         |
-| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| [**MCPOIDCConfig**](./auth-k8s.mdx#set-up-shared-oidc-configuration-with-mcpoidcconfig)          | Shared OIDC authentication settings, referenced via `oidcConfigRef`                                             |
-| [**MCPTelemetryConfig**](./telemetry-and-metrics.mdx#shared-telemetry-configuration-recommended) | Shared telemetry/observability settings, referenced via `telemetryConfigRef`                                    |
-| [**MCPToolConfig**](./customize-tools.mdx)                                                       | Tool filtering and renaming, referenced via `toolConfigRef`                                                     |
-| [**MCPExternalAuthConfig**](./auth-k8s.mdx#set-up-embedded-authorization-server-authentication)  | Token exchange or embedded auth server configuration, referenced via `externalAuthConfigRef` or `authServerRef` |
+| Resource                                                                                        | Purpose                                                                                                         |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [**MCPOIDCConfig**](./auth-k8s.mdx#set-up-shared-oidc-configuration-with-mcpoidcconfig)         | Shared OIDC authentication settings, referenced via `oidcConfigRef`                                             |
+| [**MCPTelemetryConfig**](./telemetry-and-metrics.mdx#shared-telemetry-configuration)            | Shared telemetry/observability settings, referenced via `telemetryConfigRef`                                    |
+| [**MCPToolConfig**](./customize-tools.mdx)                                                      | Tool filtering and renaming, referenced via `toolConfigRef`                                                     |
+| [**MCPExternalAuthConfig**](./auth-k8s.mdx#set-up-embedded-authorization-server-authentication) | Token exchange or embedded auth server configuration, referenced via `externalAuthConfigRef` or `authServerRef` |
 
 ## Installation
 

--- a/docs/toolhive/guides-k8s/migrate-to-v1beta1.mdx
+++ b/docs/toolhive/guides-k8s/migrate-to-v1beta1.mdx
@@ -2,12 +2,12 @@
 title: Migrate to v1beta1
 description:
   Breaking changes and migration steps for the CRD API stabilization track from
-  v0.15.0 through v0.20.0
+  v0.15.0 through v0.21.0
 ---
 
 The ToolHive Kubernetes Operator has undergone a series of CRD API changes in
 preparation for the `v1beta1` API version promotion. These changes span releases
-v0.15.0 through v0.20.0, each introducing breaking changes that require manifest
+v0.15.0 through v0.21.0, each introducing breaking changes that require manifest
 and tooling updates.
 
 This guide covers every breaking change in order, so you can start from
@@ -46,20 +46,12 @@ that point forward.
 | v0.19.0 | [`enforceServers` removed](#enforceservers-removed)                                       | MCPRegistry                                                                   | Field removed from schema; manifests with it fail validation                                                                        |
 | v0.20.0 | [`groupRef` changed to typed struct](#groupref-changed-to-typed-struct)                   | MCPServer, MCPRemoteProxy, MCPServerEntry, VirtualMCPServer                   | Bare string `groupRef: name` must become `groupRef: { name: name }`                                                                 |
 | v0.20.0 | [`protectedResourceAllowPrivateIP` separated](#protectedresourceallowprivateip-separated) | VirtualMCPServer (OIDC config)                                                | Must be set explicitly; no longer inherited from `jwksAllowPrivateIP`                                                               |
-
-### Deprecations not yet removed
-
-These fields still work but will be removed at or after the `v1beta1` promotion.
-Migrate when convenient.
-
-| Deprecated field                            | Replacement                                    | Affected resources          | Deprecated in |
-| ------------------------------------------- | ---------------------------------------------- | --------------------------- | ------------- |
-| `spec.oidcConfig` (inline)                  | `spec.oidcConfigRef` (MCPOIDCConfig)           | MCPServer, VirtualMCPServer | v0.15.0       |
-| `spec.telemetry` (inline)                   | `spec.telemetryConfigRef` (MCPTelemetryConfig) | MCPServer                   | v0.15.0       |
-| `spec.telemetry` (inline)                   | `spec.telemetryConfigRef` (MCPTelemetryConfig) | MCPRemoteProxy              | v0.19.0       |
-| `backendAuthType: external_auth_config_ref` | `externalAuthConfigRef`                        | VirtualMCPServer            | v0.19.0       |
-| `spec.config.groupRef`                      | `spec.groupRef` (typed struct)                 | VirtualMCPServer            | v0.20.0       |
-| `spec.config.telemetry`                     | `spec.telemetryConfigRef`                      | VirtualMCPServer            | v0.20.0       |
+| v0.21.0 | [Inline `oidcConfig` removed](#inline-oidcconfig-removed)                                 | MCPServer, MCPRemoteProxy                                                     | `spec.oidcConfig` removed; use `oidcConfigRef` with MCPOIDCConfig                                                                   |
+| v0.21.0 | [Inline `telemetry` removed](#inline-telemetry-removed)                                   | MCPServer, MCPRemoteProxy                                                     | `spec.telemetry` removed; use `telemetryConfigRef` with MCPTelemetryConfig                                                          |
+| v0.21.0 | [Inline vMCP `oidcConfig` removed](#inline-vmcp-oidcconfig-removed)                       | VirtualMCPServer                                                              | `incomingAuth.oidcConfig` removed; use `oidcConfigRef`                                                                              |
+| v0.21.0 | [`config.groupRef` fallback removed](#configgroupref-fallback-removed)                    | VirtualMCPServer                                                              | `spec.config.groupRef` removed; use `spec.groupRef`                                                                                 |
+| v0.21.0 | [`external_auth_config_ref` enum removed](#external_auth_config_ref-enum-removed)         | VirtualMCPServer                                                              | Snake_case enum value removed; use `externalAuthConfigRef`                                                                          |
+| v0.21.0 | [Inline vMCP `telemetry` removed](#inline-vmcp-telemetry-removed)                         | VirtualMCPServer                                                              | `spec.config.telemetry` removed; use `spec.telemetryConfigRef`                                                                      |
 
 ## General upgrade procedure
 
@@ -562,6 +554,151 @@ spec:
         jwksAllowPrivateIP: true
         protectedResourceAllowPrivateIP: true
 ```
+
+## v0.21.0
+
+[Full release notes](https://github.com/stacklok/toolhive/releases/tag/v0.21.0)
+
+### Inline `oidcConfig` removed
+
+The inline `spec.oidcConfig` field has been removed from MCPServer and
+MCPRemoteProxy. Create an MCPOIDCConfig resource and reference it with
+`oidcConfigRef`.
+
+```yaml
+# Before (no longer accepted)
+spec:
+  oidcConfig:
+    type: inline
+    inline:
+      issuer: "https://idp.example.com"
+      audience: "my-audience"
+
+# After
+spec:
+  oidcConfigRef:
+    name: my-oidc-config
+    audience: "my-audience"
+```
+
+Create a shared MCPOIDCConfig resource:
+
+```yaml
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: my-oidc-config
+spec:
+  type: inline
+  inline:
+    issuer: 'https://idp.example.com'
+```
+
+### Inline `telemetry` removed
+
+The inline `spec.telemetry` field has been removed from MCPServer and
+MCPRemoteProxy. Create an MCPTelemetryConfig resource and reference it with
+`telemetryConfigRef`.
+
+```yaml
+# Before (no longer accepted)
+spec:
+  telemetry:
+    openTelemetry:
+      enabled: true
+      endpoint: "http://otel-collector:4318"
+      serviceName: "my-server"
+
+# After
+spec:
+  telemetryConfigRef:
+    name: my-telemetry
+    serviceName: "my-server"
+```
+
+Create a shared MCPTelemetryConfig resource:
+
+```yaml
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPTelemetryConfig
+metadata:
+  name: my-telemetry
+spec:
+  openTelemetry:
+    enabled: true
+    endpoint: 'http://otel-collector:4318'
+```
+
+### Inline vMCP `oidcConfig` removed
+
+The inline `spec.incomingAuth.oidcConfig` field has been removed from
+VirtualMCPServer. Use `oidcConfigRef` to reference a shared MCPOIDCConfig
+resource.
+
+```yaml
+# Before (no longer accepted)
+spec:
+  incomingAuth:
+    type: oidc
+    oidcConfig:
+      type: kubernetes
+      kubernetes:
+        audience: "toolhive"
+
+# After
+spec:
+  incomingAuth:
+    type: oidc
+    oidcConfigRef:
+      name: my-oidc-config
+      audience: "toolhive"
+```
+
+### `config.groupRef` fallback removed
+
+The `spec.config.groupRef` fallback path on VirtualMCPServer has been removed.
+Use `spec.groupRef` directly.
+
+```yaml
+# Before (no longer accepted)
+spec:
+  config:
+    group: "my-group"
+
+# After
+spec:
+  groupRef:
+    name: my-group
+```
+
+### `external_auth_config_ref` enum removed
+
+The snake_case `external_auth_config_ref` enum value in
+`outgoingAuth.backends[*].type` has been removed. Use the camelCase
+`externalAuthConfigRef` value.
+
+```yaml
+# Before (no longer accepted)
+outgoingAuth:
+  backends:
+    github-mcp:
+      type: external_auth_config_ref
+      externalAuthConfigRef:
+        name: github-token-config
+
+# After
+outgoingAuth:
+  backends:
+    github-mcp:
+      type: externalAuthConfigRef
+      externalAuthConfigRef:
+        name: github-token-config
+```
+
+### Inline vMCP `telemetry` removed
+
+The inline `spec.config.telemetry` field on VirtualMCPServer has been removed.
+Use `spec.telemetryConfigRef` to reference a shared MCPTelemetryConfig resource.
 
 ## Next steps
 

--- a/docs/toolhive/guides-k8s/migrate-to-v1beta1.mdx
+++ b/docs/toolhive/guides-k8s/migrate-to-v1beta1.mdx
@@ -584,7 +584,7 @@ spec:
 Create a shared MCPOIDCConfig resource:
 
 ```yaml
-apiVersion: toolhive.stacklok.com/v1alpha1
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPOIDCConfig
 metadata:
   name: my-oidc-config
@@ -619,7 +619,7 @@ spec:
 Create a shared MCPTelemetryConfig resource:
 
 ```yaml
-apiVersion: toolhive.stacklok.com/v1alpha1
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPTelemetryConfig
 metadata:
   name: my-telemetry
@@ -663,7 +663,8 @@ Use `spec.groupRef` directly.
 # Before (no longer accepted)
 spec:
   config:
-    group: "my-group"
+    groupRef:
+      name: my-group
 
 # After
 spec:

--- a/docs/toolhive/guides-k8s/rate-limiting.mdx
+++ b/docs/toolhive/guides-k8s/rate-limiting.mdx
@@ -23,11 +23,11 @@ request must pass all applicable limits to proceed.
 Before you begin, ensure you have:
 
 - A Kubernetes cluster with the ToolHive Operator installed
-- Redis deployed in your cluster — rate limiting stores token bucket counters in
+- Redis deployed in your cluster - rate limiting stores token bucket counters in
   Redis (see [Redis Sentinel session storage](./redis-session-storage.mdx) for
   deployment instructions)
-- For per-user limits: authentication enabled on the MCPServer (`oidcConfig`,
-  `oidcConfigRef`, or `externalAuthConfigRef`)
+- For per-user limits: authentication enabled on the MCPServer (`oidcConfigRef`
+  or `externalAuthConfigRef`)
 
 If you need help with these prerequisites, see:
 
@@ -93,17 +93,25 @@ users by the `sub` claim from their JWT token.
 
 ```yaml title="mcpserver-peruser-ratelimit.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: ratelimit-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://my-idp.example.com
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: weather-server
 spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: streamable-http
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://my-idp.example.com
-      audience: my-audience
+  oidcConfigRef:
+    name: ratelimit-oidc
+    audience: my-audience
   sessionStorage:
     provider: redis
     address: <YOUR_REDIS_ADDRESS>
@@ -125,17 +133,25 @@ throughput.
 
 ```yaml title="mcpserver-combined-ratelimit.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: ratelimit-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://my-idp.example.com
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: weather-server
 spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: streamable-http
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://my-idp.example.com
-      audience: my-audience
+  oidcConfigRef:
+    name: ratelimit-oidc
+    audience: my-audience
   sessionStorage:
     provider: redis
     address: <YOUR_REDIS_ADDRESS>
@@ -157,17 +173,25 @@ limits are enforced **in addition to** server-level limits.
 
 ```yaml title="mcpserver-pertool-ratelimit.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: ratelimit-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://my-idp.example.com
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
   name: weather-server
 spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: streamable-http
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://my-idp.example.com
-      audience: my-audience
+  oidcConfigRef:
+    name: ratelimit-oidc
+    audience: my-audience
   sessionStorage:
     provider: redis
     address: <YOUR_REDIS_ADDRESS>

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -744,14 +744,6 @@ When Prometheus is enabled, metrics are exposed at `/metrics` and include:
 - `toolhive_mcp_tool_calls_total` - Tool call operations
 - `toolhive_mcp_active_connections` - Number of active connections
 
-:::warning[Inline telemetry removed]
-
-The inline `spec.telemetry` field was removed in v0.21.0. Use
-`telemetryConfigRef` to reference a shared `MCPTelemetryConfig` resource
-instead.
-
-:::
-
 See [Telemetry and metrics](./telemetry-and-metrics.mdx) for more information.
 
 ## Use with Virtual MCP Server

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -240,21 +240,22 @@ The proxy automatically discovers the JWKS URL from the issuer's OIDC discovery
 endpoint (`/.well-known/openid-configuration`).
 
 </TabItem>
-<TabItem value='configmap' label='ConfigMap'>
+<TabItem value='k8s-sa' label='Kubernetes service account'>
 
-For more complex configurations or when you need to share OIDC settings across
-multiple proxies, use a ConfigMap:
+For in-cluster clients, create an MCPOIDCConfig that validates Kubernetes
+service account tokens:
 
-```yaml {21-24} title="oidc-config.yaml"
-apiVersion: v1
-kind: ConfigMap
+```yaml title="k8s-sa-oidc.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
 metadata:
-  name: company-oidc-config
+  name: k8s-sa-oidc
   namespace: toolhive-system
-data:
-  issuer: 'https://auth.company.com/realms/production'
-  audience: 'mcp-proxy'
-  clientId: 'mcp-proxy-client'
+spec:
+  type: kubernetesServiceAccount
+  kubernetesServiceAccount:
+    serviceAccount: mcp-client
+    namespace: client-apps
 ---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
@@ -263,10 +264,9 @@ metadata:
   namespace: toolhive-system
 spec:
   remoteUrl: https://mcp.analytics.example.com
-  oidcConfig:
-    type: configMap
-    configMap:
-      name: company-oidc-config
+  oidcConfigRef:
+    name: k8s-sa-oidc
+    audience: mcp-proxy
 ```
 
 </TabItem>

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -106,6 +106,19 @@ server with OIDC authentication:
 
 ```yaml title="analytics-proxy.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: analytics-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    # Your identity provider's issuer URL
+    issuer: https://auth.company.com/realms/production
+    # Optional: Client ID if using introspection
+    clientId: analytics-proxy
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
 metadata:
   name: analytics-proxy
@@ -121,15 +134,10 @@ spec:
   transport: streamable-http
 
   # OIDC authentication configuration
-  oidcConfig:
-    type: inline
-    inline:
-      # Your identity provider's issuer URL
-      issuer: https://auth.company.com/realms/production
-      # Expected audience claim in tokens
-      audience: analytics-mcp-proxy
-      # Optional: Client ID if using introspection
-      clientId: analytics-proxy
+  oidcConfigRef:
+    name: analytics-oidc
+    # Expected audience claim in tokens
+    audience: analytics-mcp-proxy
 
   # Authorization policies
   authzConfig:
@@ -192,29 +200,40 @@ When you apply an `MCPRemoteProxy` resource, here's what happens:
 
 ### Authentication configuration
 
-The `oidcConfig` field validates incoming tokens from users. The proxy supports
-multiple authentication methods:
+The `oidcConfigRef` field references an MCPOIDCConfig resource that validates
+incoming tokens from users. The proxy supports multiple authentication methods:
 
 <Tabs groupId='auth-method' queryString='auth-method'>
-<TabItem value='inline' label='Inline OIDC' default>
+<TabItem value='inline' label='MCPOIDCConfig (inline)' default>
 
-Inline OIDC configuration is the simplest approach and works with most identity
-providers:
+Create an MCPOIDCConfig resource with inline OIDC settings and reference it from
+the MCPRemoteProxy. This works with most identity providers:
 
-```yaml {4-6}
+```yaml {1-12,21-25}
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: company-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.company.com/realms/production
+    clientId: mcp-proxy-client
+    clientSecretRef:
+      name: mcp-proxy-secret
+      key: client-secret
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPRemoteProxy
+metadata:
+  name: my-proxy
+  namespace: toolhive-system
 spec:
   remoteUrl: https://mcp.example.com
-
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://auth.company.com/realms/production
-      audience: mcp-proxy
-      # Optional: For token introspection
-      clientId: mcp-proxy-client
-      clientSecretRef:
-        name: mcp-proxy-secret
-        key: client-secret
+  oidcConfigRef:
+    name: company-oidc
+    audience: mcp-proxy
 ```
 
 The proxy automatically discovers the JWKS URL from the issuer's OIDC discovery
@@ -275,8 +294,8 @@ This example shows different policy patterns:
 ```yaml {6-9}
 spec:
   remoteUrl: https://mcp.example.com
-  oidcConfig:
-    # ... OIDC config ...
+  oidcConfigRef:
+    # ... OIDC config ref ...
 
   authzConfig:
     type: inline
@@ -415,8 +434,8 @@ metadata:
   namespace: toolhive-system
 spec:
   remoteUrl: https://mcp.analytics.example.com
-  oidcConfig:
-    # ... Company IDP config ...
+  oidcConfigRef:
+    # ... Company IDP config ref ...
 
   externalAuthConfigRef:
     name: analytics-token-exchange
@@ -528,6 +547,16 @@ For testing and development, you can use the public MCP specification server:
 
 ```yaml title="mcp-spec-proxy.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: test-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.company.com/realms/test
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
 metadata:
   name: mcp-spec-proxy
@@ -538,11 +567,9 @@ spec:
   transport: streamable-http
 
   # For testing - use your IDP's configuration
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://auth.company.com/realms/test
-      audience: mcp-test
+  oidcConfigRef:
+    name: test-oidc
+    audience: mcp-test
 
   # Simple allow-all policy for testing
   authzConfig:
@@ -717,37 +744,13 @@ When Prometheus is enabled, metrics are exposed at `/metrics` and include:
 - `toolhive_mcp_tool_calls_total` - Tool call operations
 - `toolhive_mcp_active_connections` - Number of active connections
 
-### Inline telemetry configuration (deprecated)
+:::warning[Inline telemetry removed]
 
-:::warning[Deprecated]
-
-The inline `spec.telemetry` field is deprecated and will be removed in a future
-release. Use `telemetryConfigRef` to reference a shared `MCPTelemetryConfig`
-resource instead. You cannot set both fields on the same resource.
+The inline `spec.telemetry` field was removed in v0.21.0. Use
+`telemetryConfigRef` to reference a shared `MCPTelemetryConfig` resource
+instead.
 
 :::
-
-You can still configure telemetry inline using the `telemetry` field:
-
-```yaml {6-15}
-spec:
-  remoteUrl: https://mcp.example.com
-  # ... other config ...
-
-  telemetry:
-    prometheus:
-      enabled: true
-    openTelemetry:
-      enabled: true
-      endpoint: otel-collector.monitoring.svc.cluster.local:4318
-      insecure: true
-      serviceName: analytics-mcp-proxy
-      tracing:
-        enabled: true
-        samplingRate: '0.1'
-      metrics:
-        enabled: true
-```
 
 See [Telemetry and metrics](./telemetry-and-metrics.mdx) for more information.
 
@@ -761,9 +764,9 @@ container-based MCPServer resources into a single unified endpoint.
 
 vMCP can discover MCPRemoteProxy backends in a group, but authentication between
 vMCP and MCPRemoteProxy is not yet fully implemented. Since MCPRemoteProxy
-requires `oidcConfig` to validate incoming requests, and vMCP does not currently
-forward authentication tokens to backends, vMCP cannot communicate with
-MCPRemoteProxy backends that require authentication.
+requires `oidcConfigRef` to validate incoming requests, and vMCP does not
+currently forward authentication tokens to backends, vMCP cannot communicate
+with MCPRemoteProxy backends that require authentication.
 
 This limitation will be addressed in a future release. For now, MCPRemoteProxy
 works best when accessed directly by clients rather than through vMCP
@@ -778,6 +781,16 @@ To include a remote proxy in an MCPGroup for future vMCP aggregation, add the
 
 ```yaml
 apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: company-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.company.com
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
 metadata:
   name: context7-proxy
@@ -788,11 +801,9 @@ spec:
   remoteUrl: https://mcp.context7.com/mcp
   transport: streamable-http
   proxyPort: 8080
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://auth.company.com
-      audience: context7-proxy
+  oidcConfigRef:
+    name: company-oidc
+    audience: context7-proxy
 ```
 
 ### Planned benefits of vMCP aggregation
@@ -848,8 +859,8 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/instance=analytics-proxy
 
 Common causes:
 
-- **Invalid OIDC configuration**: Verify the issuer URL is accessible and
-  returns valid OIDC discovery metadata
+- **Invalid OIDC configuration**: Verify the MCPOIDCConfig resource is valid and
+  the issuer URL is accessible
 - **Certificate validation issues**: If using a custom CA, ensure `caBundleRef`
   is set correctly
 - **Resource limits**: Check if the pod has sufficient CPU and memory
@@ -870,7 +881,7 @@ Common causes:
 
 - **Missing audience claim**: Ensure tokens include the expected `aud` claim
 - **Token expired**: Check token expiration time
-- **Issuer mismatch**: Verify token `iss` claim matches `oidcConfig.issuer`
+- **Issuer mismatch**: Verify token `iss` claim matches the MCPOIDCConfig issuer
 - **JWKS fetch failure**: Check proxy can reach the OIDC provider's JWKS
   endpoint
 

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -19,10 +19,18 @@ the [observability overview](../concepts/observability.mdx).
 
 ## Enable telemetry
 
-There are two ways to configure telemetry: a shared `MCPTelemetryConfig`
-resource (recommended) or inline `spec.telemetry` on each MCPServer.
+The recommended way to configure telemetry is with a shared `MCPTelemetryConfig`
+resource referenced by `telemetryConfigRef` on each MCPServer or MCPRemoteProxy.
 
-### Shared telemetry configuration (recommended)
+:::warning[Inline telemetry removed]
+
+The inline `spec.telemetry` field on `MCPServer` and `MCPRemoteProxy` was
+removed in v0.21.0. Use `telemetryConfigRef` to reference a shared
+`MCPTelemetryConfig` resource instead.
+
+:::
+
+### Shared telemetry configuration
 
 The `MCPTelemetryConfig` CRD lets you define telemetry settings once and
 reference them from multiple MCPServer resources. Each server can override its
@@ -191,52 +199,10 @@ spec:
 
 :::note
 
-`caBundleRef` cannot be used when `insecure` is set to `true` — they are
+`caBundleRef` cannot be used when `insecure` is set to `true` - they are
 mutually exclusive.
 
 :::
-
-### Inline telemetry configuration
-
-:::warning[Deprecated]
-
-The inline `spec.telemetry` field on `MCPServer` and `MCPRemoteProxy` is
-deprecated and will be removed in a future release. Use `telemetryConfigRef` to
-reference a shared `MCPTelemetryConfig` resource instead. You cannot set both
-fields on the same resource.
-
-:::
-
-To enable telemetry inline, specify the configuration directly in the MCPServer
-or MCPRemoteProxy custom resource. The inline fields mirror the shared
-`MCPTelemetryConfig` structure under `spec.telemetry`:
-
-```yaml
-apiVersion: toolhive.stacklok.dev/v1alpha1
-kind: MCPServer # or MCPRemoteProxy
-metadata:
-  name: gofetch
-  namespace: toolhive-system
-spec:
-  image: ghcr.io/stackloklabs/gofetch/server
-  transport: streamable-http
-  proxyPort: 8080
-  mcpPort: 8080
-  # ... other spec fields ...
-  telemetry:
-    openTelemetry:
-      enabled: true
-      endpoint: otel-collector-opentelemetry-collector.monitoring.svc.cluster.local:4318
-      serviceName: mcp-fetch-server
-      insecure: true
-      metrics:
-        enabled: true
-      tracing:
-        enabled: true
-        samplingRate: '0.05'
-    prometheus:
-      enabled: true
-```
 
 ## Observability backends
 
@@ -249,8 +215,7 @@ will vary based on your environment and requirements.
 
 The backend examples below use `MCPTelemetryConfig` resources. Reference them
 from your MCPServer resources using `telemetryConfigRef` as shown in the
-[shared telemetry configuration](#shared-telemetry-configuration-recommended)
-section above.
+[shared telemetry configuration](#shared-telemetry-configuration) section above.
 
 :::
 

--- a/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-k8s/telemetry-and-metrics.mdx
@@ -22,14 +22,6 @@ the [observability overview](../concepts/observability.mdx).
 The recommended way to configure telemetry is with a shared `MCPTelemetryConfig`
 resource referenced by `telemetryConfigRef` on each MCPServer or MCPRemoteProxy.
 
-:::warning[Inline telemetry removed]
-
-The inline `spec.telemetry` field on `MCPServer` and `MCPRemoteProxy` was
-removed in v0.21.0. Use `telemetryConfigRef` to reference a shared
-`MCPTelemetryConfig` resource instead.
-
-:::
-
 ### Shared telemetry configuration
 
 The `MCPTelemetryConfig` CRD lets you define telemetry settings once and

--- a/docs/toolhive/guides-k8s/token-exchange-k8s.mdx
+++ b/docs/toolhive/guides-k8s/token-exchange-k8s.mdx
@@ -116,9 +116,21 @@ receives a fresh, properly scoped token for every call.
 
 ## Deploy an MCP server with token exchange
 
-Create an `MCPServer` resource that references the token exchange configuration:
+Create an `MCPOIDCConfig` resource and an `MCPServer` resource that references
+both the OIDC configuration and the token exchange configuration:
 
 ```yaml title="mcpserver-token-exchange.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: token-exchange-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: '<YOUR_OIDC_ISSUER>'
+    jwksUrl: '<YOUR_JWKS_URL>'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -132,12 +144,9 @@ spec:
   externalAuthConfigRef:
     name: backend-token-exchange
   # OIDC configuration for validating incoming client tokens
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: '<YOUR_OIDC_ISSUER>'
-      audience: '<YOUR_MCP_AUDIENCE>'
-      jwksUrl: '<YOUR_JWKS_URL>'
+  oidcConfigRef:
+    name: token-exchange-oidc
+    audience: '<YOUR_MCP_AUDIENCE>'
 ```
 
 ```bash
@@ -145,7 +154,7 @@ kubectl apply -f mcpserver-token-exchange.yaml
 ```
 
 The `externalAuthConfigRef` tells ToolHive to use the token exchange
-configuration you created earlier. The `oidcConfig` validates incoming client
+configuration you created earlier. The `oidcConfigRef` validates incoming client
 tokens before performing the exchange.
 
 ## Verify the configuration
@@ -213,9 +222,20 @@ spec:
       - 'api:write'
 ```
 
-### MCPServer
+### MCPOIDCConfig and MCPServer
 
 ```yaml title="mcpserver-okta.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: okta-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: 'https://dev-123456.okta.com/oauth2/aus1234567890'
+    jwksUrl: 'https://dev-123456.okta.com/oauth2/aus1234567890/v1/keys'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -227,22 +247,19 @@ spec:
   proxyPort: 8080
   externalAuthConfigRef:
     name: okta-backend-exchange
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: okta-oidc
     # Set resourceUrl to the external URL if exposing outside the cluster
     resourceUrl: 'https://my-backend-server.example.com'
-    inline:
-      issuer: 'https://dev-123456.okta.com/oauth2/aus1234567890'
-      audience: 'mcp-server'
-      jwksUrl: 'https://dev-123456.okta.com/oauth2/aus1234567890/v1/keys'
+    audience: 'mcp-server'
 ```
 
 Key points in this example:
 
-- **Two authorization servers**: The `issuer` in `oidcConfig` (`aus1234567890`)
-  validates incoming client tokens. The `tokenUrl` in `MCPExternalAuthConfig`
-  uses a different authorization server (`aus9876543210`) that issues tokens for
-  the backend API.
+- **Two authorization servers**: The `issuer` in `MCPOIDCConfig`
+  (`aus1234567890`) validates incoming client tokens. The `tokenUrl` in
+  `MCPExternalAuthConfig` uses a different authorization server
+  (`aus9876543210`) that issues tokens for the backend API.
 - **Audience transformation**: Client tokens arrive with audience `mcp-server`.
   ToolHive exchanges them for tokens with audience `backend-api`, which the
   backend service expects.

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -70,34 +70,54 @@ credentials.
 
 Validate tokens from an external identity provider:
 
+```yaml title="MCPOIDCConfig resource"
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: vmcp-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.example.com
+    clientId: <YOUR_CLIENT_ID>
+```
+
 ```yaml title="VirtualMCPServer resource"
 spec:
   incomingAuth:
     type: oidc
-    oidcConfig:
-      type: inline
-      inline:
-        issuer: https://auth.example.com
-        clientId: <YOUR_CLIENT_ID>
-        audience: vmcp
+    oidcConfigRef:
+      name: vmcp-oidc
+      audience: vmcp
 ```
 
 When using an identity provider that issues opaque OAuth tokens, add a
-`clientSecretRef` referencing a Kubernetes Secret to enable token introspection:
+`clientSecretRef` to the MCPOIDCConfig resource to enable token introspection:
+
+```yaml title="MCPOIDCConfig resource"
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: vmcp-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://auth.example.com
+    clientId: <YOUR_CLIENT_ID>
+    clientSecretRef:
+      name: oidc-client-secret
+      key: clientSecret
+```
 
 ```yaml title="VirtualMCPServer resource"
 spec:
   incomingAuth:
     type: oidc
-    oidcConfig:
-      type: inline
-      inline:
-        issuer: https://auth.example.com
-        clientId: <YOUR_CLIENT_ID>
-        audience: vmcp
-        clientSecretRef:
-          name: oidc-client-secret
-          key: clientSecret
+    oidcConfigRef:
+      name: vmcp-oidc
+      audience: vmcp
 ```
 
 Create the Secret:
@@ -117,14 +137,24 @@ stringData:
 
 Authenticate using Kubernetes service account tokens for in-cluster clients:
 
+```yaml title="MCPOIDCConfig resource"
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: vmcp-k8s-oidc
+  namespace: toolhive-system
+spec:
+  type: kubernetesServiceAccount
+  kubernetesServiceAccount:
+    audience: toolhive
+```
+
 ```yaml title="VirtualMCPServer resource"
 spec:
   incomingAuth:
     type: oidc
-    oidcConfig:
-      type: kubernetes
-      kubernetes:
-        audience: toolhive
+    oidcConfigRef:
+      name: vmcp-k8s-oidc
 ```
 
 This configuration uses the Kubernetes API server as the OIDC issuer and

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -71,7 +71,7 @@ credentials.
 Validate tokens from an external identity provider:
 
 ```yaml title="MCPOIDCConfig resource"
-apiVersion: toolhive.stacklok.com/v1alpha1
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPOIDCConfig
 metadata:
   name: vmcp-oidc
@@ -96,7 +96,7 @@ When using an identity provider that issues opaque OAuth tokens, add a
 `clientSecretRef` to the MCPOIDCConfig resource to enable token introspection:
 
 ```yaml title="MCPOIDCConfig resource"
-apiVersion: toolhive.stacklok.com/v1alpha1
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPOIDCConfig
 metadata:
   name: vmcp-oidc
@@ -138,15 +138,14 @@ stringData:
 Authenticate using Kubernetes service account tokens for in-cluster clients:
 
 ```yaml title="MCPOIDCConfig resource"
-apiVersion: toolhive.stacklok.com/v1alpha1
+apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPOIDCConfig
 metadata:
   name: vmcp-k8s-oidc
   namespace: toolhive-system
 spec:
   type: kubernetesServiceAccount
-  kubernetesServiceAccount:
-    audience: toolhive
+  kubernetesServiceAccount: {}
 ```
 
 ```yaml title="VirtualMCPServer resource"
@@ -155,6 +154,7 @@ spec:
     type: oidc
     oidcConfigRef:
       name: vmcp-k8s-oidc
+      audience: toolhive
 ```
 
 This configuration uses the Kubernetes API server as the OIDC issuer and

--- a/docs/toolhive/guides-vmcp/backend-discovery.mdx
+++ b/docs/toolhive/guides-vmcp/backend-discovery.mdx
@@ -164,7 +164,7 @@ spec:
     # highlight-end
     backends:
       github-mcp:
-        type: external_auth_config_ref
+        type: externalAuthConfigRef
         externalAuthConfigRef:
           name: github-token-config
 ```
@@ -501,7 +501,7 @@ kubectl get virtualmcpserver engineering-vmcp -n toolhive-system \
    ```
 
    Ensure all backends have `spec.groupRef` matching the VirtualMCPServer's
-   `spec.config.groupRef`.
+   `spec.groupRef`.
 
 3. **vMCP pod not restarted after backend changes**
 
@@ -692,10 +692,10 @@ spec:
 **Missing groupRef:**
 
 ```text
-Error: spec.config.groupRef is required
+Error: spec.groupRef is required
 ```
 
-**Fix:** Add `spec.config.groupRef` referencing an existing MCPGroup.
+**Fix:** Add `spec.groupRef` referencing an existing MCPGroup.
 
 **Invalid backend URL in inline mode:**
 

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -70,11 +70,9 @@ spec:
   proxyPort: 8080
 
   # Validate incoming requests
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: https://auth.company.com
-      audience: context7-proxy
+  oidcConfigRef:
+    name: company-oidc
+    audience: context7-proxy
 ```
 
 :::caution[Current limitation]

--- a/docs/toolhive/integrations/aws-sts.mdx
+++ b/docs/toolhive/integrations/aws-sts.mdx
@@ -358,6 +358,22 @@ roleMappings:
 Create an `MCPRemoteProxy` resource that points to the AWS MCP Server endpoint
 and references the authentication configuration from the previous step.
 
+First, create an MCPOIDCConfig resource with your identity provider settings:
+
+```yaml title="aws-mcp-oidc.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: aws-mcp-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: https://<YOUR_OIDC_ISSUER>
+```
+
+Then create the MCPRemoteProxy:
+
 ```yaml {7,10-11,14-19} title="aws-mcp-remote-proxy.yaml"
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPRemoteProxy
@@ -372,15 +388,13 @@ spec:
     name: aws-mcp-sts-auth
 
   # OIDC configuration for validating incoming client tokens
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: aws-mcp-oidc
+    audience: <YOUR_OIDC_AUDIENCE>
     # Public URL of this proxy's MCP endpoint, advertised to clients
     # via WWW-Authenticate so they can discover your OIDC provider.
     # Must match the hostname you configure in Step 5.
     resourceUrl: https://<YOUR_DOMAIN>/mcp
-    inline:
-      issuer: https://<YOUR_OIDC_ISSUER>
-      audience: <YOUR_OIDC_AUDIENCE>
 
   proxyPort: 8080
   transport: streamable-http
@@ -671,12 +685,9 @@ spec:
   # highlight-end
 
   # Validate JWTs issued by the embedded authorization server
-  oidcConfig:
-    type: inline
+  oidcConfigRef:
+    name: embedded-auth-oidc
     resourceUrl: https://<YOUR_DOMAIN>/mcp
-    inline:
-      # This must match the issuer in your embedded auth server config
-      issuer: https://<YOUR_EMBEDDED_AUTH_ISSUER>
 
   proxyPort: 8080
   transport: streamable-http
@@ -689,8 +700,8 @@ In this configuration:
 - `externalAuthConfigRef` points to the `MCPExternalAuthConfig` with
   `type: awsSts`, which exchanges OIDC tokens for AWS credentials on outgoing
   requests.
-- `oidcConfig` validates JWTs issued by the embedded auth server. The `issuer`
-  must match the `issuer` in your embedded auth server's
+- `oidcConfigRef` validates JWTs issued by the embedded auth server. Create an
+  MCPOIDCConfig whose `issuer` matches the embedded auth server's
   `MCPExternalAuthConfig`.
 
 :::info[authServerRef vs. externalAuthConfigRef]
@@ -801,7 +812,7 @@ kubectl logs -n toolhive-system \
 
 If clients receive 401 errors, the OIDC token validation is failing. Verify:
 
-- The `issuer` in `oidcConfig` matches the `iss` claim in your token.
+- The `issuer` in your MCPOIDCConfig matches the `iss` claim in your token.
 - The `audience` matches the `aud` claim.
 - The token hasn't expired (check the `exp` claim).
 - The proxy can reach your OIDC provider's JWKS endpoint from within the

--- a/docs/toolhive/integrations/okta.mdx
+++ b/docs/toolhive/integrations/okta.mdx
@@ -18,7 +18,7 @@ This tutorial uses Okta, but the pattern applies to any OIDC provider. Only Step
 and adding a groups claim to the token. If you use a different provider
 (Keycloak, Entra ID, Auth0, etc.), complete the equivalent setup in your
 provider, then pick up from [Step 2](#step-2-deploy-the-github-mcp-server)
-onward. The Kubernetes manifests, Cedar policies, and `oidcConfig` fields all
+onward. The Kubernetes manifests, Cedar policies, and `oidcConfigRef` fields all
 consume standard OIDC values regardless of which provider issued them.
 
 :::
@@ -178,11 +178,22 @@ kubectl logs -n toolhive-system deployment/toolhive-operator
 
 ## Step 3: Add Okta OIDC authentication
 
-Update the MCPServer to include an `oidcConfig` section. Replace the placeholder
-values with the configuration values you collected in
-[Step 1](#collect-your-configuration-values):
+Create an MCPOIDCConfig resource with your Okta OIDC settings, then update the
+MCPServer to reference it. Replace the placeholder values with the configuration
+values you collected in [Step 1](#collect-your-configuration-values):
 
 ```yaml title="github-mcpserver-oidc.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPOIDCConfig
+metadata:
+  name: okta-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: 'YOUR_ISSUER_URL'
+    jwksUrl: 'YOUR_JWKS_URL'
+---
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
@@ -196,12 +207,9 @@ spec:
       key: token
       targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
   # highlight-start
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: 'YOUR_ISSUER_URL'
-      audience: 'YOUR_AUDIENCE'
-      jwksUrl: 'YOUR_JWKS_URL'
+  oidcConfigRef:
+    name: okta-oidc
+    audience: 'YOUR_AUDIENCE'
   # highlight-end
   # ... resources same as before
 ```
@@ -299,12 +307,9 @@ spec:
     - name: github-pat
       key: token
       targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
-  oidcConfig:
-    type: inline
-    inline:
-      issuer: 'YOUR_ISSUER_URL'
-      audience: 'YOUR_AUDIENCE'
-      jwksUrl: 'YOUR_JWKS_URL'
+  oidcConfigRef:
+    name: okta-oidc
+    audience: 'YOUR_AUDIENCE'
   # highlight-start
   authzConfig:
     type: configMap
@@ -430,7 +435,7 @@ kubectl delete secret -n toolhive-system github-pat
 If clients can't authenticate:
 
 1. Check that the JWT is valid and not expired.
-2. Verify that the audience and issuer match your `oidcConfig` values.
+2. Verify that the audience and issuer match your MCPOIDCConfig values.
 3. Ensure the JWKS URL is accessible from within the cluster.
 4. Check the operator and proxy logs for specific errors:
 
@@ -481,7 +486,7 @@ policies if needed.
 </details>
 
 <details>
-<summary>401 after adding oidcConfig</summary>
+<summary>401 after adding OIDC configuration</summary>
 
 Verify that the issuer URL includes the full authorization server path. For the
 default Okta authorization server, the issuer URL should end with

--- a/docs/toolhive/reference/authz-policy-reference.mdx
+++ b/docs/toolhive/reference/authz-policy-reference.mdx
@@ -319,6 +319,30 @@ cedar:
   entities_json: '[]'
 ```
 
+### How roles are resolved
+
+In addition to group claims, ToolHive can extract role claims from a separate
+JWT field when `role_claim_name` is configured. This is useful when your
+identity provider separates group membership from application roles (for
+example, Microsoft Entra ID uses `groups` for directory groups and `roles` for
+app roles).
+
+When `role_claim_name` is set, ToolHive extracts the claim value and creates
+`THVGroup` parent entities for the principal, following the same pattern as
+group claims. Both groups and roles use the `THVGroup` entity type.
+
+### Server-scoped resources
+
+Each MCP server is automatically registered as an `MCP` entity. You can use this
+to write policies that restrict access to specific servers:
+
+```text
+resource in MCP::"my-server-name"
+```
+
+The server name matches the name of the MCPServer, MCPRemoteProxy, or container
+name in the ToolHive deployment.
+
 ## Argument preprocessing
 
 Tool and prompt arguments are converted to Cedar-compatible types with an `arg_`

--- a/docs/toolhive/tutorials/custom-registry.mdx
+++ b/docs/toolhive/tutorials/custom-registry.mdx
@@ -248,14 +248,16 @@ thv run my-fetch
 The server should start successfully, demonstrating that your custom registry is
 working correctly.
 
-Next, run the `dev-toolkit` group:
+Next, run the `fetch-tool` server from the `dev-toolkit` group using a runtime
+group:
 
 ```bash
-thv group run dev-toolkit
+thv group create dev-toolkit
+thv run --group dev-toolkit fetch-tool
 ```
 
-This starts all servers in the `dev-toolkit` group (in this case, just the
-`fetch-tool` server).
+This creates a runtime group called `dev-toolkit` and runs the `fetch-tool`
+server within it.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

- Update 20 documentation files for the ToolHive v0.21.0 release
- Document removal of previously deprecated CRD fields (inline `oidcConfig`, inline `telemetry`, `config.groupRef` fallback, `external_auth_config_ref` enum)
- Replace all inline `oidcConfig` / `telemetry` YAML examples across K8s, vMCP, and integration docs with the `oidcConfigRef` / `telemetryConfigRef` + shared resource pattern
- Remove `thv group run` registry-based group support from CLI docs; replace with `thv group create` + `thv run --group`
- Add Cedar `role_claim_name` documentation for separate IdP role extraction (e.g., Entra ID `roles` claim)
- Add Cedar server-scoped policy documentation (`resource in MCP::"server-name"`)
- Bump CRD install URLs from v0.20.0 to v0.21.0 in deploy-operator guide
- Update migration guide with v0.21.0 breaking changes section
- Fix pre-existing broken anchor in intro.mdx

### Files changed

**Migration & deployment (2 files)**
- `guides-k8s/migrate-to-v1beta1.mdx` - Added v0.21.0 section, moved deprecations to removed
- `guides-k8s/deploy-operator.mdx` - Version bump v0.20.0 → v0.21.0

**CLI docs (3 files)**
- `guides-cli/run-mcp-servers.mdx` - Replace `thv group run` with `thv group create` + `thv run --group`
- `guides-cli/registry.mdx` - Same
- `tutorials/custom-registry.mdx` - Same

**K8s docs (7 files)**
- `guides-k8s/auth-k8s.mdx` - Replace inline oidcConfig with MCPOIDCConfig + oidcConfigRef
- `guides-k8s/rate-limiting.mdx` - Same
- `guides-k8s/token-exchange-k8s.mdx` - Same
- `guides-k8s/remote-mcp-proxy.mdx` - Same + remove inline telemetry section
- `guides-k8s/connect-clients.mdx` - Same
- `guides-k8s/telemetry-and-metrics.mdx` - Remove inline telemetry, update deprecation notices
- `guides-k8s/intro.mdx` - Fix broken anchor

**vMCP docs (3 files)**
- `guides-vmcp/authentication.mdx` - Replace inline oidcConfig with MCPOIDCConfig + oidcConfigRef
- `guides-vmcp/backend-discovery.mdx` - Fix `external_auth_config_ref` → `externalAuthConfigRef`, update groupRef
- `guides-vmcp/configuration.mdx` - Replace inline oidcConfig

**Cedar docs (3 files)**
- `concepts/cedar-policies.mdx` - Add `role_claim_name`, server-scoped policies
- `reference/authz-policy-reference.mdx` - Add role resolution, server-scoped resources
- `_partials/_basic-cedar-config.mdx` - Add `role_claim_name` field

**Integration docs (2 files)**
- `integrations/okta.mdx` - Replace inline oidcConfig with MCPOIDCConfig + oidcConfigRef
- `integrations/aws-sts.mdx` - Same

## CRD dry-run validation

132 YAML blocks validated against v0.21.0 CRD schemas (`kubectl apply --dry-run=server`). No real failures.

| Doc | Section | Blocks | Pass | Fail | Expected | Skip |
|-----|---------|--------|------|------|----------|------|
| k8s-auth-k8s | K8s | 15 | 15 | 0 | 0 | 0 |
| k8s-connect-clients | K8s | 3 | 1 | **2** | 0 | 0 |
| k8s-customize-tools | K8s | 8 | 8 | 0 | 0 | 0 |
| k8s-logging | K8s | 3 | 0 | 0 | 3 | 0 |
| k8s-mcp-server-entry | K8s | 9 | 9 | 0 | 0 | 0 |
| k8s-migrate-to-v1beta1 | K8s | 3 | 3 | 0 | 0 | 0 |
| k8s-rate-limiting | K8s | 7 | 7 | 0 | 0 | 0 |
| k8s-redis-session-storage | K8s | 1 | 1 | 0 | 0 | 0 |
| k8s-remote-mcp-proxy | K8s | 15 | 15 | 0 | 0 | 0 |
| k8s-run-mcp-k8s | K8s | 5 | 5 | 0 | 0 | 0 |
| k8s-telemetry-and-metrics | K8s | 9 | 9 | 0 | 0 | 0 |
| k8s-token-exchange-k8s | K8s | 6 | 6 | 0 | 0 | 0 |
| vmcp-audit-logging | vMCP | 2 | 0 | 0 | 2 | 0 |
| vmcp-authentication | vMCP | 10 | 10 | 0 | 0 | 0 |
| vmcp-backend-discovery | vMCP | 7 | 7 | 0 | 0 | 0 |
| vmcp-composite-tools | vMCP | 2 | 1 | 0 | 1 | 0 |
| vmcp-configuration | vMCP | 7 | 6 | 0 | 1 | 0 |
| vmcp-failure-handling | vMCP | 4 | 4 | 0 | 0 | 0 |
| vmcp-optimizer | vMCP | 5 | 5 | 0 | 0 | 0 |
| vmcp-quickstart | vMCP | 4 | 4 | 0 | 0 | 0 |
| vmcp-telemetry-and-metrics | vMCP | 3 | 3 | 0 | 0 | 0 |
| vmcp-tool-aggregation | vMCP | 4 | 4 | 0 | 0 | 0 |
| **TOTAL** | | **132** | **123** | **2** | **7** | **0** |

The 2 failures in `k8s-connect-clients` are false positives - these are intentionally abbreviated snippets that use `# ...` as a YAML comment placeholder for the metadata section. The extractor sees `kind:` and `name:` (from `oidcConfigRef.name`) but there is no `metadata.name`, so kubectl rejects them. No schema issues.

## Test plan

- [x] `npm run build` passes with no new broken anchors
- [x] CRD dry-run validation passes (132 blocks, 0 real failures)
- [ ] Spot-check rendered pages in Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)