### PR TITLE
Document additionalAuthorizationParams with Google refresh-token example

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -587,10 +587,15 @@ spec:
           clientSecretRef:
             name: upstream-idp-secret
             key: client-secret
+          # Scopes must be set explicitly when using access_type=offline, to avoid
+          # sending the default offline_access scope alongside Google's
+          # access_type=offline mechanism (they serve the same purpose).
           scopes:
             - openid
-            - profile
             - email
+            - profile
+          additionalAuthorizationParams:
+            access_type: 'offline'
 ```
 
 ```bash
@@ -791,6 +796,41 @@ user identity fields. For example, GitHub returns `login` instead of the
 standard `name` field.
 
 :::
+
+### Upstream-specific authorization parameters
+
+Some identity providers require custom query parameters on the authorization URL
+that aren't part of the standard OAuth 2.0 or OIDC specs. The most common case
+is Google, which issues refresh tokens only when the authorization request
+includes `access_type=offline` - Google's non-standard alternative to the
+`offline_access` scope.
+
+To pass these parameters, set `additionalAuthorizationParams` on the
+`oidcConfig` or `oauth2Config` of an upstream provider:
+
+```yaml
+upstreamProviders:
+  - name: google
+    type: oidc
+    oidcConfig:
+      issuerUrl: 'https://accounts.google.com'
+      clientId: '<YOUR_GOOGLE_CLIENT_ID>'
+      clientSecretRef:
+        name: upstream-idp-secret
+        key: client-secret
+      scopes:
+        - openid
+        - email
+        - profile
+      additionalAuthorizationParams:
+        access_type: 'offline'
+```
+
+**Scope interaction:** When an OIDC upstream does not specify `scopes`
+explicitly, ToolHive sends the default `["openid", "offline_access"]`. If you're
+using `access_type=offline` for a provider that does not understand
+`offline_access` (such as Google), set `scopes` explicitly so the two mechanisms
+don't conflict.
 
 ## Set up authorization
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -808,7 +808,7 @@ includes `access_type=offline` - Google's non-standard alternative to the
 To pass these parameters, set `additionalAuthorizationParams` on the
 `oidcConfig` or `oauth2Config` of an upstream provider:
 
-```yaml
+```yaml title="upstreamProviders configuration block"
 upstreamProviders:
   - name: google
     type: oidc

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -832,6 +832,15 @@ using `access_type=offline` for a provider that does not understand
 `offline_access` (such as Google), set `scopes` explicitly so the two mechanisms
 don't conflict.
 
+**First consent only:** Google only issues a refresh token on the user's first
+consent. If users previously authorized the app without `access_type=offline`,
+they won't receive a refresh token until their current access token expires and
+they sign in again. To force re-consent immediately (for example, after losing
+refresh-token state), add `prompt: 'consent'` alongside `access_type: 'offline'`
+
+- Google then shows the consent screen on every login and re-issues a refresh
+  token each time.
+
 ## Set up authorization
 
 All authentication approaches can use the same authorization configuration using


### PR DESCRIPTION
### Description

Document the `additionalAuthorizationParams` field on upstream OIDC and OAuth 2.0 providers in the embedded authorization server. Google's `access_type=offline` mechanism is the motivating example — without it, Google won't issue refresh tokens even if `offline_access` is in the scopes.

Changes to `docs/toolhive/guides-k8s/auth-k8s.mdx`:

- Extend the existing Google OIDC example (Approach 5, Step 4) to include `additionalAuthorizationParams: access_type: 'offline'`, reorder scopes to `openid, email, profile`, and add a comment explaining why scopes must be set explicitly in this case.
- Add a new `### Upstream-specific authorization parameters` subsection at the end of Approach 5 with a standalone example and a "Scope interaction" note covering the default `offline_access` scope conflict.

The CRD reference page (`docs/toolhive/reference/crd-spec.md`) is autogenerated from the toolhive Go types, so it'll update automatically once stacklok/toolhive#4862 ships.

### Type of change

- Documentation update

### Related issues/PRs

Closes #726

Depends on stacklok/toolhive#4862 — **do not merge this PR until that change ships in a ToolHive release** so docs don't reference a field that isn't yet available to users.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)