### PR TITLE
Add Registry Server quickstart and document Helm deployment

### DIFF
--- a/docs/toolhive/guides-registry/deploy-helm.mdx
+++ b/docs/toolhive/guides-registry/deploy-helm.mdx
@@ -21,7 +21,7 @@ For alternative deployment approaches, see
   with your cluster
 - [Helm](https://helm.sh/docs/intro/install/) v3.10 or later (v3.14+ is
   recommended)
-- A PostgreSQL database
+- PostgreSQL 14 or later
 
 ## Overview
 

--- a/docs/toolhive/guides-registry/deploy-helm.mdx
+++ b/docs/toolhive/guides-registry/deploy-helm.mdx
@@ -1,0 +1,150 @@
+---
+title: Deploy with Helm
+description:
+  How to deploy the ToolHive Registry Server in Kubernetes using the official
+  Helm chart
+---
+
+:::info
+
+For alternative deployment approaches, see
+[Deploy with the ToolHive Operator](./deploy-operator.mdx) or
+[Deploy manually](./deploy-manual.mdx).
+
+:::
+
+## Prerequisites
+
+- A Kubernetes cluster (current and two previous minor versions are supported)
+- Permissions to create resources in the cluster
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
+  with your cluster
+- [Helm](https://helm.sh/docs/intro/install/) v3.10 or later (v3.14+ is
+  recommended)
+- A PostgreSQL database
+
+## Overview
+
+The official Helm chart in the
+[toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
+repository deploys a standalone Registry Server. Use this method when you want
+to manage the Registry Server like any other Helm release without installing the
+ToolHive Operator.
+
+## Install the chart
+
+Install the chart from its OCI registry into the `toolhive-system` namespace:
+
+```bash
+helm upgrade --install registry-server \
+  oci://ghcr.io/stacklok/toolhive-registry-server \
+  -n toolhive-system --create-namespace \
+  -f values.yaml
+```
+
+## Configure the Registry Server
+
+The chart's `config` block maps directly to the Registry Server's
+[configuration file](./configuration.mdx). Any valid configuration field can be
+set under `config` in your values file:
+
+```yaml title="values.yaml"
+config:
+  sources:
+    - name: toolhive
+      git:
+        repository: https://github.com/stacklok/toolhive-catalog.git
+        branch: main
+        path: pkg/catalog/toolhive/data/registry-upstream.json
+      syncPolicy:
+        interval: '30m'
+  registries:
+    - name: default
+      sources: ['toolhive']
+  auth:
+    mode: anonymous
+  database:
+    host: postgres
+    port: 5432
+    user: registry
+    database: registry
+    sslMode: require
+```
+
+## Provide database credentials
+
+Database credentials use the pgpass file pattern. Create a Kubernetes Secret
+with a
+[pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
+entry under the key `.pgpass`, then point the chart at it with an init container
+that prepares the file and a `PGPASSFILE` environment variable that tells libpq
+where to find it.
+
+The chart's main container runs with `readOnlyRootFilesystem: true` as the
+non-root UID `65535`, so the init container copies the Secret into an `emptyDir`
+volume and applies `0600` permissions (libpq rejects pgpass files with wider
+permissions):
+
+```yaml title="values.yaml (excerpt)"
+extraEnv:
+  - name: PGPASSFILE
+    value: /pgpass-prepared/.pgpass
+
+extraVolumes:
+  - name: pgpass-secret
+    secret:
+      secretName: registry-pgpass
+      defaultMode: 0600
+  - name: pgpass-prepared
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: pgpass-prepared
+    mountPath: /pgpass-prepared
+    readOnly: true
+
+initContainers:
+  - name: pgpass-init
+    image: cgr.dev/chainguard/busybox:latest
+    command:
+      - sh
+      - -c
+      - cp /pgpass-secret/.pgpass /pgpass-prepared/.pgpass && chmod 600
+        /pgpass-prepared/.pgpass
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65535
+    volumeMounts:
+      - name: pgpass-secret
+        mountPath: /pgpass-secret
+        readOnly: true
+      - name: pgpass-prepared
+        mountPath: /pgpass-prepared
+```
+
+The init container runs as the same UID as the main container, so the copied
+file is already owned by `65535` and the Registry Server can read it without a
+separate `chown` step. This matches the commented pgpass example in the chart's
+own
+[`values.yaml`](https://github.com/stacklok/toolhive-registry-server/blob/main/deploy/charts/toolhive-registry-server/values.yaml).
+
+## Next steps
+
+- [Configure sources and registries](./configuration.mdx) to set up your data
+  sources and sync policies
+- [Set up authentication](./authentication.mdx) to secure access to your
+  registry
+- [Configure telemetry](./telemetry-metrics.mdx) to monitor your deployment
+
+## Related information
+
+- [Database configuration](./database.mdx) for the pgpass format and user
+  privileges
+- [toolhive-registry-server repository](https://github.com/stacklok/toolhive-registry-server)
+  for the full set of chart values and their defaults
+- [Quickstart: Registry Server](./quickstart.mdx) for a hands-on walkthrough of
+  a minimal local deployment

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -5,18 +5,18 @@ description:
   operator, Helm, or raw manifests
 ---
 
-The Registry server can be deployed in Kubernetes using three methods. Choose
+The Registry Server can be deployed in Kubernetes using three methods. Choose
 the one that fits your environment:
 
-| Method                                           | Description                                                     |
-| ------------------------------------------------ | --------------------------------------------------------------- |
-| [ToolHive Operator](#toolhive-operator)          | Manage the Registry Server lifecycle through `MCPRegistry` CRDs |
-| [Helm](#helm)                                    | Deploy using the Registry Server Helm chart                     |
-| [Manual manifests](#manual-kubernetes-manifests) | Deploy directly using raw Kubernetes manifests                  |
+| Method                                           | Description                                                        |
+| ------------------------------------------------ | ------------------------------------------------------------------ |
+| [ToolHive Operator](#toolhive-operator)          | Manage the Registry Server lifecycle through `MCPRegistry` CRDs    |
+| [Helm](#helm)                                    | Deploy a standalone Registry Server using its dedicated Helm chart |
+| [Manual manifests](#manual-kubernetes-manifests) | Deploy directly using raw Kubernetes manifests                     |
 
 ## ToolHive Operator
 
-Deploy and manage the Registry server using `MCPRegistry` custom resources. The
+Deploy and manage the Registry Server using `MCPRegistry` custom resources. The
 ToolHive Operator watches for these resources and creates the necessary
 infrastructure automatically.
 
@@ -25,8 +25,89 @@ guide.
 
 ## Helm
 
-A Helm chart is available for the Registry Server. Documentation for this
-deployment method is coming soon.
+Deploy the Registry Server directly with the official Helm chart from the
+[toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
+repository. Use this method when you want to manage the Registry Server like any
+other Helm release without installing the ToolHive Operator.
+
+Install from the OCI registry:
+
+```bash
+helm upgrade --install registry-server \
+  oci://ghcr.io/stacklok/toolhive-registry-server \
+  -n toolhive-system --create-namespace \
+  -f values.yaml
+```
+
+The chart's `config` block maps directly to the Registry Server's
+[configuration file](./configuration.mdx). Any valid configuration field can be
+set under `config` in your values file:
+
+```yaml title="values.yaml"
+config:
+  sources:
+    - name: toolhive
+      git:
+        repository: https://github.com/stacklok/toolhive-catalog.git
+        branch: main
+        path: pkg/catalog/toolhive/data/registry-upstream.json
+      syncPolicy:
+        interval: '30m'
+  registries:
+    - name: default
+      sources: ['toolhive']
+  auth:
+    mode: anonymous
+  database:
+    host: postgres
+    port: 5432
+    user: registry
+    database: registry
+    sslMode: require
+```
+
+Database credentials use the pgpass file pattern. Create a Kubernetes Secret
+with a
+[pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
+entry, then mount it into the Registry Server pod using the chart's
+`extraVolumes`, `extraVolumeMounts`, and `initContainers` values:
+
+```yaml title="values.yaml (excerpt)"
+initContainers:
+  - name: pgpass-init
+    image: alpine:3
+    command:
+      - sh
+      - -c
+      - cp /pgpass/.pgpass /home/appuser/.pgpass && chmod 600
+        /home/appuser/.pgpass
+    volumeMounts:
+      - name: pgpass-secret
+        mountPath: /pgpass
+      - name: pgpass
+        mountPath: /home/appuser
+extraVolumes:
+  - name: pgpass-secret
+    secret:
+      secretName: registry-pgpass
+  - name: pgpass
+    emptyDir: {}
+extraVolumeMounts:
+  - name: pgpass
+    mountPath: /home/appuser
+```
+
+See [Database configuration](./database.mdx) for the pgpass format and user
+privileges, and the
+[toolhive-registry-server repository](https://github.com/stacklok/toolhive-registry-server)
+for the full set of chart values and their defaults.
+
+:::tip[Trying this out for the first time?]
+
+For a hands-on walkthrough that gets a Registry Server running end-to-end in a
+local cluster, see [Quickstart: Registry Server](./quickstart.mdx).
+
+:::
 
 ## Manual Kubernetes manifests
 

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -70,8 +70,12 @@ Database credentials use the pgpass file pattern. Create a Kubernetes Secret
 with a
 [pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
 entry, then mount it into the Registry Server pod using the chart's
-`extraVolumes`, `extraVolumeMounts`, and `initContainers` values:
+`extraVolumes`, `extraVolumeMounts`, and `initContainers` values. The init
+container copies the Secret into a shared `emptyDir`, sets the ownership to the
+non-root UID the Registry Server container runs as (`65532`), and applies `0600`
+permissions so the server can read the file:
 
+{/* prettier-ignore */}
 ```yaml title="values.yaml (excerpt)"
 initContainers:
   - name: pgpass-init
@@ -79,8 +83,7 @@ initContainers:
     command:
       - sh
       - -c
-      - cp /pgpass/.pgpass /home/appuser/.pgpass && chmod 600
-        /home/appuser/.pgpass
+      - cp /pgpass/.pgpass /home/appuser/.pgpass && chown 65532:65532 /home/appuser/.pgpass && chmod 600 /home/appuser/.pgpass
     volumeMounts:
       - name: pgpass-secret
         mountPath: /pgpass

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -69,36 +69,61 @@ config:
 Database credentials use the pgpass file pattern. Create a Kubernetes Secret
 with a
 [pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
-entry, then mount it into the Registry Server pod using the chart's
-`extraVolumes`, `extraVolumeMounts`, and `initContainers` values. The init
-container copies the Secret into a shared `emptyDir`, sets the ownership to the
-non-root UID the Registry Server container runs as (`65532`), and applies `0600`
-permissions so the server can read the file:
+entry under the key `.pgpass`, then point the chart at it with an init container
+that prepares the file and a `PGPASSFILE` environment variable that tells libpq
+where to find it.
 
-{/* prettier-ignore */}
+The chart's main container runs with `readOnlyRootFilesystem: true` as the
+non-root UID `65535`, so the init container copies the Secret into an `emptyDir`
+volume and applies `0600` permissions (libpq rejects pgpass files with wider
+permissions):
+
 ```yaml title="values.yaml (excerpt)"
-initContainers:
-  - name: pgpass-init
-    image: alpine:3
-    command:
-      - sh
-      - -c
-      - cp /pgpass/.pgpass /home/appuser/.pgpass && chown 65532:65532 /home/appuser/.pgpass && chmod 600 /home/appuser/.pgpass
-    volumeMounts:
-      - name: pgpass-secret
-        mountPath: /pgpass
-      - name: pgpass
-        mountPath: /home/appuser
+extraEnv:
+  - name: PGPASSFILE
+    value: /pgpass-prepared/.pgpass
+
 extraVolumes:
   - name: pgpass-secret
     secret:
       secretName: registry-pgpass
-  - name: pgpass
+      defaultMode: 0600
+  - name: pgpass-prepared
     emptyDir: {}
+
 extraVolumeMounts:
-  - name: pgpass
-    mountPath: /home/appuser
+  - name: pgpass-prepared
+    mountPath: /pgpass-prepared
+    readOnly: true
+
+initContainers:
+  - name: pgpass-init
+    image: cgr.dev/chainguard/busybox:latest
+    command:
+      - sh
+      - -c
+      - cp /pgpass-secret/.pgpass /pgpass-prepared/.pgpass && chmod 600
+        /pgpass-prepared/.pgpass
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65535
+    volumeMounts:
+      - name: pgpass-secret
+        mountPath: /pgpass-secret
+        readOnly: true
+      - name: pgpass-prepared
+        mountPath: /pgpass-prepared
 ```
+
+The init container runs as the same UID as the main container, so the copied
+file is already owned by `65535` and the Registry Server can read it without a
+separate `chown` step. This matches the commented pgpass example in the chart's
+own
+[`values.yaml`](https://github.com/stacklok/toolhive-registry-server/blob/main/deploy/charts/toolhive-registry-server/values.yaml).
 
 See [Database configuration](./database.mdx) for the pgpass format and user
 privileges, and the

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -8,11 +8,11 @@ description:
 The Registry Server can be deployed in Kubernetes using three methods. Choose
 the one that fits your environment:
 
-| Method                                           | Description                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------------ |
-| [ToolHive Operator](#toolhive-operator)          | Manage the Registry Server lifecycle through `MCPRegistry` CRDs    |
-| [Helm](#helm)                                    | Deploy a standalone Registry Server using its dedicated Helm chart |
-| [Manual manifests](#manual-kubernetes-manifests) | Deploy directly using raw Kubernetes manifests                     |
+| Method                                  | Description                                                        |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| [ToolHive Operator](#toolhive-operator) | Manage the Registry Server lifecycle through `MCPRegistry` CRDs    |
+| [Helm](#helm)                           | Deploy a standalone Registry Server using its dedicated Helm chart |
+| [Manual manifests](#manual-manifests)   | Deploy directly using raw Kubernetes manifests                     |
 
 ## ToolHive Operator
 
@@ -30,114 +30,9 @@ Deploy the Registry Server directly with the official Helm chart from the
 repository. Use this method when you want to manage the Registry Server like any
 other Helm release without installing the ToolHive Operator.
 
-Install from the OCI registry:
+See [Deploy with Helm](./deploy-helm.mdx) for a complete guide.
 
-```bash
-helm upgrade --install registry-server \
-  oci://ghcr.io/stacklok/toolhive-registry-server \
-  -n toolhive-system --create-namespace \
-  -f values.yaml
-```
-
-The chart's `config` block maps directly to the Registry Server's
-[configuration file](./configuration.mdx). Any valid configuration field can be
-set under `config` in your values file:
-
-```yaml title="values.yaml"
-config:
-  sources:
-    - name: toolhive
-      git:
-        repository: https://github.com/stacklok/toolhive-catalog.git
-        branch: main
-        path: pkg/catalog/toolhive/data/registry-upstream.json
-      syncPolicy:
-        interval: '30m'
-  registries:
-    - name: default
-      sources: ['toolhive']
-  auth:
-    mode: anonymous
-  database:
-    host: postgres
-    port: 5432
-    user: registry
-    database: registry
-    sslMode: require
-```
-
-Database credentials use the pgpass file pattern. Create a Kubernetes Secret
-with a
-[pgpass-formatted](https://www.postgresql.org/docs/current/libpq-pgpass.html)
-entry under the key `.pgpass`, then point the chart at it with an init container
-that prepares the file and a `PGPASSFILE` environment variable that tells libpq
-where to find it.
-
-The chart's main container runs with `readOnlyRootFilesystem: true` as the
-non-root UID `65535`, so the init container copies the Secret into an `emptyDir`
-volume and applies `0600` permissions (libpq rejects pgpass files with wider
-permissions):
-
-```yaml title="values.yaml (excerpt)"
-extraEnv:
-  - name: PGPASSFILE
-    value: /pgpass-prepared/.pgpass
-
-extraVolumes:
-  - name: pgpass-secret
-    secret:
-      secretName: registry-pgpass
-      defaultMode: 0600
-  - name: pgpass-prepared
-    emptyDir: {}
-
-extraVolumeMounts:
-  - name: pgpass-prepared
-    mountPath: /pgpass-prepared
-    readOnly: true
-
-initContainers:
-  - name: pgpass-init
-    image: cgr.dev/chainguard/busybox:latest
-    command:
-      - sh
-      - -c
-      - cp /pgpass-secret/.pgpass /pgpass-prepared/.pgpass && chmod 600
-        /pgpass-prepared/.pgpass
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop: [ALL]
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-      runAsUser: 65535
-    volumeMounts:
-      - name: pgpass-secret
-        mountPath: /pgpass-secret
-        readOnly: true
-      - name: pgpass-prepared
-        mountPath: /pgpass-prepared
-```
-
-The init container runs as the same UID as the main container, so the copied
-file is already owned by `65535` and the Registry Server can read it without a
-separate `chown` step. This matches the commented pgpass example in the chart's
-own
-[`values.yaml`](https://github.com/stacklok/toolhive-registry-server/blob/main/deploy/charts/toolhive-registry-server/values.yaml).
-
-See [Database configuration](./database.mdx) for the pgpass format and user
-privileges, and the
-[toolhive-registry-server repository](https://github.com/stacklok/toolhive-registry-server)
-for the full set of chart values and their defaults.
-
-:::tip[Trying this out for the first time?]
-
-For a hands-on walkthrough that gets a Registry Server running end-to-end in a
-local cluster, see [Quickstart: Registry Server](./quickstart.mdx).
-
-:::
-
-## Manual Kubernetes manifests
+## Manual manifests
 
 Deploy the Registry Server directly using raw Kubernetes manifests. This
 approach gives you full control over the deployment configuration.

--- a/docs/toolhive/guides-registry/index.mdx
+++ b/docs/toolhive/guides-registry/index.mdx
@@ -26,10 +26,13 @@ yourself. Looking for the built-in registry instead? See
 
 ## Where to start
 
+- **New to the Registry Server?** Follow the
+  [Registry Server quickstart](./quickstart.mdx) to get a working deployment on
+  a local Kubernetes cluster.
 - **Evaluating the Registry Server?** Read the [Introduction](./intro.mdx) for
   architecture, features, and supported registry source types.
-- **Ready to deploy?** See [Deployment overview](./deployment.mdx) to choose
-  between Kubernetes Operator and manual deployment methods.
+- **Ready to deploy?** See [Deploy the Registry Server](./deployment.mdx) to
+  choose between the Operator, Helm, and manual methods.
 - **Already running?** Jump to [Configuration](./configuration.mdx),
   [Authentication](./authentication.mdx), or
   [Authorization](./authorization.mdx).

--- a/docs/toolhive/guides-registry/quickstart.mdx
+++ b/docs/toolhive/guides-registry/quickstart.mdx
@@ -1,0 +1,423 @@
+---
+title: 'Quickstart: Registry Server'
+sidebar_label: Quickstart
+description:
+  Deploy the ToolHive Registry Server on a local Kubernetes cluster with a
+  file-based source and query its API.
+schema_type: tutorial
+---
+
+In this tutorial, you'll deploy the ToolHive Registry Server on a local
+Kubernetes cluster and query its API. By the end, you'll have a working Registry
+Server serving MCP server entries from a local file, with anonymous
+authentication for fast experimentation.
+
+This quickstart covers the standalone Registry Server that you host and curate
+yourself. If you're looking for the built-in catalog that ships with the
+ToolHive CLI and UI, see the [Introduction](./intro.mdx) for a comparison.
+
+## What you'll learn
+
+- How to install the ToolHive Operator, which bundles the `MCPRegistry` CRD
+- How to deploy a minimal PostgreSQL database for the Registry Server
+- How to define registry data in a ConfigMap using the
+  [upstream MCP registry format](../reference/registry-schema-upstream.mdx)
+- How to create an `MCPRegistry` resource that reads from that ConfigMap
+- How to query the Registry API
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- [Helm](https://helm.sh/docs/intro/install/) (v3.10 minimum, v3.14+
+  recommended)
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+- [Docker](https://docs.docker.com/get-docker/) or
+  [Podman](https://podman-desktop.io/downloads) running
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- Basic familiarity with Kubernetes concepts
+
+## Step 1: Create a kind cluster
+
+Create a local Kubernetes cluster named `registry-quickstart`:
+
+```bash
+kind create cluster --name registry-quickstart
+```
+
+Verify the cluster is running:
+
+```bash
+kubectl cluster-info
+```
+
+## Step 2: Install the ToolHive Operator
+
+The Registry Server is managed through the ToolHive Operator using `MCPRegistry`
+custom resources. Install the operator and its CRDs (which include
+`MCPRegistry`):
+
+```bash
+helm upgrade --install toolhive-operator-crds \
+  oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+```
+
+```bash
+helm upgrade --install toolhive-operator \
+  oci://ghcr.io/stacklok/toolhive/toolhive-operator \
+  -n toolhive-system --create-namespace
+```
+
+Wait for the operator pod to become ready:
+
+```bash
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=toolhive-operator \
+  -n toolhive-system --timeout=120s
+```
+
+:::info[What's happening?]
+
+The operator CRDs chart bundles `MCPRegistry` alongside the other ToolHive CRDs,
+so installing it makes the Registry Server resource type available in your
+cluster. The operator itself watches for `MCPRegistry` resources and provisions
+the Registry Server pod, service, and RBAC for each one.
+
+:::
+
+## Step 3: Deploy a PostgreSQL database
+
+The Registry Server requires a PostgreSQL database. For this quickstart, you
+deploy a minimal single-pod PostgreSQL instance in the `toolhive-system`
+namespace. This setup has no persistent storage or TLS, so don't use it for
+production workloads.
+
+Create a manifest that defines the credentials Secret, Deployment, and Service:
+
+```yaml title="postgres.yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: toolhive-system
+type: Opaque
+stringData:
+  POSTGRES_USER: registry
+  POSTGRES_PASSWORD: quickstart
+  POSTGRES_DB: registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: toolhive-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          envFrom:
+            - secretRef:
+                name: postgres-credentials
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ['pg_isready', '-U', 'registry', '-d', 'registry']
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: toolhive-system
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+```
+
+Apply the manifest and wait for the database to be ready:
+
+```bash
+kubectl apply -f postgres.yaml
+kubectl wait --for=condition=Ready pod -l app=postgres \
+  -n toolhive-system --timeout=120s
+```
+
+Create a pgpass Secret for the Registry Server to use when connecting:
+
+```bash
+kubectl create secret generic registry-pgpass \
+  -n toolhive-system \
+  --from-literal=.pgpass='postgres:5432:registry:registry:quickstart'
+```
+
+:::info[What's happening?]
+
+The Registry Server uses PostgreSQL's standard
+[pgpass](https://www.postgresql.org/docs/current/libpq-pgpass.html) file format
+for credentials. The line above maps to
+`hostname:port:database:username:password`. The operator mounts this Secret into
+the Registry Server pod and points the server at it automatically when you set
+`pgpassSecretRef` on the `MCPRegistry` resource.
+
+:::
+
+## Step 4: Define your registry data
+
+Define registry data in a ConfigMap. The Registry Server reads it through a
+file-based source. The ConfigMap uses the
+[upstream MCP registry format](../reference/registry-schema-upstream.mdx) with a
+single example server entry:
+
+```yaml title="registry-data.yaml"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-data
+  namespace: toolhive-system
+data:
+  registry.json: |
+    {
+      "version": "1.0.0",
+      "meta": {
+        "last_updated": "2026-04-21T00:00:00Z"
+      },
+      "data": {
+        "servers": [
+          {
+            "name": "io.github.stacklok/fetch",
+            "description": "Fetch web content for AI agents",
+            "title": "fetch",
+            "repository": {
+              "url": "https://github.com/stacklok/toolhive",
+              "source": "github"
+            },
+            "version": "1.0.0",
+            "packages": [
+              {
+                "registryType": "oci",
+                "identifier": "docker.io/mcp/fetch:latest",
+                "transport": {
+                  "type": "stdio"
+                }
+              }
+            ],
+            "_meta": {
+              "io.modelcontextprotocol.registry/publisher-provided": {
+                "io.github.stacklok": {
+                  "docker.io/mcp/fetch:latest": {
+                    "status": "Active",
+                    "tier": "Community",
+                    "tags": ["web", "fetch"],
+                    "tools": ["fetch"]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+```
+
+Apply the ConfigMap:
+
+```bash
+kubectl apply -f registry-data.yaml
+```
+
+## Step 5: Create an MCPRegistry resource
+
+Create an `MCPRegistry` that mounts the ConfigMap, reads from the file, and
+exposes the data through a registry named `default`:
+
+```yaml title="my-registry.yaml"
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPRegistry
+metadata:
+  name: my-registry
+  namespace: toolhive-system
+spec:
+  displayName: My Registry
+  pgpassSecretRef:
+    name: registry-pgpass
+    key: .pgpass
+  volumes:
+    - name: registry-data
+      configMap:
+        name: registry-data
+  volumeMounts:
+    - name: registry-data
+      mountPath: /data/registry
+      readOnly: true
+  configYAML: |
+    sources:
+      - name: local
+        file:
+          path: /data/registry/registry.json
+        syncPolicy:
+          interval: '15m'
+    registries:
+      - name: default
+        sources: ["local"]
+    auth:
+      mode: anonymous
+    database:
+      host: postgres
+      port: 5432
+      user: registry
+      database: registry
+      sslMode: disable
+```
+
+Apply the resource and wait for the Registry Server pod to become ready:
+
+```bash
+kubectl apply -f my-registry.yaml
+kubectl wait --for=condition=Ready pod \
+  -l app.kubernetes.io/instance=my-registry \
+  -n toolhive-system --timeout=180s
+```
+
+:::info[What's happening?]
+
+The operator reconciles the `MCPRegistry` resource and creates a Deployment that
+runs the Registry Server container. On startup, the server:
+
+1. Runs database migrations against the `registry` database
+2. Reads the registry JSON from the mounted ConfigMap
+3. Starts serving the MCP Registry API on port 8080
+
+The `auth.mode: anonymous` setting disables authentication entirely, which is
+appropriate for local experimentation. Never use anonymous mode in production.
+
+:::
+
+## Step 6: Query the Registry API
+
+The operator exposes each `MCPRegistry` through a Service named
+`<registry-name>-api`. For this quickstart, that's `my-registry-api`. Confirm it
+exists:
+
+```bash
+kubectl get svc my-registry-api -n toolhive-system
+```
+
+Port-forward the Service to your local machine. This command blocks, so leave it
+running and open a separate terminal for the curl commands below:
+
+```bash
+kubectl port-forward svc/my-registry-api 8080:8080 -n toolhive-system
+```
+
+In the separate terminal, list servers in the `default` registry:
+
+```bash
+curl -s http://localhost:8080/default/v0.1/servers | jq .
+```
+
+You should see a response containing the `io.github.stacklok/fetch` entry you
+defined in the ConfigMap.
+
+Fetch a specific entry by name. The `/` inside server names is part of the
+identifier (reverse-DNS convention), so URL-encode it as `%2F`:
+
+```bash
+curl -s http://localhost:8080/default/v0.1/servers/io.github.stacklok%2Ffetch \
+  | jq .
+```
+
+## Step 7: Clean up
+
+When you're done experimenting, delete the kind cluster to remove every resource
+you created:
+
+```bash
+kind delete cluster --name registry-quickstart
+```
+
+## Next steps
+
+You've deployed the Registry Server, defined a registry in a file, and queried
+the API. From here, explore the pieces you're most likely to need for a real
+deployment:
+
+- [Configure sources and registries](./configuration.mdx) to sync from Git
+  repositories, upstream APIs, or Kubernetes discovery instead of a single file
+- [Set up authentication](./authentication.mdx) with OAuth/OIDC to replace the
+  anonymous mode used here
+- [Deploy the Registry Server](./deployment.mdx) in production using the Helm
+  chart or raw manifests
+- [Configure the database](./database.mdx) for production, including separate
+  application and migration users, TLS, and persistent storage
+
+:::enterprise
+
+The Registry Server is available in both ToolHive Community and Stacklok
+Enterprise. Enterprise adds turnkey IdP integration (Okta, Entra ID),
+supply-chain-attested images, and SLA-backed support for teams running an
+internal MCP catalog at scale.
+
+[Learn more about Stacklok Enterprise](../enterprise.mdx).
+
+:::
+
+## Troubleshooting
+
+<details>
+<summary>MCPRegistry pod stuck in pending or crash-looping</summary>
+
+Check the Registry Server pod status and logs:
+
+```bash
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=my-registry
+kubectl logs -n toolhive-system -l app.kubernetes.io/instance=my-registry
+```
+
+The most common causes are database connectivity problems and malformed registry
+JSON. Verify that the `postgres` pod is ready and that the ConfigMap contains
+valid JSON.
+
+</details>
+
+<details>
+<summary>Empty response from the `/servers` endpoint</summary>
+
+Confirm the source synced successfully by describing the `MCPRegistry`:
+
+```bash
+kubectl describe mcpregistry my-registry -n toolhive-system
+```
+
+The status conditions report sync state. If the source reports a parse error,
+re-apply the ConfigMap with corrected JSON and wait for the next sync interval,
+or restart the pod to force an immediate sync.
+
+</details>
+
+<details>
+<summary>Operator pod not running</summary>
+
+If the operator pod never becomes ready, check its logs:
+
+```bash
+kubectl logs -n toolhive-system deployment/toolhive-operator
+```
+
+Make sure the operator CRDs chart was installed before the operator chart. The
+operator needs the CRDs to exist before it starts.
+
+</details>

--- a/docs/toolhive/guides-registry/quickstart.mdx
+++ b/docs/toolhive/guides-registry/quickstart.mdx
@@ -65,17 +65,6 @@ helm upgrade --install toolhive-operator-crds \
   -n toolhive-system --create-namespace
 ```
 
-:::warning[Namespace consistency]
-
-The CRDs chart stamps each CRD with a `meta.helm.sh/release-namespace`
-annotation set to the namespace used at install time. Future `helm upgrade`
-commands for the CRDs must use the same namespace, or the upgrade fails with an
-ownership error. See
-[Namespace consistency in the operator guide](../guides-k8s/deploy-operator.mdx)
-for details.
-
-:::
-
 ```bash
 helm upgrade --install toolhive-operator \
   oci://ghcr.io/stacklok/toolhive/toolhive-operator \
@@ -218,14 +207,14 @@ data:
             "description": "Fetch web content for AI agents",
             "title": "fetch",
             "repository": {
-              "url": "https://github.com/stacklok/toolhive",
+              "url": "https://github.com/StacklokLabs/gofetch",
               "source": "github"
             },
             "version": "1.0.0",
             "packages": [
               {
                 "registryType": "oci",
-                "identifier": "docker.io/mcp/fetch:latest",
+                "identifier": "ghcr.io/stackloklabs/gofetch/server:latest",
                 "transport": {
                   "type": "stdio"
                 }
@@ -234,7 +223,7 @@ data:
             "_meta": {
               "io.modelcontextprotocol.registry/publisher-provided": {
                 "io.github.stacklok": {
-                  "docker.io/mcp/fetch:latest": {
+                  "ghcr.io/stackloklabs/gofetch/server:latest": {
                     "status": "Active",
                     "tier": "Community",
                     "tags": ["web", "fetch"],
@@ -390,6 +379,14 @@ internal MCP catalog at scale.
 [Learn more about Stacklok Enterprise](../enterprise.mdx).
 
 :::
+
+## Related information
+
+- [Deploy the ToolHive Operator](../guides-k8s/deploy-operator.mdx) covers
+  production installation, upgrades, and namespace-consistency considerations
+  for the operator used in this quickstart
+- [Deploy the Registry Server](./deployment.mdx) compares the operator, Helm,
+  and manual deployment methods
 
 ## Troubleshooting
 

--- a/docs/toolhive/guides-registry/quickstart.mdx
+++ b/docs/toolhive/guides-registry/quickstart.mdx
@@ -61,8 +61,20 @@ custom resources. Install the operator and its CRDs (which include
 
 ```bash
 helm upgrade --install toolhive-operator-crds \
-  oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
+  oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
+  -n toolhive-system --create-namespace
 ```
+
+:::warning[Namespace consistency]
+
+The CRDs chart stamps each CRD with a `meta.helm.sh/release-namespace`
+annotation set to the namespace used at install time. Future `helm upgrade`
+commands for the CRDs must use the same namespace, or the upgrade fails with an
+ownership error. See
+[Namespace consistency in the operator guide](../guides-k8s/deploy-operator.mdx)
+for details.
+
+:::
 
 ```bash
 helm upgrade --install toolhive-operator \
@@ -92,7 +104,9 @@ the Registry Server pod, service, and RBAC for each one.
 The Registry Server requires a PostgreSQL database. For this quickstart, you
 deploy a minimal single-pod PostgreSQL instance in the `toolhive-system`
 namespace. This setup has no persistent storage or TLS, so don't use it for
-production workloads.
+production workloads. Production deployments should use separate application and
+migration users with distinct privileges. See
+[Database configuration](./database.mdx) for the production pattern.
 
 Create a manifest that defines the credentials Secret, Deployment, and Service:
 
@@ -328,7 +342,7 @@ kubectl port-forward svc/my-registry-api 8080:8080 -n toolhive-system
 In the separate terminal, list servers in the `default` registry:
 
 ```bash
-curl -s http://localhost:8080/default/v0.1/servers | jq .
+curl -s http://localhost:8080/registry/default/v0.1/servers | jq .
 ```
 
 You should see a response containing the `io.github.stacklok/fetch` entry you
@@ -338,7 +352,7 @@ Fetch a specific entry by name. The `/` inside server names is part of the
 identifier (reverse-DNS convention), so URL-encode it as `%2F`:
 
 ```bash
-curl -s http://localhost:8080/default/v0.1/servers/io.github.stacklok%2Ffetch \
+curl -s http://localhost:8080/registry/default/v0.1/servers/io.github.stacklok%2Ffetch \
   | jq .
 ```
 

--- a/docs/toolhive/guides-registry/quickstart.mdx
+++ b/docs/toolhive/guides-registry/quickstart.mdx
@@ -35,6 +35,8 @@ Before starting, make sure you have:
 - [Docker](https://docs.docker.com/get-docker/) or
   [Podman](https://podman-desktop.io/downloads) running
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [`jq`](https://jqlang.org/download/) for formatting the API responses in Step
+  6
 - Basic familiarity with Kubernetes concepts
 
 ## Step 1: Create a kind cluster

--- a/docs/toolhive/guides-registry/quickstart.mdx
+++ b/docs/toolhive/guides-registry/quickstart.mdx
@@ -354,6 +354,17 @@ you created:
 kind delete cluster --name registry-quickstart
 ```
 
+:::enterprise
+
+The Registry Server is available in both ToolHive Community and Stacklok
+Enterprise. Enterprise adds turnkey IdP integration (Okta, Entra ID),
+supply-chain-attested images, and SLA-backed support for teams running an
+internal MCP catalog at scale.
+
+[Learn more about Stacklok Enterprise](../enterprise.mdx).
+
+:::
+
 ## Next steps
 
 You've deployed the Registry Server, defined a registry in a file, and queried
@@ -368,17 +379,6 @@ deployment:
   chart or raw manifests
 - [Configure the database](./database.mdx) for production, including separate
   application and migration users, TLS, and persistent storage
-
-:::enterprise
-
-The Registry Server is available in both ToolHive Community and Stacklok
-Enterprise. Enterprise adds turnkey IdP integration (Okta, Entra ID),
-supply-chain-attested images, and SLA-backed support for teams running an
-internal MCP catalog at scale.
-
-[Learn more about Stacklok Enterprise](../enterprise.mdx).
-
-:::
 
 ## Related information
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -200,6 +200,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'toolhive/guides-registry/intro',
+        'toolhive/guides-registry/quickstart',
         'toolhive/guides-registry/deployment',
         'toolhive/guides-registry/deploy-operator',
         'toolhive/guides-registry/deploy-manual',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -203,6 +203,7 @@ const sidebars: SidebarsConfig = {
         'toolhive/guides-registry/quickstart',
         'toolhive/guides-registry/deployment',
         'toolhive/guides-registry/deploy-operator',
+        'toolhive/guides-registry/deploy-helm',
         'toolhive/guides-registry/deploy-manual',
         'toolhive/guides-registry/configuration',
         'toolhive/guides-registry/authentication',


### PR DESCRIPTION
## Summary

- Adds `docs/toolhive/guides-registry/quickstart.mdx`, a net-new tutorial that walks a reader from an empty local machine to a running Registry Server and a successful API query. Uses kind, a minimal single-pod PostgreSQL, a ConfigMap-based file source, and anonymous auth so there is no external infrastructure to set up.
- Replaces the "coming soon" placeholder in `deployment.mdx` with a real Helm section covering the chart's `config` block, a complete `values.yaml` excerpt for mounting the pgpass Secret via `initContainers`/`extraVolumes`/`extraVolumeMounts`, and a pointer to the chart repo.
- Adds the new quickstart to `sidebars.ts` and surfaces it as the first "Where to start" bullet in `guides-registry/index.mdx`.

Addresses the top two outstanding gaps in #364 (no quickstart and the Helm placeholder). The publishing guide and polish items are coming in follow-up PRs.

Relates to #364

## Test plan

- [x] \`npm run build\` - site builds cleanly (one pre-existing broken anchor on an unrelated page under /guides-ui/mcp-optimizer)
- [ ] Spot-check on \`npm run start\`: quickstart renders, sidebar order is correct, enterprise admonition renders correctly, code blocks have expected titles
- [ ] Walk the quickstart against a real kind cluster end-to-end (nice to have before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)