### PR TITLE
Fix retry-mode git context + push refresh commit immediately

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -111,8 +111,11 @@ jobs:
             workflow_dispatch)
               if [ -n "$DISPATCH_PR" ]; then
                 PR_NUMBER="$DISPATCH_PR"
-                HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)
-                AUTHOR=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login')
+                # --repo is required because this step runs before the
+                # actions/checkout below — gh otherwise looks for a
+                # local .git context and fails with "not a git repository".
+                HEAD_REF=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+                AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq '.author.login')
                 case "$AUTHOR" in
                   app/renovate|renovate[bot]|app/github-actions|github-actions[bot])
                     ;;
@@ -235,9 +238,10 @@ jobs:
             BASE="$BASE_FROM_EVENT"
           else
             # workflow_dispatch retry: look up the PR's base_ref.
+            # --repo because in retry mode there's no prior checkout.
             NUMBER="$PR_FROM_RESOLVE"
             HEAD="$HEAD_FROM_RESOLVE"
-            BASE=$(gh pr view "$NUMBER" --json baseRefName --jq .baseRefName)
+            BASE=$(gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)
           fi
           {
             echo "number=$NUMBER"
@@ -344,21 +348,26 @@ jobs:
           node scripts/bundle-upstream-schema.mjs
           rm -rf "$TMP"
 
-      # Commit the refreshed reference assets (synced release-asset
-      # files + regenerated toolhive CRD MDX if applicable) before the
-      # skill runs. This keeps the skill's content commit clean and
+      # Commit AND PUSH the refreshed reference assets (synced release-
+      # asset files + regenerated toolhive CRD MDX if applicable) before
+      # the skill runs. Pushing here — rather than batching the push
+      # with the skill-content commit later — means refresh work is
+      # preserved on the PR even if the skill step fails or is
+      # cancelled. Also keeps the skill's content commit clean and
       # lets the autogen-detect step below distinguish skill touches
       # from our own legitimate refresh writes.
-      - name: Commit refreshed reference assets
+      - name: Commit + push refreshed reference assets
         env:
           PROJECT_ID: ${{ steps.detect.outputs.id }}
           NEW_TAG: ${{ steps.detect.outputs.new_tag }}
+          HEAD_REF: ${{ steps.eff.outputs.head_ref }}
         run: |
           git add -A
           if git diff --cached --quiet; then
             echo "No reference changes for $PROJECT_ID $NEW_TAG."
           else
             git commit -m "Refresh reference assets for $PROJECT_ID $NEW_TAG"
+            git push origin "HEAD:$HEAD_REF"
           fi
 
       - name: Extract reviewers from release compare


### PR DESCRIPTION
Two bugs diagnosed from today's Renovate runs (#759 + its retry 24744962001):

## 1. workflow_dispatch retry mode: \`gh pr view\` needs \`--repo\` pre-checkout

The retry path failed at "Resolve PR number and head ref" with:

> failed to run git: fatal: not a git repository (or any of the parent directories): .git

The step runs BEFORE \`actions/checkout\`, so \`gh pr view\` has no local \`.git\` to infer the repo from. Added \`--repo "\$GITHUB_REPOSITORY"\` to the three pre-checkout \`gh pr view\` calls (two in the retry branch of the \`pr\` step, one in the retry branch of the \`eff\` step).

The earlier misleading "author ... is not an accepted bot" message in logs was just \`bash -x\`-style source echoing; the actual runtime never reached that branch.

## 2. Push the refresh commit immediately (don't batch with skill push)

Across multiple runs today — 24743070052, 24743776702, 24744962001 — the "Commit refreshed reference assets" step created a real local commit (~38 files, all the reference-asset + CRD regen output), but the \`git push\` only happened at the END of the workflow in the "Commit and push" step AFTER the skill. Every time the skill failed or was cancelled, that final push never ran, and the refresh commit died with the runner.

Example from run 24743070052's log:

\`\`\`
[manual/upstream-toolhive-v0.23.1 2167ea4]
Refresh reference assets for toolhive v0.23.1
38 files changed, 69 insertions(+), 69 deletions(-)
\`\`\`

...yet the PR ended up with only the one-line YAML bump.

Fix: push the refresh commit right after creating it. Skill can fail or hang without losing reference-asset updates.

This change was pushed to #760's branch but landed after its squash-merge, so it got orphaned. Re-shipping.

## Testing

- \`gh workflow run upstream-release-docs.yml -f pr_number=<existing-renovate-pr>\` should no longer fail at the Resolve step
- Refresh commits should appear on the PR within ~1 min of dispatch, before the skill even starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)