### PR TITLE
Fix remaining Registry API paths that miss /registry prefix

### DIFF
--- a/docs/toolhive/concepts/skills.mdx
+++ b/docs/toolhive/concepts/skills.mdx
@@ -41,8 +41,8 @@ flowchart LR
 
 When you publish skills to the ToolHive Registry for team-wide discovery, they
 are stored under a separate extensions API path
-(`/{registryName}/v0.1/x/dev.toolhive/skills`, where `{registryName}` is the
-name of your registry). They are not intermixed with MCP server entries.
+(`/registry/{registryName}/v0.1/x/dev.toolhive/skills`, where `{registryName}`
+is the name of your registry). They are not intermixed with MCP server entries.
 
 ## Skill structure
 

--- a/docs/toolhive/guides-registry/authentication.mdx
+++ b/docs/toolhive/guides-registry/authentication.mdx
@@ -411,7 +411,7 @@ the authentication requirements.
 TOKEN="your-jwt-token-here"
 
 curl -H "Authorization: Bearer $TOKEN" \
-  https://registry.example.com/default/v0.1/servers
+  https://registry.example.com/registry/default/v0.1/servers
 ```
 
 ### Using kubectl with Kubernetes service accounts
@@ -426,7 +426,7 @@ TOKEN=$(kubectl create token <service-account-name> \
 
 # Make authenticated request
 curl -H "Authorization: Bearer $TOKEN" \
-  https://registry.example.com/registry/v0.1/servers
+  https://registry.example.com/registry/default/v0.1/servers
 ```
 
 :::tip[Projected tokens vs kubectl create token]

--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -193,8 +193,8 @@ registries:
     # No claims - accessible to all authenticated users
 ```
 
-A caller who requests `GET /platform/v0.1/servers` must have JWT claims that
-include `org: "acme"` and `team: "platform"`. Otherwise, the server returns
+A caller who requests `GET /registry/platform/v0.1/servers` must have JWT claims
+that include `org: "acme"` and `team: "platform"`. Otherwise, the server returns
 `403 Forbidden`.
 
 ### Claim containment


### PR DESCRIPTION
## Summary

Follow-up to the #364 stack that closes the remaining pre-existing instances where client-facing Registry Server URLs were missing the \`/registry\` mount prefix.

The Registry Server mounts v0.1 routes under \`/registry\` (verified against \`toolhive-registry-server@main\` \`internal/api/server.go\` at \`r.Mount(\"/registry\", v01.Router(svc))\` and the swagger spec under \`docs/thv-registry-api/swagger.yaml\`). So the correct client path is \`/registry/{registryName}/v0.1/...\`, not \`/{registryName}/v0.1/...\`.

Fixed in this PR:

- \`docs/toolhive/guides-registry/authentication.mdx\`: two curl examples in the "Testing authentication" section. The \`kubectl\`-token example also had a malformed \`/registry/v0.1/servers\` URL missing the registry name entirely; normalized to \`/registry/default/v0.1/servers\` to match the adjacent bearer-token example.
- \`docs/toolhive/guides-registry/authorization.mdx\`: the claims-gating example now reads \`GET /registry/platform/v0.1/servers\`.
- \`docs/toolhive/concepts/skills.mdx\`: the skills extensions-API path description now includes the \`/registry/\` prefix.

Not in scope for this PR:

- Matching instances inside the #364 stack (quickstart, intro, skills guide, configuration, publishing) are already fixed in PRs #742/#743/#744.
- \`telemetry-metrics.mdx\` line 130 is intentionally left alone. The \`/v0.1/servers/{name}\` string there is the chi route pattern the instrumentation records, which is matched *after* the outer \`/registry\` mount has been consumed - so it correctly has no prefix.
- "Registry server" (lowercase-s) drift across several files is a separate style pass, not this correctness fix.

## Test plan

- [x] \`npm run build\` - site builds cleanly (only the pre-existing broken-anchor warning on /guides-ui/mcp-optimizer)
- [ ] \`npm run start\` visual spot-check that the three changed lines render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)