### PR TITLE
Polish Registry Server docs: requirements, upgrade, auth

### DIFF
--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -255,11 +255,11 @@ registry.
 
 ## Provider-specific examples
 
-Pick the provider you use and adapt the example. Expand each block to see the
+Pick the provider you use and adapt the example. Each tab includes the
 configuration and any notes specific to that provider.
 
-<details>
-<summary>Keycloak</summary>
+<Tabs groupId='idp' queryString='provider'>
+<TabItem value='keycloak' label='Keycloak' default>
 
 ```yaml
 auth:
@@ -275,10 +275,8 @@ auth:
 The `issuerUrl` should point to your Keycloak realm. The realm name is part of
 the URL path.
 
-</details>
-
-<details>
-<summary>Auth0</summary>
+</TabItem>
+<TabItem value='auth0' label='Auth0'>
 
 ```yaml
 auth:
@@ -294,10 +292,8 @@ auth:
 For Auth0, the `issuerUrl` is your Auth0 domain. The `audience` should match the
 API identifier configured in your Auth0 dashboard.
 
-</details>
-
-<details>
-<summary>Azure AD</summary>
+</TabItem>
+<TabItem value='azure-ad' label='Azure AD'>
 
 ```yaml
 auth:
@@ -313,10 +309,8 @@ auth:
 For Azure AD, the `issuerUrl` includes your tenant ID, and the `audience`
 typically uses the `api://` scheme with your application's client ID.
 
-</details>
-
-<details>
-<summary>Okta</summary>
+</TabItem>
+<TabItem value='okta' label='Okta'>
 
 ```yaml
 auth:
@@ -333,7 +327,8 @@ For Okta, the `issuerUrl` points to your Okta authorization server. Use
 `/oauth2/default` for the default authorization server or
 `/oauth2/YOUR_AUTH_SERVER_ID` for custom servers.
 
-</details>
+</TabItem>
+</Tabs>
 
 ## Anonymous authentication
 

--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -255,7 +255,11 @@ registry.
 
 ## Provider-specific examples
 
-### Keycloak
+Pick the provider you use and adapt the example. Expand each block to see the
+configuration and any notes specific to that provider.
+
+<details>
+<summary>Keycloak</summary>
 
 ```yaml
 auth:
@@ -271,7 +275,10 @@ auth:
 The `issuerUrl` should point to your Keycloak realm. The realm name is part of
 the URL path.
 
-### Auth0
+</details>
+
+<details>
+<summary>Auth0</summary>
 
 ```yaml
 auth:
@@ -287,7 +294,10 @@ auth:
 For Auth0, the `issuerUrl` is your Auth0 domain. The `audience` should match the
 API identifier configured in your Auth0 dashboard.
 
-### Azure AD
+</details>
+
+<details>
+<summary>Azure AD</summary>
 
 ```yaml
 auth:
@@ -303,7 +313,10 @@ auth:
 For Azure AD, the `issuerUrl` includes your tenant ID, and the `audience`
 typically uses the `api://` scheme with your application's client ID.
 
-### Okta
+</details>
+
+<details>
+<summary>Okta</summary>
 
 ```yaml
 auth:
@@ -319,6 +332,8 @@ auth:
 For Okta, the `issuerUrl` points to your Okta authorization server. Use
 `/oauth2/default` for the default authorization server or
 `/oauth2/YOUR_AUTH_SERVER_ID` for custom servers.
+
+</details>
 
 ## Anonymous authentication
 

--- a/docs/toolhive/guides-registry/database.mdx
+++ b/docs/toolhive/guides-registry/database.mdx
@@ -9,6 +9,13 @@ The Registry server requires a PostgreSQL database for storing registry state
 and metadata. This enables persistence across restarts and provides a foundation
 for advanced features.
 
+## Supported versions
+
+PostgreSQL 14 or later is required. The server runs database migrations
+automatically on startup, so the migration user needs schema-modification
+privileges. See [Migration user privileges](#migration-user-privileges) for the
+full privilege model.
+
 ## Configuration
 
 ### Basic database configuration

--- a/docs/toolhive/guides-registry/deploy-manual.mdx
+++ b/docs/toolhive/guides-registry/deploy-manual.mdx
@@ -365,6 +365,26 @@ this automatically.
 
 :::
 
+## Upgrade and migration
+
+To upgrade a manually-managed Registry Server, update the container image tag in
+your Deployment manifest and re-apply:
+
+```bash
+kubectl apply -f registry-deployment.yaml
+```
+
+Kubernetes performs a rolling update using the Deployment's configured strategy.
+The new pod runs database migrations on startup, so the migration user needs
+schema-modification privileges at the time of the upgrade. Review the
+[Registry Server release notes](https://github.com/stacklok/toolhive-registry-server/releases)
+before upgrading across a major version in case new required config fields or
+migration-user privileges are needed.
+
+If the new image introduces new configuration fields, update your ConfigMap and
+re-apply it before or alongside the Deployment change. See
+[Configuration](./configuration.mdx) for the current field reference.
+
 ## Next steps
 
 - [Configure sources and registries](./configuration.mdx) to set up your data

--- a/docs/toolhive/guides-registry/deploy-manual.mdx
+++ b/docs/toolhive/guides-registry/deploy-manual.mdx
@@ -7,18 +7,19 @@ description:
 
 :::info
 
-For an alternative deployment approach using Kubernetes custom resources, see
-[Deploy with the ToolHive Operator](./deploy-operator.mdx).
+For alternative deployment approaches, see
+[Deploy with the ToolHive Operator](./deploy-operator.mdx) or
+[Deploy with Helm](./deploy-helm.mdx).
 
 :::
 
 Below is an example Kubernetes Deployment configuring the ToolHive Registry
 Server to expose a single static registry based on a Git repository.
 
-This example assumes that a Postgres database is available at `db.example.com`
-and the necessary users for migration and application execution are configured
-and able to connect to a `registry` database. It also assumes that you have a
-keycloak instance configured to act as identity provider.
+This example assumes that a PostgreSQL 14 or later database is available at
+`db.example.com` and the necessary users for migration and application execution
+are configured and able to connect to a `registry` database. It also assumes
+that you have a keycloak instance configured to act as identity provider.
 
 All resources are created in the `toolhive-system` namespace. This namespace
 must exist before applying the deployment.

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -13,7 +13,7 @@ description:
   with your cluster
 - The ToolHive operator installed in your cluster (see
   [Deploy the operator](../guides-k8s/deploy-operator.mdx))
-- A PostgreSQL database
+- PostgreSQL 14 or later
 
 ## Overview
 

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -691,6 +691,27 @@ You can also use `kubectl wait` to wait for the registry to be ready:
 kubectl -n <NAMESPACE> wait --for=condition=Ready mcpregistry/<NAME>
 ```
 
+## Upgrade and migration
+
+Upgrading an operator-managed Registry Server happens in two layers:
+
+- **Operator**: upgrade the ToolHive operator and its CRDs chart with
+  `helm upgrade --install` as described in
+  [Deploy the operator](../guides-k8s/deploy-operator.mdx). Always upgrade the
+  CRDs chart before the operator chart so any new CRD fields are present by the
+  time the new operator reads them.
+- **Registry Server image**: the operator reconciles the Registry Server pod
+  image from the CRD. Update the image tag in your `MCPRegistry` resource (or
+  let the operator default to its bundled version), then apply the change. The
+  operator performs a rolling update of the underlying Deployment.
+
+Database migrations run automatically when the Registry Server pod starts, using
+the migration user declared in [database configuration](./database.mdx). Review
+the
+[Registry Server release notes](https://github.com/stacklok/toolhive-registry-server/releases)
+before upgrading across a major version in case new required config fields or
+migration-user privileges are needed.
+
 ## Next steps
 
 - [Configure authentication](./authentication.mdx) to secure access to your

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -61,6 +61,7 @@ Pick the deployment method that fits your environment and follow its guide:
 
 - [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a CRD-driven
   workflow
+- [Deploy with Helm](./deploy-helm.mdx) for a standalone chart-based install
 - [Deploy manually](./deploy-manual.mdx) for raw Kubernetes manifests
 
 Then configure the rest of the stack:

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -57,6 +57,14 @@ See [Deploy manually](./deploy-manual.mdx) for instructions.
 
 ## Next steps
 
+Pick the deployment method that fits your environment and follow its guide:
+
+- [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a CRD-driven
+  workflow
+- [Deploy manually](./deploy-manual.mdx) for raw Kubernetes manifests
+
+Then configure the rest of the stack:
+
 - [Configure sources and registries](./configuration.mdx) to set up your data
   sources and sync policies
 - [Set up authentication](./authentication.mdx) to secure access to your

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -5,6 +5,22 @@ description:
   operator, Helm, or raw manifests
 ---
 
+## System requirements
+
+- **Kubernetes**: current and two previous minor versions are supported.
+  Production workloads should run on a cluster with at least one node providing
+  1 vCPU and 1 GB of memory available for the Registry Server pod.
+- **PostgreSQL**: version 14 or later. The server runs database migrations
+  automatically on startup, so the migration user needs schema-modification
+  privileges. See [Database configuration](./database.mdx) for the full
+  user-privilege model.
+- **Persistent storage** (recommended for Git sources): a volume mounted at
+  `/data` avoids re-cloning repositories on every container restart.
+- **Network access**: outbound connectivity to your configured sources (Git
+  hosts, upstream registries, file URLs) and to the PostgreSQL server.
+
+## Deployment methods
+
 The Registry Server can be deployed in Kubernetes using three methods. Choose
 the one that fits your environment:
 

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -12,8 +12,9 @@ description:
   1 vCPU and 1 GB of memory available for the Registry Server pod.
 - **PostgreSQL**: version 14 or later. The server runs database migrations
   automatically on startup, so the migration user needs schema-modification
-  privileges. See [Database configuration](./database.mdx) for the full
-  user-privilege model.
+  privileges. See
+  [Migration user privileges](./database.mdx#migration-user-privileges) for the
+  full privilege model.
 - **Persistent storage** (recommended for Git sources): a volume mounted at
   `/data` avoids re-cloning repositories on every container restart.
 - **Network access**: outbound connectivity to your configured sources (Git

--- a/docs/toolhive/guides-registry/intro.mdx
+++ b/docs/toolhive/guides-registry/intro.mdx
@@ -32,9 +32,9 @@ The Registry Server is built around three core concepts:
   Sources produce entries; each entry belongs to exactly one source.
 - A **registry** is a named API surface that aggregates entries from one or more
   sources. Clients access entries through a registry name in the URL (for
-  example, `GET /default/v0.1/servers`). You can create multiple registries from
-  the same sources to serve different audiences or apply different access
-  controls.
+  example, `GET /registry/default/v0.1/servers`). You can create multiple
+  registries from the same sources to serve different audiences or apply
+  different access controls.
 
 ## How the Registry Server works
 

--- a/docs/toolhive/guides-registry/intro.mdx
+++ b/docs/toolhive/guides-registry/intro.mdx
@@ -111,9 +111,10 @@ The server supports five source types:
    - Does not support publishing
 
 3. **Kubernetes** - Automatically creates registry entries for running workloads
-   - Ideal to quickly grant access to running MCP servers to knowledge workers
-   - Useful for bigger organizations where MCP server developers differ from
-     users
+   - Ideal for surfacing running MCP servers to end users without manual
+     registration
+   - Useful for larger organizations where MCP server developers differ from
+     consumers
    - Does not support publishing
 
 4. **Git** - Clone and sync from Git repositories
@@ -125,6 +126,25 @@ The server supports five source types:
    - Ideal for local development and testing
    - Syncs both MCP servers and skills (upstream format)
    - Does not support publishing
+
+## Registry Server and the rest of ToolHive
+
+The Registry Server is a standalone service. It is separate from the built-in
+catalog that the ToolHive CLI and UI ship with for browsing public MCP servers.
+The pieces work together:
+
+- The CLI's [`thv search`](../reference/cli/thv_search.md) and
+  [`thv registry`](../guides-cli/registry.mdx) commands query the built-in
+  catalog by default, but can also point at a Registry Server you host.
+- Kubernetes deployments driven by the
+  [ToolHive operator](../guides-k8s/deploy-operator.mdx) can register discovered
+  `MCPServer` workloads as entries in a Registry Server through the Kubernetes
+  source type.
+
+If you want a private or team-scoped catalog with publishing, claims-based
+access control, and multi-source aggregation, deploy a Registry Server. If you
+only need to browse the public ToolHive catalog, the built-in registry is
+enough.
 
 ## Next steps
 

--- a/docs/toolhive/guides-registry/intro.mdx
+++ b/docs/toolhive/guides-registry/intro.mdx
@@ -135,7 +135,8 @@ The pieces work together:
 
 - The CLI's [`thv search`](../reference/cli/thv_search.md) and
   [`thv registry`](../guides-cli/registry.mdx) commands query the built-in
-  catalog by default, but can also point at a Registry Server you host.
+  catalog by default, but can also be pointed at a Registry Server you host with
+  [`thv config set-registry`](../reference/cli/thv_config_set-registry.md).
 - Kubernetes deployments driven by the
   [ToolHive operator](../guides-k8s/deploy-operator.mdx) can register discovered
   `MCPServer` workloads as entries in a Registry Server through the Kubernetes

--- a/docs/toolhive/guides-registry/skills.mdx
+++ b/docs/toolhive/guides-registry/skills.mdx
@@ -38,7 +38,7 @@ this page focuses on the admin API.
 Skills use two API path families:
 
 - **Browse endpoints** (list, get, search) use the registry-scoped path:
-  `/{registryName}/v0.1/x/dev.toolhive/skills`
+  `/registry/{registryName}/v0.1/x/dev.toolhive/skills`
 - **Admin endpoints** (publish, delete) use the `/v1/entries` path
 
 Replace `{registryName}` with the `name` of the registry as defined in your
@@ -129,7 +129,7 @@ after `1.0.0` exists) does not change the latest pointer.
 To list skills in a registry:
 
 ```bash title="List all skills"
-curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills
+curl https://registry.example.com/registry/my-registry/v0.1/x/dev.toolhive/skills
 ```
 
 ### Query parameters
@@ -144,7 +144,7 @@ curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills
 ### Search example
 
 ```bash title="Search for skills by keyword"
-curl "https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills?search=review&limit=10"
+curl "https://registry.example.com/registry/my-registry/v0.1/x/dev.toolhive/skills?search=review&limit=10"
 ```
 
 ### Response format
@@ -189,19 +189,19 @@ Use the `nextCursor` value to fetch the next page of results. An empty
 ### Get the latest version
 
 ```bash title="Get the latest version of a skill"
-curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review
+curl https://registry.example.com/registry/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review
 ```
 
 ### Get a specific version
 
 ```bash title="Get a specific version"
-curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review/versions/1.0.0
+curl https://registry.example.com/registry/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review/versions/1.0.0
 ```
 
 ### List all versions
 
 ```bash title="List all versions of a skill"
-curl https://registry.example.com/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review/versions
+curl https://registry.example.com/registry/my-registry/v0.1/x/dev.toolhive/skills/io.github.acme/code-review/versions
 ```
 
 ## Delete a skill version

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -201,10 +201,20 @@ const sidebars: SidebarsConfig = {
       items: [
         'toolhive/guides-registry/intro',
         'toolhive/guides-registry/quickstart',
-        'toolhive/guides-registry/deployment',
-        'toolhive/guides-registry/deploy-operator',
-        'toolhive/guides-registry/deploy-helm',
-        'toolhive/guides-registry/deploy-manual',
+        {
+          type: 'category',
+          label: 'Deploy the Registry Server',
+          link: {
+            type: 'doc',
+            id: 'toolhive/guides-registry/deployment',
+          },
+          collapsible: false,
+          items: [
+            'toolhive/guides-registry/deploy-operator',
+            'toolhive/guides-registry/deploy-helm',
+            'toolhive/guides-registry/deploy-manual',
+          ],
+        },
         'toolhive/guides-registry/configuration',
         'toolhive/guides-registry/publish-servers',
         'toolhive/guides-registry/authentication',


### PR DESCRIPTION
## Summary

Final polish pass for the remaining secondary items from #364:

- **authentication.mdx**: Wrap the four provider-specific examples (Keycloak, Auth0, Azure AD, Okta) in collapsible \`<details>\` blocks so readers can focus on their provider without scrolling through the others. Matches the progressive-disclosure pattern used in \`guides-k8s/auth-k8s.mdx\`.
- **intro.mdx**:
  - Rephrase the Kubernetes-source "knowledge workers" bullet that Dan flagged as jargon without context. New wording talks about surfacing running servers to end users and the dev/consumer split in larger orgs.
  - Add a new "Registry Server and the rest of ToolHive" section that explicitly clarifies how the Registry Server relates to the CLI's built-in catalog (\`thv search\`, \`thv registry\`, and \`thv config set-registry\`) and the ToolHive operator's Kubernetes source integration.
- **deployment.mdx**: Add an explicit "System requirements" section (Kubernetes version support, PostgreSQL 14+, migration privileges, persistent storage recommendation for Git sources, network-access notes). Group the deployment-method table under a "Deployment methods" heading.
- **deploy-operator.mdx**: New "Upgrade and migration" section covering the operator-and-CRD upgrade order, image-tag rollout through the \`MCPRegistry\` CR, automatic database migrations, and a pointer to the release notes.
- **deploy-manual.mdx**: New "Upgrade and migration" section for the manifest path (image tag change, rolling update, config-change considerations, release-notes pointer).

### Stacked on #743

This PR is stacked on [#743 (Add Publish MCP servers guide)](https://github.com/stacklok/docs-website/pull/743), which is stacked on [#742](https://github.com/stacklok/docs-website/pull/742). Merge the stack in order (#742 → #743 → this) for a clean fast-forward.

With this round, every issue listed in #364 is either closed or has a concrete follow-up already deployed.

Closes #364

## Test plan

- [x] \`npm run build\` - site builds cleanly (only the pre-existing broken anchor on an unrelated page under /guides-ui/mcp-optimizer)
- [ ] \`npm run start\` spot-check: \`<details>\` blocks expand/collapse correctly on authentication page; new sections render; cross-links resolve; sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)