### PR TITLE
Label upstream-projects Renovate PRs as autogen-docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -94,6 +94,7 @@
       "rebaseWhen": "never",
       "recreateWhen": "never",
       "commitMessageTopic": "{{depName}}",
+      "labels": ["autogen-docs"],
       "prBodyNotes": [
         "After this PR opens, `.github/workflows/upstream-release-docs.yml` adds source-verified content edits for the new release. For `stacklok/toolhive`, the same workflow also syncs reference assets (CLI help, Swagger) and regenerates the CRD MDX pages."
       ]


### PR DESCRIPTION
## Summary

- Override Renovate's top-level `dependencies` label for the `upstream-projects.yaml` custom manager only
- Those PRs trigger docs regeneration via `.github/workflows/upstream-release-docs.yml` rather than updating real dependencies, so `autogen-docs` is a more accurate label
- All other Renovate PRs (npm, GitHub Actions, MCP guide Docker images) keep their existing labels

## Test plan

- [ ] Next upstream release PR opened by Renovate is labeled `autogen-docs` and not `dependencies`
- [ ] Routine npm/GitHub Actions PRs still get `dependencies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)