### PR TITLE
Allow Renovate bot + stream skill progress to PR in real time

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -422,6 +422,18 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
+          # Allow the action to run when the triggering PR was opened
+          # by Renovate. Without this, claude-code-action refuses to
+          # run for bot-initiated workflows as a safety default.
+          allowed_bots: 'renovate'
+          # Real-time visibility into skill progress during long runs.
+          # track_progress posts a sticky tracking comment on the PR
+          # that updates as the skill works through each phase.
+          # display_report surfaces the Claude Code Report in the
+          # Actions Step Summary so operators watching the run see
+          # progress without waiting for gh run view --log.
+          track_progress: true
+          display_report: true
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed


### PR DESCRIPTION
Three small fixes to unblock + observe the Renovate-driven skill runs:

## 1. Allow the Renovate bot to trigger the skill

Seen on [run 24743776702](https://github.com/stacklok/docs-website/actions/runs/24743776702) against PR #759:

> Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

`anthropics/claude-code-action@v1` defaults to refusing bot-initiated workflows as a safety measure. Since the whole point of this pipeline is to react to Renovate's version-bump PRs, we explicitly allow that one bot via `allowed_bots: 'renovate'`. Other bots remain blocked.

## 2. Real-time progress visibility

Skill runs can take 20–45 min; `gh run view --log` won't surface any output until the whole run finishes. The action exposes two inputs that fix the black-hole experience:

- `track_progress: true` — posts a sticky tracking comment on the PR that updates as the skill works through each phase
- `display_report: true` — streams the Claude Code Report to the Actions Step Summary live, rather than waiting for the step to finish

Operators can now watch progress from either the PR page or the run page, in real time.

## 3. Push the refresh commit immediately (don't batch with skill push)

Diagnosed from runs 24743070052 + 24743776702: the "Commit refreshed reference assets" step was creating a real commit locally (~38 file changes covering all toolhive reference assets), but the `git push` only happened at the END of the workflow in the final "Commit and push" step AFTER the skill. When the skill failed or was cancelled, that final push never ran, and the refresh commit died with the runner.

Result: PR #759 and PR #756 ended up with only the one-line YAML bump — even though the refresh logic had actually worked correctly upstream of the skill.

Fix: push the refresh commit right after creating it. The skill step can now fail or hang without losing the reference asset updates; they're already on the PR branch by the time the skill starts.

## Testing

- Any Renovate-triggered dispatch after this merges should:
  - Get past the skill step (no more bot rejection)
  - Show live progress during the skill as a sticky PR comment + Step Summary
  - Have the reference-asset refresh persisted to the PR even if skill later fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)