### PR TITLE
Gitignore SUMMARY.md signal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,11 @@ yarn-error.log*
 .claude/settings.local.json
 
 # Signal files written by upstream-release-docs.yml for the skill to
-# communicate gaps or no-op releases back to the workflow. Never committed.
+# communicate gaps, no-op releases, or a change summary back to the
+# workflow. Never committed; the workflow reads and removes them.
 /GAPS.md
 /NO_CHANGES.md
+/SUMMARY.md
 .claude/scheduled_tasks.lock
 
 # Scratch workspace claude-code-action creates during skill runs.


### PR DESCRIPTION
Small follow-up to #785.

## Problem

On PR #788's v0.24.0 run, \`SUMMARY.md\` landed on the branch alongside the skill's content commit (\`42267da\`). It shouldn't have — \`SUMMARY.md\` is a signal file the workflow's \`Capture skill signal files\` step is supposed to read + delete, not something to commit.

## Cause

\`/GAPS.md\` and \`/NO_CHANGES.md\` are already in \`.gitignore\` for exactly this reason. \`SUMMARY.md\` was introduced in #785 but I missed adding the matching gitignore entry. \`claude-code-action\`'s \`git add -A\` during auto-commit then swept it up.

## Fix

Add \`/SUMMARY.md\` to \`.gitignore\` alongside the existing signal-file entries. Matches how GAPS/NO_CHANGES are handled — skill writes to disk, workflow reads, neither ever hits a commit.

## Current in-flight retry

Run [24787405392](https://github.com/stacklok/docs-website/actions/runs/24787405392) (retry against PR #788) is still running as of this PR. It's using the workflow from \`main\` (which has the caps bump from #789) but the PR branch doesn't have the gitignore fix yet, so the retry's skill may commit another \`SUMMARY.md\`. The signals step's \`rm SUMMARY.md\` + commit-and-push's \`git add -A\` will clean it up in a deletion commit, so the final state is correct but the history is ugly.

After this gitignore fix merges, the user can optionally re-merge main into PR #788's branch for a clean future run; for any fresh Renovate PRs, the fix applies automatically.