### PR TITLE
Rebase local commits before push to handle PR-branch drift

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -367,6 +367,14 @@ jobs:
             echo "No reference changes for $PROJECT_ID $NEW_TAG."
           else
             git commit -m "Refresh reference assets for $PROJECT_ID $NEW_TAG"
+            # Someone may have pushed to HEAD_REF between our checkout
+            # and now (merges from main, etc). Rebase onto the latest
+            # tip before pushing so we don't fail with "fetch first".
+            git fetch origin "$HEAD_REF" --quiet
+            git rebase "origin/$HEAD_REF" || {
+              echo "::error::Rebase of the refresh commit onto origin/$HEAD_REF hit conflicts. Resolve manually on the PR branch."
+              exit 1
+            }
             git push origin "HEAD:$HEAD_REF"
           fi
 
@@ -588,16 +596,30 @@ jobs:
           HEAD_REF: ${{ steps.eff.outputs.head_ref }}
         run: |
           # Stage any skill content and add a content commit if non-empty.
-          # A refresh commit from the earlier step may also be waiting.
           git add -A
           if ! git diff --cached --quiet; then
             git commit -m "Add upstream-release-docs content for $PROJECT_ID $NEW_TAG"
           else
             echo "No skill content changes to commit."
           fi
-          # Push whatever local commits are ahead of the remote — refresh
-          # only, content only, or both. Empty push is a no-op.
-          git push origin "HEAD:$HEAD_REF"
+
+          # Skill can take 20-45 min; during that window someone may
+          # push merges-from-main or other commits to the PR branch.
+          # Handle that safely:
+          #   - If our local HEAD is already on origin (no new work
+          #     to push), exit cleanly.
+          #   - Otherwise rebase any local-only commits onto the
+          #     latest origin tip, then push. Conflicts fail loudly.
+          git fetch origin "$HEAD_REF" --quiet
+          if git merge-base --is-ancestor HEAD "origin/$HEAD_REF" 2>/dev/null; then
+            echo "Origin is at or ahead of local; nothing to push."
+          else
+            git rebase "origin/$HEAD_REF" || {
+              echo "::error::Rebase of local commits onto origin/$HEAD_REF hit conflicts. Resolve manually on the PR branch."
+              exit 1
+            }
+            git push origin "HEAD:$HEAD_REF"
+          fi
 
       - name: Augment PR body (marker-delimited section)
         # Runs even if earlier steps soft-failed so the augmentation


### PR DESCRIPTION
## Context

The skill step runs for 20-45 min. During that window, the PR branch often gets updated from outside our workflow — typical cause is someone merging main into the PR branch to keep it current. When the workflow's final "Commit and push" then tries to push its local state, git rejects the push with:

\`\`\`
! [rejected] HEAD -> renovate/... (fetch first)
error: failed to push some refs to 'https://github.com/stacklok/docs-website.git'
\`\`\`

Seen on [run 24745672604](https://github.com/stacklok/docs-website/actions/runs/24745672604) — the skill actually completed successfully in 14 min for the first time, but the final push failed because the PR branch had a merge-from-main committed seconds after our workflow's initial checkout.

## Fix

In the "Commit and push" step, after committing any skill content:

1. \`git fetch origin "\$HEAD_REF"\` to refresh our view of the remote tip
2. \`git merge-base --is-ancestor HEAD origin/\$HEAD_REF\`:
   - If origin is at or ahead of local (no new local commits), skip the push entirely. Common case when the skill produced no content changes.
   - Otherwise rebase local commits onto the latest remote tip, then push. Rebase conflicts fail loudly with an actionable message.

Same protection applied to the earlier "Commit + push refreshed reference assets" step. The race window there is smaller (seconds, not minutes) but non-zero and the fix is cheap.

## Why not force-push?

Force-push would destroy the user-added merge commits. The workflow should cooperate with manual edits to the branch, not stomp them.

## Testing

Next Renovate-triggered or dispatch-retried run that has the race condition: instead of failing, local rebase + push succeeds. If the skill produces no changes, nothing is pushed and the step completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)