### PR TITLE
Cancel stale On PR runs via concurrency group

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -6,6 +6,17 @@ on:
 permissions:
   contents: read
 
+# Cancel stale runs so only the PR's current HEAD determines the
+# check status. Matters specifically for PRs where the
+# upstream-release-docs workflow pushes multiple commits
+# in quick succession (skill output + prettier/eslint autofix): the
+# intermediate commits briefly fail lint until the autofix lands,
+# and without cancel-in-progress those intermediate failures stay
+# in the check history.
+concurrency:
+  group: on-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   static-checks:
     name: Static checks


### PR DESCRIPTION
## Context

On PR #759, after the upstream-release-docs workflow pushed the skill's generation commit, the \`On PR\` workflow's Lint and format checks job ran against that still-unformatted commit and reported FAILURE. A later step in the same upstream workflow ran prettier/eslint and pushed a fixup commit, triggering a new \`On PR\` run that succeeded — but the earlier FAILURE lingered in the check history.

The race is unavoidable on our side: \`claude-code-action@v1\` auto-commits AND auto-pushes with no configurable way to disable either, so intermediate commits always hit the branch before the autofix step can run.

## Fix

Add a concurrency group on \`on-pr.yaml\`:

\`\`\`yaml
concurrency:
  group: on-pr-\${{ github.event.pull_request.number }}
  cancel-in-progress: true
\`\`\`

When the autofix commit lands, the in-flight \`On PR\` run on the skill commit cancels. Only the final run determines check status. This is standard GitHub Actions practice for PR CI — rapid-fire commits (humans pushing fixups, or our skill pipeline) don't tie up runner minutes on stale results.

Keyed on \`pull_request.number\` so PRs can't cancel each other's runs.

## Doesn't affect

- Required-check evaluation: GitHub evaluates required checks against the PR's HEAD. As long as the final commit's \`On PR\` run succeeds, the PR is mergeable.
- Branch protection: no changes.
- Non-upstream PRs: they get the same benefit — if a human pushes a rapid fixup, the stale run cancels. Strict improvement.