### PR TITLE
Gate track_progress on pull_request event (fixes skill on workflow_dispatch)

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -437,11 +437,15 @@ jobs:
           allowed_bots: 'renovate'
           # Real-time visibility into skill progress during long runs.
           # track_progress posts a sticky tracking comment on the PR
-          # that updates as the skill works through each phase.
+          # that updates as the skill works through each phase —
+          # BUT it's only supported for pull_request / issue_comment
+          # /* events. Setting it on workflow_dispatch fails the
+          # action with "track_progress is only supported for events
+          # ... Current event: workflow_dispatch", so gate it on the
+          # triggering event.
           # display_report surfaces the Claude Code Report in the
-          # Actions Step Summary so operators watching the run see
-          # progress without waiting for gh run view --log.
-          track_progress: true
+          # Actions Step Summary regardless of trigger.
+          track_progress: ${{ github.event_name == 'pull_request' }}
           display_report: true
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow


### PR DESCRIPTION
Single-line fix. \`claude-code-action\` rejects \`track_progress: true\` for \`workflow_dispatch\` triggers:

Seen on [run 24745470509](https://github.com/stacklok/docs-website/actions/runs/24745470509):

> Action failed with error: track_progress is only supported for events: pull_request, issues, issue_comment, pull_request_review_comment, pull_request_review. Current event: workflow_dispatch

Fix: evaluate \`track_progress\` from \`github.event_name\` — on \`pull_request\` triggers (the natural Renovate flow), it's \`true\`; on \`workflow_dispatch\` retries, it's \`false\`. \`display_report: true\` stays on unconditionally since it's supported everywhere.

Good news from the same run:
- The retry-path \`--repo\` fix works — got past "Resolve PR number and head ref" cleanly
- The refresh step completed successfully (registry-server had no reference changes between v1.2.1 and v1.2.2, so the refresh was a correct no-op — just the YAML bump)
- Skill was the only remaining blocker

After this lands, the next Renovate-triggered run (natural \`pull_request\` event) should execute the skill end-to-end with tracking-comment visibility. Retries via \`workflow_dispatch\` won't have the tracking comment but \`display_report\` will still stream to the Step Summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)