### PR TITLE
Address Dan's review feedback: shorter minimumReleaseAge + precise wording

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -367,21 +367,48 @@ jobs:
           REPO: ${{ steps.detect.outputs.repo }}
           PREV: ${{ steps.detect.outputs.prev_tag }}
           NEW: ${{ steps.detect.outputs.new_tag }}
+          REVIEW_REPO: ${{ github.repository }}
         run: |
-          # Capture stderr separately so we can surface a missing-compare
-          # situation in the PR body rather than silently dropping reviewers.
+          # Get non-bot commit authors in the release range.
           if COMPARE=$(gh api "repos/$REPO/compare/$PREV...$NEW" \
               --jq '[.commits[].author.login? // empty] | unique | .[]' 2>/dev/null); then
-            REVIEWERS=$(echo "$COMPARE" |
-              grep -Ev '(\[bot\]$|^github-actions|^stacklokbot$|^dependabot|^renovate|^copilot)' |
-              head -5 | paste -sd, -)
             echo "compare_ok=true" >> "$GITHUB_OUTPUT"
           else
-            REVIEWERS=""
+            COMPARE=""
             echo "compare_ok=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # Filter out bot accounts, then further filter to only this
+          # repo's collaborators. GitHub rejects reviewer requests for
+          # non-collaborators with 422, which would fail the whole
+          # `gh pr edit --add-reviewer` call and drop the valid
+          # reviewers along with the invalid ones. Community
+          # contributors from the upstream repo often aren't
+          # collaborators on docs-website; silently skip them rather
+          # than ping or fail.
+          CANDIDATES=$(echo "$COMPARE" |
+            grep -Ev '(\[bot\]$|^github-actions|^stacklokbot$|^dependabot|^renovate|^copilot)' || true)
+
+          REVIEWERS=""
+          SKIPPED=""
+          while IFS= read -r login; do
+            [ -z "$login" ] && continue
+            if gh api "repos/$REVIEW_REPO/collaborators/$login" --silent 2>/dev/null; then
+              REVIEWERS="${REVIEWERS:+$REVIEWERS,}$login"
+            else
+              SKIPPED="${SKIPPED:+$SKIPPED, }$login"
+            fi
+          done <<< "$CANDIDATES"
+
+          # Cap at 5 to avoid review fatigue.
+          REVIEWERS=$(echo "$REVIEWERS" | tr ',' '\n' | head -5 | paste -sd, -)
+
           echo "list=$REVIEWERS" >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
           echo "Reviewers: ${REVIEWERS:-<none>}"
+          if [ -n "$SKIPPED" ]; then
+            echo "Skipped non-collaborator contributors: $SKIPPED"
+          fi
 
       - name: Read docs_paths hint
         id: hints
@@ -570,6 +597,7 @@ jobs:
           GAPS_BLOCK: ${{ steps.signals.outputs.gaps_block }}
           AUTOGEN_NOTE: ${{ steps.autogen.outputs.note }}
           COMPARE_OK: ${{ steps.reviewers.outputs.compare_ok }}
+          SKIPPED_REVIEWERS: ${{ steps.reviewers.outputs.skipped }}
         run: |
           START='<!-- upstream-release-docs:start -->'
           END='<!-- upstream-release-docs:end -->'
@@ -603,8 +631,12 @@ jobs:
               echo "$GAPS_BLOCK"
               echo ""
             fi
-            echo "Reviewers below are non-bot commit authors in the release range."
+            echo "Reviewers below are non-bot commit authors in the release range who are also collaborators on this repo."
             echo ""
+            if [ -n "$SKIPPED_REVIEWERS" ]; then
+              echo "Other release contributors (not assigned as reviewers because they aren't repo collaborators): $SKIPPED_REVIEWERS. Thanks for the contribution!"
+              echo ""
+            fi
             echo "$END"
           } > /tmp/section.md
 

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -384,19 +384,15 @@ jobs:
           # `gh pr edit --add-reviewer` call and drop the valid
           # reviewers along with the invalid ones. Community
           # contributors from the upstream repo often aren't
-          # collaborators on docs-website; silently skip them rather
-          # than ping or fail.
+          # collaborators here; silently skip them.
           CANDIDATES=$(echo "$COMPARE" |
             grep -Ev '(\[bot\]$|^github-actions|^stacklokbot$|^dependabot|^renovate|^copilot)' || true)
 
           REVIEWERS=""
-          SKIPPED=""
           while IFS= read -r login; do
             [ -z "$login" ] && continue
             if gh api "repos/$REVIEW_REPO/collaborators/$login" --silent 2>/dev/null; then
               REVIEWERS="${REVIEWERS:+$REVIEWERS,}$login"
-            else
-              SKIPPED="${SKIPPED:+$SKIPPED, }$login"
             fi
           done <<< "$CANDIDATES"
 
@@ -404,11 +400,7 @@ jobs:
           REVIEWERS=$(echo "$REVIEWERS" | tr ',' '\n' | head -5 | paste -sd, -)
 
           echo "list=$REVIEWERS" >> "$GITHUB_OUTPUT"
-          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
           echo "Reviewers: ${REVIEWERS:-<none>}"
-          if [ -n "$SKIPPED" ]; then
-            echo "Skipped non-collaborator contributors: $SKIPPED"
-          fi
 
       - name: Read docs_paths hint
         id: hints
@@ -597,7 +589,6 @@ jobs:
           GAPS_BLOCK: ${{ steps.signals.outputs.gaps_block }}
           AUTOGEN_NOTE: ${{ steps.autogen.outputs.note }}
           COMPARE_OK: ${{ steps.reviewers.outputs.compare_ok }}
-          SKIPPED_REVIEWERS: ${{ steps.reviewers.outputs.skipped }}
         run: |
           START='<!-- upstream-release-docs:start -->'
           END='<!-- upstream-release-docs:end -->'
@@ -633,10 +624,6 @@ jobs:
             fi
             echo "Reviewers below are non-bot commit authors in the release range who are also collaborators on this repo."
             echo ""
-            if [ -n "$SKIPPED_REVIEWERS" ]; then
-              echo "Other release contributors (not assigned as reviewers because they aren't repo collaborators): $SKIPPED_REVIEWERS. Thanks for the contribution!"
-              echo ""
-            fi
             echo "$END"
           } > /tmp/section.md
 

--- a/renovate.json
+++ b/renovate.json
@@ -88,14 +88,14 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["**/.github/upstream-projects.yaml"],
       "schedule": ["at any time"],
-      "minimumReleaseAge": "24 hours",
+      "minimumReleaseAge": "1 hour",
       "minimumReleaseAgeBehaviour": "timestamp-optional",
       "ignoreUnstable": true,
       "rebaseWhen": "never",
       "recreateWhen": "never",
       "commitMessageTopic": "{{depName}}",
       "prBodyNotes": [
-        "After this PR opens, `.github/workflows/upstream-release-docs.yml` adds source-verified content edits for the new release. For `stacklok/toolhive`, the same workflow also regenerates reference docs (CLI help, Swagger, CRD schemas)."
+        "After this PR opens, `.github/workflows/upstream-release-docs.yml` adds source-verified content edits for the new release. For `stacklok/toolhive`, the same workflow also syncs reference assets (CLI help, Swagger) and regenerates the CRD MDX pages."
       ]
     }
   ]


### PR DESCRIPTION
Four follow-ups to [#748](https://github.com/stacklok/docs-website/pull/748):

## 1. `minimumReleaseAge: 24 hours` → `1 hour`

Dan flagged that 24h is overcautious for first-party Stacklok releases. Renovate itself only runs every 4h so `1 hour` is effectively close to `0` in the common case while still protecting against same-day yanks/reverts.

## 2. `regenerates` wording in `prBodyNotes`

One leftover instance that missed the earlier terminology pass. Now precisely:

> For `stacklok/toolhive`, the same workflow also **syncs** reference assets (CLI help, Swagger) and **regenerates** the CRD MDX pages.

## 3. Filter reviewers to repo collaborators

Previous behavior passed every non-bot commit author to `gh pr edit --add-reviewer` as a single comma-separated list. GitHub rejects non-collaborator reviewer requests with 422, and because the API treats the list atomically, one community contributor in the range would fail the whole call and drop all valid reviewers with it.

**Fix:** probe each candidate with `gh api repos/<repo>/collaborators/<user>` before adding. 204 → keep; 404 → silently skip. Prevents both the notification-to-strangers case AND the whole-call-failure case.

## 4. Real-time skill progress visibility

The skill step previously went silent for 20-45 min with no way to observe progress without waiting for logs to finalize. Two `claude-code-action` inputs expose live status:

- `track_progress: true` — posts a sticky tracking comment on the PR that updates as the skill works through each phase
- `display_report: true` — surfaces the Claude Code Report in the Actions Step Summary as the step runs

Operators watching a run now see progress from either the PR page or the run view, in real time.

## Testing

- #1 and #2 are one-line changes to `renovate.json`
- #3 and #4 are workflow-YAML changes; will prove themselves on next dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)