### PR TITLE
Re-order llms.txt index

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -59,10 +59,10 @@ const config: Config = {
           ],
         },
         includeOrder: [
-          '/toolhive/tutorials/**',
           '/toolhive/concepts/**',
-          '/toolhive/reference/client-compatibility',
           '/toolhive/guides-*',
+          '/toolhive/tutorials/**',
+          '/toolhive/integrations/**',
           '/toolhive/reference/**',
         ],
         optionalLinks: [


### PR DESCRIPTION
### Description

Slightly re-order the llms.txt index.

- Moves the now-lighter tutorials section below guides.
- Moves the new integrations section above reference.
- Removes the ineffective client-compatibility entry (it was having no effect).

### Type of change

- Other / internal

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>