### PR TITLE
Fix npm script allowlist patterns in Claude workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,4 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --allowed-tools "Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"
+            --allowed-tools "Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -558,7 +558,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 1000
-            --allowed-tools "Bash(gh:*) Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"
+            --allowed-tools "Bash(gh:*) Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed
@@ -752,7 +752,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 200
-            --allowed-tools "Bash(gh:*) Bash(npm run build:*) Bash(npm run prettier:*) Bash(npm run eslint:*)"
+            --allowed-tools "Bash(gh:*) Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed


### PR DESCRIPTION
### Description

PR #793 added `Bash(npm run prettier:*)` / `Bash(npm run eslint:*)` / `Bash(npm run build:*)` to `--allowed-tools` in `claude.yml` and `upstream-release-docs.yml`, intending the `:*` suffix to cover the `:fix` script variants as a wildcard. It doesn't.

In Claude Code's Bash permission grammar, `:*` is aliased to a space-separated argument wildcard: `Bash(foo:*) == Bash(foo *)`. The space enforces a word boundary. From the [Claude Code permissions docs](https://code.claude.com/docs/en/permissions.md):

> The `:*` suffix is an equivalent way to write a trailing wildcard, so `Bash(ls:*)` matches the same commands as `Bash(ls *)`.
> The space before `*` matters: `Bash(ls *)` matches `ls -la` but not `lsof`.

So `Bash(npm run prettier:*)` matches `npm run prettier --foo` (with a space before the arg) but not `npm run prettier:fix`, because `:fix` is part of the script name, not an argument — the permission matcher sees `npm run prettier:fix` as one token.

Fix: replace the wildcarded patterns with explicit script names for the five scripts these workflows actually invoke (`build`, `prettier`, `prettier:fix`, `eslint`, `eslint:fix`, all declared in `package.json`). `Bash(gh:*)` in `upstream-release-docs.yml` stays as-is — `gh` is a real CLI with real subcommands, so the arg wildcard is correct there.

Reported by @danbarr watching the 0.24.1 docs PR — `npm run prettier:fix` was still prompting "This command requires approval" despite the allowlist entry.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up to #793.

### Test plan

- [ ] `@claude` mention a PR and ask Claude to run `npm run prettier:fix` — command should auto-approve.
- [ ] On the next upstream release PR, confirm the skill's internal `npm run eslint:fix` call runs without approval prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)