### PR TITLE
Bump skill turn caps (review 30→200, gen 500→1000)

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -548,14 +548,16 @@ jobs:
           # authors write at open time. GH_TOKEN for auth is already
           # in the job env at the top of this workflow.
           #
-          # --max-turns 500: observed gen baselines are 89 turns
-          # (silent) to 397 (full content rebuild). 500 gives headroom
-          # over the worst legitimate run, while clipping a genuine
-          # runaway before it spirals. Hitting the cap produces a
-          # loud failure -- raise deliberately if a release needs more.
+          # --max-turns 1000: observed gen baselines are 20 turns
+          # (silent) to 152 (full content rebuild). 500 was the
+          # initial cap; bumped to 1000 for extra headroom on
+          # multi-feature releases and to stay well above the
+          # suspected-looping 397-turn v3-test run (still clips
+          # genuine runaways). Hitting the cap produces a loud
+          # failure -- raise deliberately if a release needs more.
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 500
+            --max-turns 1000
             --allowed-tools "Bash(gh:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
@@ -738,12 +740,18 @@ jobs:
           display_report: true
           # gh access parallels skill_gen so the review pass can
           # re-verify claims against PR descriptions and linked
-          # issues if needed. --max-turns 30 is 6x the 4-5-turn
-          # baseline; if review ever needs more, the cap fails
-          # loudly and we raise it.
+          # issues if needed.
+          #
+          # --max-turns 200: initial cap of 30 was sized against
+          # silent-release baselines (4-6 turns) and was too tight
+          # for real content reviews. v0.24.0 (PR #788) hit it at
+          # turn 31 mid-review and failed the run; the editorial
+          # pass genuinely needs ~30-100 turns to walk a multi-
+          # file content PR. 200 gives 2x-6x headroom over that
+          # working range while still clipping a runaway.
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 30
+            --max-turns 200
             --allowed-tools "Bash(gh:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow


### PR DESCRIPTION
## Context

PR #788 ([Update stacklok/toolhive to v0.24.0](https://github.com/stacklok/docs-website/pull/788)) failed the augmentation run when \`skill_review\` hit the 30-turn cap mid-edit.

From run [24786157448](https://github.com/stacklok/docs-website/actions/runs/24786157448):

| Session | Turns | Cost (USD) | Outcome |
| --- | ---: | ---: | --- |
| \`skill_gen\` | 67 | \$4.72 | ✅ Success (under 500 cap), committed \`42267da Document local vMCP CLI mode\` |
| \`skill_review\` | 31 | \$1.86 | ❌ Exit \`error_max_turns\` at turn 31 / 30 |

Review's failure cascaded the workflow to \`failure\`, skipping autofix and PR body augmentation — so PR #788 is stuck with an incomplete rendered body and no run-cost table, even though the skill's content work actually landed.

## Why the cap was too tight

My original review cap of **30** was sized against silent / no-changes release runs (baseline 4-6 turns). For a real multi-file content release like v0.24.0, the editorial pass genuinely walks each edited file and makes tightening edits — ~30-100 turns is legitimate working range.

## Changes

| Session | Old | New | Headroom rationale |
| --- | ---: | ---: | --- |
| \`skill_review\` | 30 | **200** | 2x-6x over observed 30-100 working range |
| \`skill_gen\` | 500 | **1000** | Defensive doubling; 500 never hit in production, but 1000 keeps us well clear of the 397-turn v3-test anomaly |

Caps still clip genuine runaways loudly; we raise them deliberately if a release ever genuinely needs more.

## Follow-up for PR #788

Once this merges, PR #788 needs a retry via \`gh workflow run upstream-release-docs.yml -f pr_number=788\` to complete the augmentation step. The existing skill content commit (\`42267da\`) stays; retry re-runs everything but should now finish review + autofix + body augmentation cleanly.