### PR TITLE
Cap skill turns/timeout + sync local HEAD after skill pushes

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -753,15 +753,21 @@ jobs:
       # commit" + unformatted files landing on CI unformatted.
       #
       # Fetch + fast-forward-merge origin so local HEAD reflects
-      # whatever the skill pushed. || true on the merge because a
-      # failed skill step may leave nothing to pull.
+      # whatever the skill pushed. Fail loudly on fetch or merge
+      # errors -- silently continuing on stale HEAD reintroduces
+      # the exact skill_commits=0 + autofix-skips-files bugs this
+      # step is meant to prevent. Gated on skill_gen success; if
+      # gen didn't run, there's nothing for the skill to have
+      # pushed and this step is skipped.
+      # A no-op fast-forward (local already at origin, e.g. skill
+      # made no commits) exits 0 cleanly.
       - name: Sync local branch with skill-pushed commits
         if: always() && steps.skill_gen.conclusion == 'success'
         env:
           HEAD_REF: ${{ steps.eff.outputs.head_ref }}
         run: |
           git fetch origin "$HEAD_REF" --quiet
-          git merge --ff-only "origin/$HEAD_REF" || true
+          git merge --ff-only "origin/$HEAD_REF"
           echo "Local HEAD after sync: $(git rev-parse HEAD)"
 
       # Mirror of skill_gen_stats for skill_review. Reads the same

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -514,6 +514,11 @@ jobs:
       # verification.
       - name: Run upstream-release-docs skill (generation)
         id: skill_gen
+        # Wall-clock ceiling. Observed gen runs take 15–22 min depending
+        # on release scope; 45 min kills a stuck process before it
+        # burns the full 90-minute job budget. Paired with --max-turns
+        # below for a runaway-cost ceiling.
+        timeout-minutes: 45
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -542,8 +547,15 @@ jobs:
           # only, which misses most of the "why" narrative that PR
           # authors write at open time. GH_TOKEN for auth is already
           # in the job env at the top of this workflow.
+          #
+          # --max-turns 500: observed gen baselines are 89 turns
+          # (silent) to 397 (full content rebuild). 500 gives headroom
+          # over the worst legitimate run, while clipping a genuine
+          # runaway before it spirals. Hitting the cap produces a
+          # loud failure -- raise deliberately if a release needs more.
           claude_args: |
             --model claude-opus-4-7
+            --max-turns 500
             --allowed-tools "Bash(gh:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
@@ -678,6 +690,11 @@ jobs:
       - name: Run docs-review on skill output (fresh context)
         id: skill_review
         if: always() && steps.skill_gen.conclusion == 'success'
+        # Editorial review is a short pass: 1-2 min wall clock, 4-5
+        # turns in every run so far. 10 / 30 are 5-6x buffers over
+        # baseline -- cheap safety net for the rare case where review
+        # spirals on a file it can't stop "improving".
+        timeout-minutes: 10
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -688,9 +705,12 @@ jobs:
           display_report: true
           # gh access parallels skill_gen so the review pass can
           # re-verify claims against PR descriptions and linked
-          # issues if needed.
+          # issues if needed. --max-turns 30 is 6x the 4-5-turn
+          # baseline; if review ever needs more, the cap fails
+          # loudly and we raise it.
           claude_args: |
             --model claude-opus-4-7
+            --max-turns 30
             --allowed-tools "Bash(gh:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
@@ -722,6 +742,27 @@ jobs:
             Do NOT touch GAPS.md or NO_CHANGES.md at the repo root
             if they exist -- they're signal files handed off to the
             next workflow step, not part of the docs.
+
+      # claude-code-action works in a sibling scratch checkout (the
+      # .claude-pr/ dir we gitignore) and pushes commits to origin
+      # directly, without advancing the outer workflow checkout's
+      # HEAD. Without an explicit sync, every subsequent step that
+      # reads local git state (skill_commits counter, autofix's git
+      # diff) sees stale HEAD at the pre-skill SHA -- which is what
+      # caused PR #780's "skill_commits=0 despite a real skill
+      # commit" + unformatted files landing on CI unformatted.
+      #
+      # Fetch + fast-forward-merge origin so local HEAD reflects
+      # whatever the skill pushed. || true on the merge because a
+      # failed skill step may leave nothing to pull.
+      - name: Sync local branch with skill-pushed commits
+        if: always() && steps.skill_gen.conclusion == 'success'
+        env:
+          HEAD_REF: ${{ steps.eff.outputs.head_ref }}
+        run: |
+          git fetch origin "$HEAD_REF" --quiet
+          git merge --ff-only "origin/$HEAD_REF" || true
+          echo "Local HEAD after sync: $(git rev-parse HEAD)"
 
       # Mirror of skill_gen_stats for skill_review. Reads the same
       # canonical log path, which skill_review overwrote on exit.


### PR DESCRIPTION
Three defensive additions driven by findings from PR #780's e2e test run.

## 1. Sync local HEAD after skill pushes (fixes two bugs)

**Root cause:** \`claude-code-action\` works in a sibling scratch checkout (the \`.claude-pr/\` dir we gitignore) and pushes its commits to origin without advancing the outer workflow checkout's HEAD. Every subsequent step that reads local git state saw stale HEAD.

**Symptoms on PR #780's run (run 24769641826):**

- \`skill_commits\` reported **0 despite commit \`d4b3c7c\` existing** on the PR branch → triggered the silent-run \`[!NOTE]\` on a run that produced real content.
- \`autofix\` early-exited with "No skill-touched files in scope" because its \`git diff BASELINE_SHA..HEAD\` returned nothing → **41 unformatted files** landed on CI and failed the Lint and format checks job.

**Fix:** new step between \`skill_review\` and \`skill_commits\`:

\`\`\`yaml
- name: Sync local branch with skill-pushed commits
  run: |
    git fetch origin "$HEAD_REF" --quiet
    git merge --ff-only "origin/$HEAD_REF" || true
\`\`\`

Local HEAD now reflects whatever the skill pushed, so downstream steps see the truth. Fixes both symptoms with one change.

## 2. \`--max-turns\` per skill invocation

| Session | Cap | Baseline | Rationale |
| --- | ---: | --- | --- |
| \`skill_gen\` | 500 | 89 (silent) / 397 (full rebuild) | ~25% headroom over worst legitimate run |
| \`skill_review\` | 30 | 4-5 every run | 6x buffer; cheap safety net |

Hitting a cap fails the step loudly. If a release genuinely needs more, we raise deliberately.

## 3. \`timeout-minutes\` per skill step

| Session | Cap | Baseline |
| --- | ---: | --- |
| \`skill_gen\` | 45 min | 15-22 min observed |
| \`skill_review\` | 10 min | 1-2 min observed |

Kills a stuck process before it burns the full 90-min job budget. Step-level, independent of turn count.

## Worst-case cost ceiling once capped

- Gen hits 500 turns → ~\$34 (extrapolating from PR #780's \$26.95 at 397 turns)
- Review hits 30 turns → ~\$2
- **Per-run ceiling: ~\$36**

## What this does NOT cover

- **Legitimate expensive runs** (PR #780 at \$27 was real work; would still cost \$27).
- **Upstream Anthropic pricing changes.**
- **High-frequency triggering** (e.g. 20 retries in a row).

For those, set a monthly spend cap at the Anthropic console — that's the ultimate ceiling independent of any workflow change.

## Validation

Next \`workflow_dispatch\` on rolled-back content should produce:
- \`skill_commits\` count matching the actual skill commit count (non-zero when content was produced).
- Autofix step finding and formatting skill-touched files before they hit CI.
- No silent-run NOTE when commits exist.
- If a runaway ever occurs, clean failure at cap with a clear error message instead of an unbounded spend.