### PR TITLE
Allow npm build/lint/format in Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,10 +26,10 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 1
+      # Checkout + Node + deps so Claude can run build/lint/format
+      # scripts when asked.
+      - name: Set up repo and dependencies
+        uses: ./.github/actions/setup
 
       - name: Run Claude Code
         id: claude
@@ -38,3 +38,5 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |
             actions: read
+          claude_args: |
+            --allowed-tools "Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,23 @@ on:
 
 jobs:
   claude:
+    # Only run for trusted actors. Fork PRs can modify package.json
+    # scripts; without this gate, an @claude mention on such a PR
+    # would execute attacker-controlled code under our secrets and
+    # write permissions.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -26,6 +38,16 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Initial checkout so GitHub Actions can resolve the local
+      # composite action below. The composite re-checks out the
+      # repo itself; this first checkout only needs the .github
+      # directory.
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          sparse-checkout: .github
+
       # Checkout + Node + deps so Claude can run build/lint/format
       # scripts when asked.
       - name: Set up repo and dependencies

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -558,7 +558,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 1000
-            --allowed-tools "Bash(gh:*)"
+            --allowed-tools "Bash(gh:*) Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed
@@ -752,7 +752,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 200
-            --allowed-tools "Bash(gh:*)"
+            --allowed-tools "Bash(gh:*) Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,9 @@ The project uses automated tooling to enforce code quality and formatting standa
 
 - **Pre-commit hooks**: lint-staged runs automatically on `git commit`, applying Prettier and appropriate linters to staged files.
 - **GitHub Actions**: All PRs trigger automated checks (ESLint, Prettier).
-- **No manual formatting needed**: The pre-commit hook handles formatting automatically - you do not need to run formatters manually.
+- **Don't rely on the pre-commit hook**: lint-staged only fires on `git commit` when Node, dependencies, and husky are all set up. It silently no-ops in CI and unattended contexts (GitHub Actions, scheduled agents) and in local environments where `npm install` hasn't been run. If you edited content, run `npm run prettier:fix` and `npm run eslint:fix` yourself to avoid lint failures on PR CI.
 
-File type to linter mapping (handled automatically by pre-commit hooks):
+File type to linter mapping (run manually if the pre-commit hook doesn't fire):
 
 - `.md` files: Prettier only
 - `.mdx` files: Prettier + ESLint


### PR DESCRIPTION
### Description

Two Claude Code workflows in this repo were missing the tooling needed to run the project's `npm run build`, `prettier`, and `eslint` scripts:

- **`upstream-release-docs.yml`** already tried to run them (the skill's Phase 5 validation calls out "run the project's lint/format commands"), but the sandbox allowlist only exposed `Bash(gh:*)`. A dedicated post-step currently auto-fixes lint/format drift to cover the gap.
- **`claude.yml`** (the `@claude` mention flow) had no Node/deps setup at all and no `claude_args`, so any mention-triggered edit to docs content would land unformatted and break PR CI.

This PR:

1. Adds `Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)` to `--allowed-tools` in both workflows. Wildcarded patterns cover the `:fix` variants.
2. Wires the mention workflow through the shared `./.github/actions/setup` composite so Node 24 + cached deps are present before the Claude step runs.
3. Updates `AGENTS.md` (the source file behind the `CLAUDE.md` symlink) to stop telling Claude "the pre-commit hook handles formatting, don't run formatters manually." That's true only on a dev machine that has Node, deps, and husky set up. The hook silently no-ops in CI, scheduled agents, and local envs without `npm install`, so the guidance now explicitly tells Claude to run `prettier:fix` and `eslint:fix` itself.

The post-step autofix in `upstream-release-docs.yml` is intentionally left in place until we've seen the new allowlist work on a real release.

### Type of change

- Navigation/structure change (workflow + AGENTS.md)

### Related issues/PRs

None.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style