### PR TITLE
Link optimizer tutorial to local CLI guide

### DIFF
--- a/docs/toolhive/tutorials/mcp-optimizer.mdx
+++ b/docs/toolhive/tutorials/mcp-optimizer.mdx
@@ -17,9 +17,9 @@ MCP tools.
 
 The optimizer is now integrated into
 [Virtual MCP Server (vMCP)](../guides-vmcp/optimizer.mdx), which provides the
-same tool filtering and token reduction at the team level. You can deploy it in
-Kubernetes today, and a local experience is coming soon. This tutorial walks you
-through the Kubernetes deployment.
+same tool filtering and token reduction at the team level. This tutorial walks
+you through the Kubernetes deployment. To run the optimizer locally, see
+[Run vMCP locally with the CLI](../guides-vmcp/local-cli.mdx).
 
 :::
 


### PR DESCRIPTION
### Description

The local vMCP CLI experience has shipped in the new [Run vMCP locally with the CLI](../blob/main/docs/toolhive/guides-vmcp/local-cli.mdx) how-to, so the "coming soon" note in the optimizer tutorial's "Moving to vMCP" admonition is stale. Replaces it with a pointer to the local CLI guide alongside the existing Kubernetes deployment callout.

### Type of change

- Documentation update

### Related issues/PRs

N/A

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)