### PR TITLE
Per-user reviewer attempts + @-mention fallback + widen toolhive docs paths

### DIFF
--- a/.github/upstream-projects.yaml
+++ b/.github/upstream-projects.yaml
@@ -36,10 +36,21 @@ projects:
   - id: toolhive
     repo: stacklok/toolhive
     version: v0.23.1
+    # toolhive is a monorepo covering the CLI, the Kubernetes
+    # operator, and the vMCP gateway. It also introduces cross-
+    # cutting features that land in concepts/, integrations/,
+    # tutorials/, and hand-written reference pages. These entries
+    # are hints, not constraints -- the skill's Phase 3 impact map
+    # decides what actually changes. Hints focus Phase 2's source
+    # reading so the skill doesn't re-scan unrelated areas.
     docs_paths:
       - docs/toolhive/guides-cli
       - docs/toolhive/guides-k8s
       - docs/toolhive/guides-vmcp
+      - docs/toolhive/concepts
+      - docs/toolhive/integrations
+      - docs/toolhive/tutorials
+      - docs/toolhive/reference/authz-policy-reference.mdx
     assets:
       - release_asset: swagger.yaml
         destination: static/api-specs/toolhive-api.yaml

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -391,13 +391,14 @@ jobs:
         id: pre_skill
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Extract reviewers and contributors from release compare
+      - name: Assign reviewers and prepare contributor mentions
         id: reviewers
         env:
           REPO: ${{ steps.detect.outputs.repo }}
           PREV: ${{ steps.detect.outputs.prev_tag }}
           NEW: ${{ steps.detect.outputs.new_tag }}
           REVIEW_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.eff.outputs.number }}
         run: |
           # Get non-bot commit authors in the release range.
           if COMPARE=$(gh api "repos/$REPO/compare/$PREV...$NEW" \
@@ -412,43 +413,53 @@ jobs:
           CANDIDATES=$(echo "$COMPARE" |
             grep -Ev '(\[bot\]$|^github-actions|^stacklokbot$|^dependabot|^renovate|^copilot)' || true)
 
-          # Split candidates into two groups:
-          #   - ASSIGN_LIST: collaborators on this repo -- safe to pass
-          #     to `gh pr edit --add-reviewer`. GitHub rejects the
-          #     entire call with 422 if any name in the list isn't a
-          #     collaborator, so the filter is mandatory to avoid
-          #     dropping valid reviewers alongside invalid ones.
-          #   - MENTION_LIST: everyone else. Upstream contributors
-          #     (often Stacklok employees with private org membership
-          #     we can't detect via GITHUB_TOKEN, which lacks
-          #     read:org) still deserve a ping so they see the PR
-          #     documenting their work. @-mentioning in the PR body
-          #     handles that without needing reviewer-assignment
-          #     rights.
-          # Future: a PAT with read:org could let us also check
-          # membership in the `stackers` team and promote those to
-          # ASSIGN_LIST. Deferred -- not wiring a secret in now.
+          # Attempt to assign each candidate as a reviewer individually,
+          # rather than filtering upfront and batching. Rationale:
+          #   - `gh pr edit --add-reviewer "a,b,c"` is atomic. A single
+          #     422 on any name aborts the whole call, dropping valid
+          #     names alongside invalid ones.
+          #   - `gh api repos/X/collaborators/Y` as a pre-filter is
+          #     unreliable from a GITHUB_TOKEN in Actions: on PR #759
+          #     the check returned 404 for Stacklok employees who ARE
+          #     collaborators via the `stackers` team (push perm on
+          #     this repo), and only `rdimitrov` slipped through. We
+          #     suspect the collaborator endpoint treats team-based
+          #     access differently for GITHUB_TOKEN vs PATs with
+          #     read:org, but haven't nailed down the exact rule.
+          # Per-user attempts sidestep both issues: the authoritative
+          # answer is "does GitHub accept this as a reviewer right now"
+          # and we ask the API that question directly.
+          #
+          # Cap attempts at 5 to avoid review fatigue on big releases.
+          TRIED=0
           ASSIGN_LIST=""
           MENTION_LIST=""
           while IFS= read -r login; do
             [ -z "$login" ] && continue
-            if gh api "repos/$REVIEW_REPO/collaborators/$login" --silent 2>/dev/null; then
+            if [ "$TRIED" -ge 5 ]; then
+              # Over the review-fatigue cap -- mention any additional
+              # contributors instead of trying to assign them.
+              MENTION_LIST="${MENTION_LIST:+$MENTION_LIST }@$login"
+              continue
+            fi
+            TRIED=$((TRIED + 1))
+            if gh pr edit "$PR_NUMBER" --add-reviewer "$login" 2>/dev/null; then
               ASSIGN_LIST="${ASSIGN_LIST:+$ASSIGN_LIST,}$login"
+              echo "Assigned: $login"
             else
               MENTION_LIST="${MENTION_LIST:+$MENTION_LIST }@$login"
+              echo "Mention (assignment rejected by GitHub): $login"
             fi
           done <<< "$CANDIDATES"
 
-          # Cap auto-assignments at 5 to avoid review fatigue. Mentions
-          # aren't capped -- they're cheap and the block is a single
-          # PR-body notification.
-          ASSIGN_LIST=$(echo "$ASSIGN_LIST" | tr ',' '\n' | head -5 | paste -sd, -)
-
+          # Exposed for diagnostic visibility in the PR body (e.g.,
+          # "Auto-assigned: @alice @bob") and for the next workflow_
+          # dispatch retry to know what was attempted.
           echo "list=$ASSIGN_LIST" >> "$GITHUB_OUTPUT"
           {
             echo "mention_block<<MENTION_EOF"
             if [ -n "$MENTION_LIST" ]; then
-              echo "Release contributors who aren't collaborators on this repo and so couldn't be auto-assigned as reviewers. Mentioning them so they see the PR documenting their work:"
+              echo "Release contributors we couldn't auto-assign as reviewers (review fatigue cap or GitHub rejected the assignment). Mentioning them so they see the PR documenting their work:"
               echo ""
               echo "$MENTION_LIST"
             fi
@@ -895,13 +906,6 @@ jobs:
           fi
 
           gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
-
-      - name: Add reviewers
-        if: always() && steps.reviewers.outputs.list != ''
-        env:
-          PR_NUMBER: ${{ steps.eff.outputs.number }}
-          REVIEWERS: ${{ steps.reviewers.outputs.list }}
-        run: gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWERS"
 
       - name: Comment on augmentation failure
         # Runs only when a preceding step failed. Comments a retry

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -391,7 +391,7 @@ jobs:
         id: pre_skill
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Extract reviewers from release compare
+      - name: Extract reviewers and contributors from release compare
         id: reviewers
         env:
           REPO: ${{ steps.detect.outputs.repo }}
@@ -408,29 +408,54 @@ jobs:
             echo "compare_ok=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Filter out bot accounts, then further filter to only this
-          # repo's collaborators. GitHub rejects reviewer requests for
-          # non-collaborators with 422, which would fail the whole
-          # `gh pr edit --add-reviewer` call and drop the valid
-          # reviewers along with the invalid ones. Community
-          # contributors from the upstream repo often aren't
-          # collaborators here; silently skip them.
+          # Filter out bot accounts.
           CANDIDATES=$(echo "$COMPARE" |
             grep -Ev '(\[bot\]$|^github-actions|^stacklokbot$|^dependabot|^renovate|^copilot)' || true)
 
-          REVIEWERS=""
+          # Split candidates into two groups:
+          #   - ASSIGN_LIST: collaborators on this repo -- safe to pass
+          #     to `gh pr edit --add-reviewer`. GitHub rejects the
+          #     entire call with 422 if any name in the list isn't a
+          #     collaborator, so the filter is mandatory to avoid
+          #     dropping valid reviewers alongside invalid ones.
+          #   - MENTION_LIST: everyone else. Upstream contributors
+          #     (often Stacklok employees with private org membership
+          #     we can't detect via GITHUB_TOKEN, which lacks
+          #     read:org) still deserve a ping so they see the PR
+          #     documenting their work. @-mentioning in the PR body
+          #     handles that without needing reviewer-assignment
+          #     rights.
+          # Future: a PAT with read:org could let us also check
+          # membership in the `stackers` team and promote those to
+          # ASSIGN_LIST. Deferred -- not wiring a secret in now.
+          ASSIGN_LIST=""
+          MENTION_LIST=""
           while IFS= read -r login; do
             [ -z "$login" ] && continue
             if gh api "repos/$REVIEW_REPO/collaborators/$login" --silent 2>/dev/null; then
-              REVIEWERS="${REVIEWERS:+$REVIEWERS,}$login"
+              ASSIGN_LIST="${ASSIGN_LIST:+$ASSIGN_LIST,}$login"
+            else
+              MENTION_LIST="${MENTION_LIST:+$MENTION_LIST }@$login"
             fi
           done <<< "$CANDIDATES"
 
-          # Cap at 5 to avoid review fatigue.
-          REVIEWERS=$(echo "$REVIEWERS" | tr ',' '\n' | head -5 | paste -sd, -)
+          # Cap auto-assignments at 5 to avoid review fatigue. Mentions
+          # aren't capped -- they're cheap and the block is a single
+          # PR-body notification.
+          ASSIGN_LIST=$(echo "$ASSIGN_LIST" | tr ',' '\n' | head -5 | paste -sd, -)
 
-          echo "list=$REVIEWERS" >> "$GITHUB_OUTPUT"
-          echo "Reviewers: ${REVIEWERS:-<none>}"
+          echo "list=$ASSIGN_LIST" >> "$GITHUB_OUTPUT"
+          {
+            echo "mention_block<<MENTION_EOF"
+            if [ -n "$MENTION_LIST" ]; then
+              echo "Release contributors who aren't collaborators on this repo and so couldn't be auto-assigned as reviewers. Mentioning them so they see the PR documenting their work:"
+              echo ""
+              echo "$MENTION_LIST"
+            fi
+            echo "MENTION_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Auto-assigned: ${ASSIGN_LIST:-<none>}"
+          echo "Mentioned:     ${MENTION_LIST:-<none>}"
 
       - name: Read docs_paths hint
         id: hints
@@ -797,6 +822,8 @@ jobs:
           GAPS_BLOCK: ${{ steps.signals.outputs.gaps_block }}
           AUTOGEN_NOTE: ${{ steps.autogen.outputs.note }}
           COMPARE_OK: ${{ steps.reviewers.outputs.compare_ok }}
+          MENTION_BLOCK: ${{ steps.reviewers.outputs.mention_block }}
+          ASSIGN_LIST: ${{ steps.reviewers.outputs.list }}
         run: |
           START='<!-- upstream-release-docs:start -->'
           END='<!-- upstream-release-docs:end -->'
@@ -830,8 +857,22 @@ jobs:
               echo "$GAPS_BLOCK"
               echo ""
             fi
-            echo "Reviewers below are non-bot commit authors in the release range who are also collaborators on this repo."
+            echo "### Release contributors"
             echo ""
+            if [ -n "$ASSIGN_LIST" ]; then
+              # Comma list -> @-mention list for rendering.
+              ASSIGNED_MENTIONS=$(echo "$ASSIGN_LIST" | tr ',' '\n' | sed 's/^/@/' | paste -sd' ' -)
+              echo "Auto-assigned as reviewers (collaborators on this repo): $ASSIGNED_MENTIONS"
+              echo ""
+            fi
+            if [ -n "$MENTION_BLOCK" ]; then
+              echo "$MENTION_BLOCK"
+              echo ""
+            fi
+            if [ -z "$ASSIGN_LIST" ] && [ -z "$MENTION_BLOCK" ]; then
+              echo "No non-bot contributors were found in the release range."
+              echo ""
+            fi
             echo "$END"
           } > /tmp/section.md
 


### PR DESCRIPTION
Three improvements stacked in one PR, from feedback on [PR #759](https://github.com/stacklok/docs-website/pull/759).

## 1. Stop pre-filtering reviewers by `repos/X/collaborators/Y` — try to assign them directly

**What happened on PR #759:** the reviewer-extract step found `rdimitrov` as the only eligible reviewer. Four other non-bot release contributors (`ChrisJBurns`, `jhrozek`, `reyortiz3`, `tgrunnagle`) were silently dropped. A local check with a PAT that has `read:org` confirms **all five ARE collaborators** on `docs-website` via the \`stackers\` team (push permission):

\`\`\`
ChrisJBurns     collaborator (maintain, via stackers team)
jhrozek         collaborator (admin,    via stackers team)
reyortiz3       collaborator (maintain, via stackers team)
tgrunnagle      collaborator (maintain, via stackers team)
rdimitrov       collaborator (admin,    via stackers team)
\`\`\`

So the pre-filter was the problem — not team membership. Suspected cause: \`GITHUB_TOKEN\` in Actions treats the \`repos/X/collaborators/Y\` endpoint differently for team-based access than a PAT with \`read:org\`. Haven't pinned the exact rule.

**Fix:** replace the upfront filter with per-user \`gh pr edit --add-reviewer\` attempts. Each attempt is independent, so a single 422 doesn't kill the batch. Routes GitHub's authoritative answer ("can this person be a reviewer right now?") directly into ASSIGN vs. MENTION, bypassing our fallible pre-filter.

## 2. @-mention the rest in the PR body

For contributors GitHub rejects (or any past the review-fatigue cap of 5), render as an @-mention list in a new **Release contributors** section of the PR body. They still get notified.

## 3. Expand \`toolhive\` docs_paths hints

The \`toolhive\` upstream is a monorepo: CLI, Kubernetes operator, vMCP gateway, plus cross-cutting features that land in \`concepts/\`, \`integrations/\`, \`tutorials/\`, and hand-written reference pages. Previous hints listed only the three \`guides-*\` folders. In practice the skill's Phase 3 impact map already expands beyond hints, so this is a focus improvement — accurate hints narrow Phase 2's source reading.

Other projects' hints are already scoped correctly. \`toolhive-cloud-ui\` keeps \`docs_paths: []\` — no associated docs in this repo yet.

## Why this works across scenarios

- If our filter was right → per-user attempts succeed for the same people, same result.
- If our filter was wrong (like on #759) → per-user attempts still succeed for the real collaborators, and rejected ones get @-mentioned rather than silently vanishing.
- If GitHub's behavior changes in the future → we adapt automatically, no code change.

## Future

Detecting Stacklok employees *directly* (e.g. via the \`stackers\` team) would still require a PAT with \`read:org\` stored as a repo secret. Not wired in here — the per-user approach solves the immediate problem without needing extra secrets.