### PR TITLE
Add Skills section to ToolHive UI guide

### DIFF
--- a/docs/toolhive/concepts/skills.mdx
+++ b/docs/toolhive/concepts/skills.mdx
@@ -150,6 +150,8 @@ Skills can be distributed as:
 
 ## Next steps
 
+- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx) for a
+  desktop-app workflow
 - [Manage agent skills](../guides-cli/skills-management.mdx) with the ToolHive
   CLI
 - [Manage skills in the registry](../guides-registry/skills.mdx) through the

--- a/docs/toolhive/concepts/skills.mdx
+++ b/docs/toolhive/concepts/skills.mdx
@@ -150,8 +150,7 @@ Skills can be distributed as:
 
 ## Next steps
 
-- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx) for a
-  desktop-app workflow
+- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx)
 - [Manage agent skills](../guides-cli/skills-management.mdx) with the ToolHive
   CLI
 - [Manage skills in the registry](../guides-registry/skills.mdx) through the

--- a/docs/toolhive/guides-cli/skills-management.mdx
+++ b/docs/toolhive/guides-cli/skills-management.mdx
@@ -374,6 +374,8 @@ pointing to that digest are removed.
 ## Related information
 
 - [Understanding skills](../concepts/skills.mdx) for a conceptual overview
+- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx) for the
+  desktop-app workflow
 - [`thv skill` command reference](../reference/cli/thv_skill.md)
 - [`thv serve` command reference](../reference/cli/thv_serve.md)
 - [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/toolhive/guides-cli/skills-management.mdx
+++ b/docs/toolhive/guides-cli/skills-management.mdx
@@ -374,8 +374,8 @@ pointing to that digest are removed.
 ## Related information
 
 - [Understanding skills](../concepts/skills.mdx) for a conceptual overview
-- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx) for the
-  desktop-app workflow
+- [Manage agent skills in the ToolHive UI](../guides-ui/skills.mdx) to browse,
+  install, and build skills without leaving the app
 - [`thv skill` command reference](../reference/cli/thv_skill.md)
 - [`thv serve` command reference](../reference/cli/thv_serve.md)
 - [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/toolhive/guides-ui/index.mdx
+++ b/docs/toolhive/guides-ui/index.mdx
@@ -55,6 +55,8 @@ details.
 - **Want to connect your AI client?** See
   [Client configuration](./client-configuration.mdx) to point Claude, Cursor, or
   another client at your running servers.
+- **Working with agent skills?** Browse the registry, build your own, and manage
+  what's installed from the [Skills](./skills.mdx) section.
 
 ## Contents
 

--- a/docs/toolhive/guides-ui/skills-browse-install.mdx
+++ b/docs/toolhive/guides-ui/skills-browse-install.mdx
@@ -49,7 +49,7 @@ Click any skill in the list to open its detail page. The layout has two columns:
   and Mermaid diagrams.
 
 Click the **Back** button to return to the **Registry** tab on the page and
-position you'd left it on.
+position you left it on.
 
 ## Install a skill
 

--- a/docs/toolhive/guides-ui/skills-browse-install.mdx
+++ b/docs/toolhive/guides-ui/skills-browse-install.mdx
@@ -5,126 +5,70 @@ description:
   clients with the ToolHive desktop app.
 ---
 
-The **Registry** tab on the **Skills** page is your catalog for ready-made agent
-skills. From there you can search the registry, open a detail page to read what
-a skill does, and install it into one or more of your AI clients without leaving
-the app.
+The **Registry** tab on the **Skills** page lets you discover skills published
+in the configured registry and install them into one or more of your AI clients.
 
 ## Prerequisites
 
 - A supported AI client installed and registered with ToolHive. See
-  [Client configuration](./client-configuration.mdx) and the
-  [client compatibility reference](../reference/client-compatibility.mdx) for
-  the list of clients that support skills.
+  [Client configuration](./client-configuration.mdx) and
+  [Client compatibility](../reference/client-compatibility.mdx).
 - A registry that publishes skills. ToolHive uses the registry configured under
   **Settings** → **Registry**. To host your own catalog, deploy the
   [ToolHive Registry Server](../guides-registry/skills.mdx).
 
-## Browse the registry
+## Install a skill from the registry
 
-Open **Skills** from the menu bar, then select the **Registry** tab.
+1. Open **Skills** from the menu bar, then select the **Registry** tab.
+2. Find the skill you want. Type in the search box to filter the catalog,
+   paginate through the results, or click a skill to open its detail page and
+   read the full `SKILL.md`.
+3. Click **Install** on the skill's card, table row, or detail page. ToolHive
+   opens the **Install skill** dialog with the reference field pre-filled.
+4. Fill in the dialog (see [Configure the install](#configure-the-install)) and
+   click **Install**.
 
-The catalog shows each skill's name, namespace, description, and an **Install**
-action. Use the controls in the top-right corner of the tab to:
-
-- **Search**: type in the search box to filter skills server-side. The query is
-  debounced so you don't see results flicker as you type.
-- **Switch view**: toggle between a card grid and a table. The table view adds
-  an **Author** column (namespace) on larger viewports.
-- **Paginate**: registry results are paginated, with 24 entries per page by
-  default. The active page is preserved when you navigate to a detail page and
-  back, so you don't lose your place.
-
-If a search returns no results, the tab shows an empty state inviting you to
-adjust the query.
-
-## View skill details
-
-Click any skill in the list to open its detail page. The layout has two columns:
-
-- **Left**: the skill name, namespace, source repository, version and license
-  badges, a short summary, and the **Install** action.
-- **Right**: the rendered `SKILL.md` content. ToolHive fetches the skill body
-  from the registry and renders it as Markdown, including code blocks, tables,
-  and Mermaid diagrams.
-
-Click the **Back** button to return to the **Registry** tab on the page and
-position you left it on.
-
-## Install a skill
-
-You can start an install in two ways:
-
-- From the **Registry** tab, click the **Install** button (with the **+** icon)
-  directly on a skill card or table row.
-- From a skill detail page, click **Install** in the sticky summary panel.
-
-In both cases, ToolHive opens the **Install skill** dialog with the reference
-field pre-filled. When you start from a registry skill, the OCI reference and
-version are split into the appropriate fields automatically.
+If the install fails, an error message appears inside the dialog with the
+details returned by the server. Common causes are an invalid reference, a
+missing version, or a project root that isn't a Git repository.
 
 ### Configure the install
 
 The **Install skill** dialog asks for:
 
-1. **Reference** [Required]\
-   The skill source. ToolHive accepts:
-   - A registry name (for example, `toolhive-cli-user`).
-   - A full OCI reference (for example,
-     `ghcr.io/<OWNER>/skills/<SKILL_NAME>:<TAG>`).
-   - A Git URL of the form `git://host/owner/repo[@ref][#path/to/skill]`.
+- **Reference** (required) - the skill source. ToolHive accepts:
+  - A registry name (for example, `toolhive-cli-user`).
+  - A full OCI reference (for example,
+    `ghcr.io/<OWNER>/skills/<SKILL_NAME>:<TAG>`).
+  - A Git URL of the form `git://host/owner/repo[@ref][#path/to/skill]`.
 
-1. **Version** [Optional]\
-   Provided automatically when you start from a registry skill. Leave blank to
-   install the latest version.
+- **Version** (optional) - provided automatically when you start from a registry
+  skill. Leave blank to install the latest version.
 
-1. **Scope** [Required]\
-   Where the skill files are written on disk. Hover the **(i)** icon to see the
-   inline tooltip:
-   - **User**: installed globally in your home directory and available across
-     all projects.
-   - **Project**: installed in the root of a specific project folder and scoped
-     to that project only.
+- **Scope** (required) - where the skill files are written on disk. Hover the
+  **(i)** icon next to the field to see the inline tooltip:
+  - **User**: installed globally in your home directory and available across all
+    projects.
+  - **Project**: installed in the root of a specific project folder and scoped
+    to that project only.
 
-1. **Project root** [Required when scope is Project]\
-   The absolute path to a Git repository on your machine. ToolHive validates
-   that the folder is a Git repo before installing, so it doesn't drop skill
-   files in arbitrary directories. Use the folder picker or paste a path.
+- **Project root** (required when scope is Project) - the absolute path to a Git
+  repository on your machine. ToolHive validates that the folder is a Git repo
+  to prevent installing skill files in unintended directories. Use the folder
+  picker or paste a path.
 
-1. **Clients** [Optional]\
-   The AI clients that should receive the skill. The dropdown lists only clients
-   you have installed and that support skills, so you don't pick a target
-   ToolHive can't write to. Select one or more boxes to target a subset.\
-   Leave the field blank to install for **all detected clients**. ToolHive sends
-   an empty list to the API, which the server interprets as "every
-   skill-supporting client this user has registered".
+- **Clients** (optional) - the AI clients that should receive the skill. The
+  dropdown lists only clients you have installed and that support skills. Select
+  one or more boxes to target a subset, or leave the field blank to install for
+  **all detected clients**.
 
-Click **Install** to write the skill files into each selected client's skills
-directory and record the install in ToolHive's database.
-
-If the install fails, an inline destructive alert appears inside the dialog with
-the error message returned by the API. Common causes are an invalid reference, a
-missing version, or a project root that isn't a Git repository.
-
-:::info[What's happening?]
-
-When you click **Install**, ToolHive:
-
-1. Resolves the reference (registry, OCI, or Git).
-2. Downloads and extracts the skill files.
-3. Writes `SKILL.md` and any supporting files to each selected client's skills
-   directory (for example, `~/.claude/skills/<SKILL_NAME>/` for Claude Code in
-   user scope, or `<PROJECT_ROOT>/.claude/skills/...` in project scope).
-4. Records the install so you can manage it from the **Installed** tab.
-
-Your AI client picks up the skill the next time it scans its skills directory.
-
-:::
+ToolHive writes the skill files into each selected client's skills directory and
+records the install so you can manage it from the **Installed** tab. Your AI
+client picks up the skill the next time it scans its skills directory.
 
 ## Next steps
 
-- [Manage installed skills](./skills-manage.mdx) to inspect, update, or
-  uninstall skills.
+- [Manage installed skills](./skills-manage.mdx) to inspect or uninstall skills.
 - [Build a skill from a local folder](./skills-build.mdx) when you want to
   package and reuse your own.
 

--- a/docs/toolhive/guides-ui/skills-browse-install.mdx
+++ b/docs/toolhive/guides-ui/skills-browse-install.mdx
@@ -1,0 +1,140 @@
+---
+title: Browse and install skills
+description:
+  Discover skills from the configured registry and install them into your AI
+  clients with the ToolHive desktop app.
+---
+
+The **Registry** tab on the **Skills** page is your catalog for ready-made agent
+skills. From there you can search the registry, open a detail page to read what
+a skill does, and install it into one or more of your AI clients without leaving
+the app.
+
+## Prerequisites
+
+- A supported AI client installed and registered with ToolHive. See
+  [Client configuration](./client-configuration.mdx) and the
+  [client compatibility reference](../reference/client-compatibility.mdx) for
+  the list of clients that support skills.
+- A registry that publishes skills. ToolHive uses the registry configured under
+  **Settings** → **Registry**. To host your own catalog, deploy the
+  [ToolHive Registry Server](../guides-registry/skills.mdx).
+
+## Browse the registry
+
+Open **Skills** from the menu bar, then select the **Registry** tab.
+
+The catalog shows each skill's name, namespace, description, and an **Install**
+action. Use the controls in the top-right corner of the tab to:
+
+- **Search**: type in the search box to filter skills server-side. The query is
+  debounced so you don't see results flicker as you type.
+- **Switch view**: toggle between a card grid and a table. The table view adds
+  an **Author** column (namespace) on larger viewports.
+- **Paginate**: registry results are paginated, with 24 entries per page by
+  default. The active page is preserved when you navigate to a detail page and
+  back, so you don't lose your place.
+
+If a search returns no results, the tab shows an empty state inviting you to
+adjust the query.
+
+## View skill details
+
+Click any skill in the list to open its detail page. The layout has two columns:
+
+- **Left**: the skill name, namespace, source repository, version and license
+  badges, a short summary, and the **Install** action.
+- **Right**: the rendered `SKILL.md` content. ToolHive fetches the skill body
+  from the registry and renders it as Markdown, including code blocks, tables,
+  and Mermaid diagrams.
+
+Click the **Back** button to return to the **Registry** tab on the page and
+position you'd left it on.
+
+## Install a skill
+
+You can start an install in two ways:
+
+- From the **Registry** tab, click the **Install** button (with the **+** icon)
+  directly on a skill card or table row.
+- From a skill detail page, click **Install** in the sticky summary panel.
+
+In both cases, ToolHive opens the **Install skill** dialog with the reference
+field pre-filled. When you start from a registry skill, the OCI reference and
+version are split into the appropriate fields automatically.
+
+### Configure the install
+
+The **Install skill** dialog asks for:
+
+1. **Reference** [Required]\
+   The skill source. ToolHive accepts:
+   - A registry name (for example, `toolhive-cli-user`).
+   - A full OCI reference (for example,
+     `ghcr.io/<OWNER>/skills/<SKILL_NAME>:<TAG>`).
+   - A Git URL of the form `git://host/owner/repo[@ref][#path/to/skill]`.
+
+1. **Version** [Optional]\
+   Provided automatically when you start from a registry skill. Leave blank to
+   install the latest version.
+
+1. **Scope** [Required]\
+   Where the skill files are written on disk. Hover the **(i)** icon to see the
+   inline tooltip:
+   - **User**: installed globally in your home directory and available across
+     all projects.
+   - **Project**: installed in the root of a specific project folder and scoped
+     to that project only.
+
+1. **Project root** [Required when scope is Project]\
+   The absolute path to a Git repository on your machine. ToolHive validates
+   that the folder is a Git repo before installing, so it doesn't drop skill
+   files in arbitrary directories. Use the folder picker or paste a path.
+
+1. **Clients** [Optional]\
+   The AI clients that should receive the skill. The dropdown lists only clients
+   you have installed and that support skills, so you don't pick a target
+   ToolHive can't write to. Select one or more boxes to target a subset.\
+   Leave the field blank to install for **all detected clients**. ToolHive sends
+   an empty list to the API, which the server interprets as "every
+   skill-supporting client this user has registered".
+
+Click **Install** to write the skill files into each selected client's skills
+directory and record the install in ToolHive's database.
+
+If the install fails, an inline destructive alert appears inside the dialog with
+the error message returned by the API. Common causes are an invalid reference, a
+missing version, or a project root that isn't a Git repository.
+
+:::info[What's happening?]
+
+When you click **Install**, ToolHive:
+
+1. Resolves the reference (registry, OCI, or Git).
+2. Downloads and extracts the skill files.
+3. Writes `SKILL.md` and any supporting files to each selected client's skills
+   directory (for example, `~/.claude/skills/<SKILL_NAME>/` for Claude Code in
+   user scope, or `<PROJECT_ROOT>/.claude/skills/...` in project scope).
+4. Records the install so you can manage it from the **Installed** tab.
+
+Your AI client picks up the skill the next time it scans its skills directory.
+
+:::
+
+## Next steps
+
+- [Manage installed skills](./skills-manage.mdx) to inspect, update, or
+  uninstall skills.
+- [Build a skill from a local folder](./skills-build.mdx) when you want to
+  package and reuse your own.
+
+## Related information
+
+- [Understanding skills](../concepts/skills.mdx) for the `SKILL.md` format
+  reference and concept overview
+- [Manage skills in the registry](../guides-registry/skills.mdx) to publish
+  skills for your team
+- [Client configuration](./client-configuration.mdx) to register AI clients with
+  ToolHive
+- [Client compatibility](../reference/client-compatibility.mdx) for clients that
+  support skills

--- a/docs/toolhive/guides-ui/skills-build.mdx
+++ b/docs/toolhive/guides-ui/skills-build.mdx
@@ -5,111 +5,70 @@ description:
   the ToolHive desktop app.
 ---
 
-The **Local Builds** tab on the **Skills** page lets you turn a folder on your
-machine into an OCI artifact you can install into your AI clients, share with
-teammates, or push to a registry later. Use it to develop skills iteratively
-without leaving the app.
+The **Local Builds** tab on the **Skills** page lets you package a folder on
+your machine into an OCI artifact, install it into your AI clients, or push it
+to a registry later. Use it to develop skills iteratively without leaving the
+app.
 
 ## Prerequisites
 
 - A skill directory on your machine that contains a `SKILL.md` file at its root.
   See [Understanding skills](../concepts/skills.mdx#skill-structure) for the
   required structure and
-  [frontmatter fields](../concepts/skills.mdx#skillmd-frontmatter).
+  [frontmatter](../concepts/skills.mdx#skillmd-frontmatter).
 - A supported AI client registered with ToolHive if you intend to install the
   build afterwards. See [Client configuration](./client-configuration.mdx).
 
-## Open the Local Builds tab
-
-Open **Skills** from the menu bar, then select the **Local Builds** tab.
-
-When the local store is empty, the tab shows an empty state with a single
-**Build skill** button. Once you've built at least one artifact, the tab also
-shows a search input, a card/table view toggle, and a **Build skill** button in
-the top-right corner.
-
 ## Build a skill
 
-Click **Build skill** to open the **Build skill** dialog and fill in:
+1. Open **Skills** from the menu bar, select the **Local Builds** tab, and click
+   **Build skill**.
+2. Fill in the **Build skill** dialog:
+   - **Path** (required) - the absolute path to the folder that contains your
+     `SKILL.md`. Click the folder icon to use the native OS folder picker, or
+     paste/type a path directly. ToolHive validates the path; if the folder
+     doesn't exist, you'll see a **Folder does not exist** error and the build
+     won't run.
+   - **Tag** (optional) - the OCI tag to apply to the build, for example
+     `my-skill:latest` or `ghcr.io/my-org/skills/my-skill:v1.0.0`. If you leave
+     it blank, ToolHive uses a default tag derived from the skill name.
 
-1. **Path** [Required]\
-   The absolute path to the folder that contains your `SKILL.md`. You can:
-   - Click the folder icon to open the native OS folder picker.
-   - Paste or type a path directly into the field.
+3. Click **Build**. ToolHive validates the contents (a `SKILL.md` with `name`
+   and `description`, no symlinks or path traversal), creates the OCI artifact
+   in your local store, and adds it to the **Local Builds** tab.
 
-   ToolHive validates the path against the file system. If the folder doesn't
-   exist, you'll see a **Folder does not exist** error under the field and the
-   build is not dispatched.
+If validation fails, the error message stays inline in the dialog so you can
+correct your input without losing typed values.
 
-   :::note[Hidden folders]
+:::note[Hidden folders]
 
-   The native folder picker on macOS and Windows hides dot-folders such as
-   `.agents` or `.claude` by default. If your skill lives inside one of those,
-   paste the absolute path directly into the **Path** field instead of using the
-   picker.
+The native folder picker on macOS and Windows hides dot-folders such as
+`.agents` or `.claude` by default. If your skill lives inside one of those,
+paste the absolute path directly into the **Path** field.
 
-   :::
+:::
 
-1. **Tag** [Optional]\
-   The OCI tag to apply to the build, for example
-   `ghcr.io/my-org/skills/my-skill:v1.0.0` or `my-skill:latest`. If you leave it
-   blank, ToolHive uses a default tag derived from the skill name.
-
-Click **Build** to package the folder. ToolHive validates the skill contents (a
-`SKILL.md` with `name` and `description`, no symlinks or path traversal),
-creates an OCI artifact in the local store, and records the build so it appears
-in the tab.
-
-If validation fails, an error message stays inline in the dialog so you can
-correct the input without losing your typed values.
-
-### Install a build right away
+## Install a build
 
 A successful build shows a toast with an **Install now** action. Click it to
-open the **Install skill** dialog with the reference pre-filled with the local
-build tag, then follow the steps in
-[Browse and install skills](./skills-browse-install.mdx#configure-the-install).
+open the **Install skill** dialog with the reference pre-filled with your
+build's tag, then follow the steps in
+[Configure the install](./skills-browse-install.mdx#configure-the-install).
 
-You can also install a build later from the **Local Builds** tab or from the
-build's detail page.
+You can also install a build later by clicking **Install** on its row, card, or
+detail page.
 
-## View build details
+## Remove a build
 
-Click any row or card in the **Local Builds** tab to open the build detail page.
-The layout matches the registry skill detail page:
+Click **Remove** on any row, card, or detail page and confirm the dialog.
+ToolHive deletes the artifact from the local OCI store. When multiple tags share
+the same digest, the underlying blobs are retained until every tag pointing to
+that digest is removed.
 
-- **Left**: the build name, version (or a `latest` badge when no version is
-  set), tag, digest (truncated with a hover tooltip showing the full hash), an
-  **Install** action, and a **Remove** action.
-- **Right**: the rendered `SKILL.md` content. ToolHive strips the YAML
-  [frontmatter](../concepts/skills.mdx#skillmd-frontmatter) from the rendered
-  body, since the same fields already appear in the summary panel.
+## Push a build to a remote registry
 
-Click the **Back** button to return to the **Local Builds** tab.
-
-## List and remove local builds
-
-The **Local Builds** tab shows every artifact you've built locally:
-
-- In **card view**, each build card displays the name, version or `latest`
-  badge, tag, and a truncated digest, with **Install** and **Remove** actions in
-  the footer.
-- In **table view**, columns include **Build**, **Version**, **Digest**,
-  **About**, and the same **Install** + **Remove** actions per row.
-
-Use the search input to filter the list by tag, name, or digest.
-
-To remove an artifact, click **Remove** on any row, card, or detail page and
-confirm the dialog. ToolHive deletes the artifact from the local OCI store. When
-multiple tags share the same digest, the underlying blobs are retained until
-every tag pointing to that digest is removed. Removing a build from the detail
-page redirects you back to the **Local Builds** list.
-
-## Push a local build to a remote registry
-
-Pushing local OCI artifacts to a remote container registry is currently a
-command-line operation. Once you've built a skill in the UI, switch to a
-terminal and run:
+Pushing to a remote container registry is currently a CLI-only operation. After
+building, run:
 
 ```bash
 thv skill push <TAG>
@@ -122,8 +81,8 @@ For details, including authenticating with the remote registry, see
 
 - [Browse and install skills](./skills-browse-install.mdx) to install your local
   build into an AI client.
-- [Manage installed skills](./skills-manage.mdx) to track, update, or uninstall
-  the skills you've added.
+- [Manage installed skills](./skills-manage.mdx) to track or uninstall the
+  skills you've added.
 
 ## Related information
 

--- a/docs/toolhive/guides-ui/skills-build.mdx
+++ b/docs/toolhive/guides-ui/skills-build.mdx
@@ -1,0 +1,136 @@
+---
+title: Build a skill from a local folder
+description:
+  Package a folder on your machine into an OCI skill artifact and reuse it with
+  the ToolHive desktop app.
+---
+
+The **Local Builds** tab on the **Skills** page lets you turn a folder on your
+machine into an OCI artifact you can install into your AI clients, share with
+teammates, or push to a registry later. Use it to develop skills iteratively
+without leaving the app.
+
+## Prerequisites
+
+- A skill directory on your machine that contains a `SKILL.md` file at its root.
+  See [Understanding skills](../concepts/skills.mdx#skill-structure) for the
+  required structure and
+  [frontmatter fields](../concepts/skills.mdx#skillmd-frontmatter).
+- A supported AI client registered with ToolHive if you intend to install the
+  build afterwards. See [Client configuration](./client-configuration.mdx).
+
+## Open the Local Builds tab
+
+Open **Skills** from the menu bar, then select the **Local Builds** tab.
+
+When the local store is empty, the tab shows an empty state with a single
+**Build skill** button. Once you've built at least one artifact, the tab also
+shows a search input, a card/table view toggle, and a **Build skill** button in
+the top-right corner.
+
+## Build a skill
+
+Click **Build skill** to open the **Build skill** dialog and fill in:
+
+1. **Path** [Required]\
+   The absolute path to the folder that contains your `SKILL.md`. You can:
+   - Click the folder icon to open the native OS folder picker.
+   - Paste or type a path directly into the field.
+
+   ToolHive validates the path against the file system. If the folder doesn't
+   exist, you'll see a **Folder does not exist** error under the field and the
+   build is not dispatched.
+
+   :::note[Hidden folders]
+
+   The native folder picker on macOS and Windows hides dot-folders such as
+   `.agents` or `.claude` by default. If your skill lives inside one of those,
+   paste the absolute path directly into the **Path** field instead of using the
+   picker.
+
+   :::
+
+1. **Tag** [Optional]\
+   The OCI tag to apply to the build, for example
+   `ghcr.io/my-org/skills/my-skill:v1.0.0` or `my-skill:latest`. If you leave it
+   blank, ToolHive uses a default tag derived from the skill name.
+
+Click **Build** to package the folder. ToolHive validates the skill contents (a
+`SKILL.md` with `name` and `description`, no symlinks or path traversal),
+creates an OCI artifact in the local store, and records the build so it appears
+in the tab.
+
+If validation fails, an error message stays inline in the dialog so you can
+correct the input without losing your typed values.
+
+### Install a build right away
+
+A successful build shows a toast with an **Install now** action. Click it to
+open the **Install skill** dialog with the reference pre-filled with the local
+build tag, then follow the steps in
+[Browse and install skills](./skills-browse-install.mdx#configure-the-install).
+
+You can also install a build later from the **Local Builds** tab or from the
+build's detail page.
+
+## View build details
+
+Click any row or card in the **Local Builds** tab to open the build detail page.
+The layout matches the registry skill detail page:
+
+- **Left**: the build name, version (or a `latest` badge when no version is
+  set), tag, digest (truncated with a hover tooltip showing the full hash), an
+  **Install** action, and a **Remove** action.
+- **Right**: the rendered `SKILL.md` content. ToolHive strips the YAML
+  [frontmatter](../concepts/skills.mdx#skillmd-frontmatter) from the rendered
+  body, since the same fields already appear in the summary panel.
+
+Click the **Back** button to return to the **Local Builds** tab.
+
+## List and remove local builds
+
+The **Local Builds** tab shows every artifact you've built locally:
+
+- In **card view**, each build card displays the name, version or `latest`
+  badge, tag, and a truncated digest, with **Install** and **Remove** actions in
+  the footer.
+- In **table view**, columns include **Build**, **Version**, **Digest**,
+  **About**, and the same **Install** + **Remove** actions per row.
+
+Use the search input to filter the list by tag, name, or digest.
+
+To remove an artifact, click **Remove** on any row, card, or detail page and
+confirm the dialog. ToolHive deletes the artifact from the local OCI store. When
+multiple tags share the same digest, the underlying blobs are retained until
+every pointing tag is removed. Removing a build from the detail page redirects
+you back to the **Local Builds** list.
+
+## Push a local build to a remote registry
+
+Pushing local OCI artifacts to a remote container registry is currently a
+command-line operation. Once you've built a skill in the UI, switch to a
+terminal and run:
+
+```bash
+thv skill push <TAG>
+```
+
+For details, including authenticating with the remote registry, see
+[Push to a registry](../guides-cli/skills-management.mdx#push-to-a-registry).
+
+## Next steps
+
+- [Browse and install skills](./skills-browse-install.mdx) to install your local
+  build into an AI client.
+- [Manage installed skills](./skills-manage.mdx) to track, update, or uninstall
+  the skills you've added.
+
+## Related information
+
+- [Understanding skills](../concepts/skills.mdx#skill-structure) for the
+  required `SKILL.md` structure and
+  [frontmatter](../concepts/skills.mdx#skillmd-frontmatter)
+- [Manage skills with the CLI](../guides-cli/skills-management.mdx) for
+  validating, pushing, and other CLI-only flows
+- [Agent Skills specification](https://agentskills.io/specification) for the
+  complete format reference

--- a/docs/toolhive/guides-ui/skills-build.mdx
+++ b/docs/toolhive/guides-ui/skills-build.mdx
@@ -102,8 +102,8 @@ Use the search input to filter the list by tag, name, or digest.
 To remove an artifact, click **Remove** on any row, card, or detail page and
 confirm the dialog. ToolHive deletes the artifact from the local OCI store. When
 multiple tags share the same digest, the underlying blobs are retained until
-every pointing tag is removed. Removing a build from the detail page redirects
-you back to the **Local Builds** list.
+every tag pointing to that digest is removed. Removing a build from the detail
+page redirects you back to the **Local Builds** list.
 
 ## Push a local build to a remote registry
 

--- a/docs/toolhive/guides-ui/skills-manage.mdx
+++ b/docs/toolhive/guides-ui/skills-manage.mdx
@@ -28,7 +28,7 @@ Use the controls in the top-right corner to:
 Each card surfaces the metadata you need at a glance:
 
 - **Name and namespace**: the skill identifier.
-- **Status badge**: `active`, `deprecated`, or `archived` (case insensitive), as
+- **Status badge**: `active`, `deprecated`, or `archived` (case-insensitive), as
   published by the source.
 - **Scope badge**: an icon and label for the install scope:
   - **User** scope (person icon): installed in your home directory and available

--- a/docs/toolhive/guides-ui/skills-manage.mdx
+++ b/docs/toolhive/guides-ui/skills-manage.mdx
@@ -6,71 +6,42 @@ description:
 ---
 
 The **Installed** tab on the **Skills** page is the source of truth for every
-skill ToolHive has added to your AI clients. Use it to confirm a skill landed
-where you expected, see which clients received it, and remove it cleanly when
-you're done.
+skill ToolHive has added to your AI clients. Use it to confirm a skill landed in
+the right scope and on the right clients, and to remove skills you no longer
+need.
 
-## Open the Installed tab
+## Find an installed skill
 
-Open **Skills** from the menu bar, then select the **Installed** tab.
+1. Open **Skills** from the menu bar, then select the **Installed** tab.
+2. Type in the search box to filter the list locally by name, namespace, or
+   description.
+3. Click any row or card to open the detail page for the full `SKILL.md` and the
+   install metadata.
 
 When the list is empty, the tab points you at the **Registry** tab to discover
 and install your first skill.
 
-Use the controls in the top-right corner to:
-
-- **Search**: filter the list locally by name, namespace, or description.
-- **Switch view**: toggle between a card grid and a table. The view preference
-  is remembered the next time you open the tab.
-
-## Read the installed skill cards
-
-Each card surfaces the metadata you need at a glance:
-
-- **Name and namespace**: the skill identifier.
-- **Status badge**: `active`, `deprecated`, or `archived` (case-insensitive), as
-  published by the source.
-- **Scope badge**: an icon and label for the install scope:
-  - **User** scope (person icon): installed in your home directory and available
-    across all projects.
-  - **Project** scope (folder icon): scoped to a specific project folder.
-- **Project root badge** (project-scoped skills only): a monospace badge showing
-  the last path segment, with a tooltip that reveals the full absolute path on
-  hover.
-- **Client badges**: the AI clients ToolHive installed the skill for. Long lists
-  collapse to the first three plus a `+N` badge that reveals the remaining
-  clients in a tooltip.
-- **Description**: the first lines of the skill's description, clamped for
-  layout. The full text lives on the detail page.
-
-In **table view**, the same fields are spread across columns so you can sort and
-scan large lists. Click any row or card to open the detail page.
-
-## View installed skill details
-
-The detail page mirrors the registry layout: a left column with the skill
-identity, scope, clients, and source reference, and the rendered `SKILL.md` on
-the right. Use the **Back** button to return to the **Installed** tab.
+Each card and table row surfaces the context you need to confirm an install: the
+skill's name and namespace, its scope (User or Project), the AI clients that
+received it, and (for project-scoped skills) the project root path.
 
 ## Uninstall a skill
 
-To remove a skill, click the **Uninstall** action on any card, table row, or
-detail page and confirm the dialog.
+Click **Uninstall** on any card, table row, or detail page and confirm the
+dialog. ToolHive deletes the skill files from every associated client's skills
+directory and removes the database record. The **Installed** tab updates
+immediately.
 
-ToolHive deletes the skill files from every associated client's skills directory
-and removes the database record. The change is reflected in the **Installed**
-tab immediately.
-
-To reinstall the same skill later, head back to the **Registry** tab or to the
-**Local Builds** tab and click **Install** again. ToolHive treats it as a fresh
-install, so you can change scope or target clients at that point.
+To reinstall the same skill later, return to the **Registry** tab or the **Local
+Builds** tab and click **Install** again. ToolHive treats it as a fresh install,
+so you can change scope or target clients at that point.
 
 :::tip[Reinstall to overwrite]
 
 The UI doesn't expose an explicit `--force` action like the
 [`thv skill install` command](../guides-cli/skills-management.mdx#overwrite-an-existing-skill).
-If you need to overwrite an existing install, uninstall the skill first and then
-install it again.
+To overwrite an existing install, uninstall the skill first and then install it
+again.
 
 :::
 

--- a/docs/toolhive/guides-ui/skills-manage.mdx
+++ b/docs/toolhive/guides-ui/skills-manage.mdx
@@ -1,0 +1,136 @@
+---
+title: Manage installed skills
+description:
+  Inspect, search, and uninstall agent skills you've added to your AI clients
+  through the ToolHive desktop app.
+---
+
+The **Installed** tab on the **Skills** page is the source of truth for every
+skill ToolHive has added to your AI clients. Use it to confirm a skill landed
+where you expected, see which clients received it, and remove it cleanly when
+you're done.
+
+## Open the Installed tab
+
+Open **Skills** from the menu bar, then select the **Installed** tab.
+
+When the list is empty, the tab points you at the **Registry** tab to discover
+and install your first skill.
+
+Use the controls in the top-right corner to:
+
+- **Search**: filter the list locally by name, namespace, or description.
+- **Switch view**: toggle between a card grid and a table. The view preference
+  is remembered the next time you open the tab.
+
+## Read the installed skill cards
+
+Each card surfaces the metadata you need at a glance:
+
+- **Name and namespace**: the skill identifier.
+- **Status badge**: `active`, `deprecated`, or `archived` (case insensitive), as
+  published by the source.
+- **Scope badge**: an icon and label for the install scope:
+  - **User** scope (person icon): installed in your home directory and available
+    across all projects.
+  - **Project** scope (folder icon): scoped to a specific project folder.
+- **Project root badge** (project-scoped skills only): a monospace badge showing
+  the last path segment, with a tooltip that reveals the full absolute path on
+  hover.
+- **Client badges**: the AI clients ToolHive installed the skill for. Long lists
+  collapse to the first three plus a `+N` badge that reveals the remaining
+  clients in a tooltip.
+- **Description**: the first lines of the skill's description, clamped for
+  layout. The full text lives on the detail page.
+
+In **table view**, the same fields are spread across columns so you can sort and
+scan large lists. Click any row or card to open the detail page.
+
+## View installed skill details
+
+The detail page mirrors the registry layout: a left column with the skill
+identity, scope, clients, and source reference, and the rendered `SKILL.md` on
+the right. Use the **Back** button to return to the **Installed** tab.
+
+## Uninstall a skill
+
+To remove a skill, click the **Uninstall** action on any card, table row, or
+detail page and confirm the dialog.
+
+ToolHive deletes the skill files from every associated client's skills directory
+and removes the database record. The change is reflected in the **Installed**
+tab immediately.
+
+To reinstall the same skill later, head back to the **Registry** tab or to the
+**Local Builds** tab and click **Install** again. ToolHive treats it as a fresh
+install, so you can change scope or target clients at that point.
+
+:::tip[Reinstall to overwrite]
+
+The UI doesn't expose an explicit `--force` action like the
+[`thv skill install` command](../guides-cli/skills-management.mdx#overwrite-an-existing-skill).
+If you need to overwrite an existing install, uninstall the skill first and then
+install it again.
+
+:::
+
+## Next steps
+
+- [Browse and install skills](./skills-browse-install.mdx) to add more skills
+  from the registry.
+- [Build a skill from a local folder](./skills-build.mdx) when you want to
+  package and reuse your own.
+
+## Related information
+
+- [Manage skills with the CLI](../guides-cli/skills-management.mdx) for
+  scripting, force-installs, and pushing builds to remote registries
+- [Manage skills in the registry](../guides-registry/skills.mdx) to publish
+  skills from a ToolHive Registry Server
+- [Client compatibility](../reference/client-compatibility.mdx) for clients that
+  support skills
+
+## Troubleshooting
+
+<details>
+<summary>An installed skill doesn't show up in my AI client</summary>
+
+If your AI client doesn't list a skill from the **Installed** tab:
+
+1. Confirm the skill is installed for the right client. Open the detail page or
+   check the client badges on the card.
+2. Confirm the scope matches where you're working. A **Project** scope skill
+   only appears when the client is opened in that project folder; a **User**
+   scope skill is global.
+3. Check the expected directory on disk. For example:
+   - **Claude Code**: `~/.claude/skills/<SKILL_NAME>/` (user) or
+     `<PROJECT_ROOT>/.claude/skills/<SKILL_NAME>/` (project).
+   - **Cursor**: `~/.cursor/skills/<SKILL_NAME>/` (user) or
+     `<PROJECT_ROOT>/.cursor/skills/<SKILL_NAME>/` (project).
+4. Restart your AI client so it rescans its skills directory.
+
+</details>
+
+<details>
+<summary>Project-scope install fails with a Git error</summary>
+
+ToolHive validates that the project root is a Git repository before writing
+skill files into it, to prevent installs in arbitrary folders.
+
+- Run `git init` in the project folder, or
+- Pick a folder that's already a Git repository, or
+- Install with **User** scope instead.
+
+</details>
+
+<details>
+<summary>Uninstall removes the skill but the client still references it</summary>
+
+Some AI clients cache their skills index on startup. After uninstalling, restart
+the client so it reloads the skills directory.
+
+If the skill files are still present on disk, run
+[`thv skill list`](../guides-cli/skills-management.mdx#list-installed-skills) in
+a terminal to confirm ToolHive's view, then remove any leftover files manually.
+
+</details>

--- a/docs/toolhive/guides-ui/skills.mdx
+++ b/docs/toolhive/guides-ui/skills.mdx
@@ -1,0 +1,67 @@
+---
+title: Manage agent skills
+sidebar_label: Skills
+description:
+  Install, build, and manage agent skills in the ToolHive desktop app to teach
+  your AI clients reusable workflows.
+---
+
+import DocCardList from '@theme/DocCardList';
+
+[Agent skills](https://agentskills.io/) are reusable bundles of instructions,
+scripts, and resources that teach AI agents how to perform specific tasks. Where
+MCP servers expose **tools** (the raw capabilities your agent can call), skills
+package the **knowledge** of when, why, and how to use those tools to get a job
+done.
+
+The ToolHive UI gives you one place to discover skills, install them for the AI
+clients you've registered, and build your own from a local folder. ToolHive
+takes care of writing the skill files into the right directory for each client
+and tracks every install so you can update or remove it cleanly.
+
+:::tip[New to skills?]
+
+If you're not sure what a skill is or how it relates to MCP servers, see
+[Understanding skills](../concepts/skills.mdx) for a conceptual overview.
+
+:::
+
+## The Skills page
+
+Open the **Skills** page from the menu bar to access three tabs:
+
+- **Registry**: browse skills from the configured registry, search and filter
+  the catalog, and install a skill in one click.
+- **Installed**: see every skill ToolHive has installed for your AI clients,
+  inspect its scope and target clients, and uninstall it.
+- **Local Builds**: list OCI artifacts you've built locally from a folder on
+  your machine, install them into a client, or remove them from your local
+  store.
+
+You can switch each tab between a card grid and a table using the view toggle in
+the top-right corner. Your preference is remembered per tab.
+
+Each skill detail page shows the rendered `SKILL.md` content alongside a summary
+panel with action buttons, so you can read what a skill does before installing
+it.
+
+## Where to start
+
+<DocCardList />
+
+:::tip[Prefer the command line?]
+
+Every action on the **Skills** page is also available through the
+[`thv skill` command](../guides-cli/skills-management.mdx), including pushing
+local builds to a remote OCI registry.
+
+:::
+
+## Related information
+
+- [Understanding skills](../concepts/skills.mdx) for the concept primer and
+  `SKILL.md` format reference
+- [Manage skills in the registry](../guides-registry/skills.mdx) to publish
+  skills from a ToolHive Registry Server
+- [Client compatibility](../reference/client-compatibility.mdx) for the list of
+  AI clients that support skills

--- a/docs/toolhive/guides-ui/skills.mdx
+++ b/docs/toolhive/guides-ui/skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manage agent skills
+title: Manage skills in ToolHive UI
 sidebar_label: Skills
 description:
   Install, build, and manage agent skills in the ToolHive desktop app to teach

--- a/docs/toolhive/guides-ui/skills.mdx
+++ b/docs/toolhive/guides-ui/skills.mdx
@@ -8,16 +8,9 @@ description:
 
 import DocCardList from '@theme/DocCardList';
 
-[Agent skills](https://agentskills.io/) are reusable bundles of instructions,
-scripts, and resources that teach AI agents how to perform specific tasks. Where
-MCP servers expose **tools** (the raw capabilities your agent can call), skills
-package the **knowledge** of when, why, and how to use those tools to get a job
-done.
-
-The ToolHive UI gives you one place to discover skills, install them for the AI
-clients you've registered, and build your own from a local folder. ToolHive
-takes care of writing the skill files into the right directory for each client
-and tracks every install so you can update or remove it cleanly.
+The ToolHive UI gives you one place to discover skills from the configured
+registry, install them into your AI clients, and build your own from a local
+folder, without switching to the command line.
 
 :::tip[New to skills?]
 
@@ -28,22 +21,18 @@ If you're not sure what a skill is or how it relates to MCP servers, see
 
 ## The Skills page
 
-Open the **Skills** page from the menu bar to access three tabs:
+Open **Skills** from the menu bar to access three tabs:
 
-- **Registry**: browse skills from the configured registry, search and filter
-  the catalog, and install a skill in one click.
-- **Installed**: see every skill ToolHive has installed for your AI clients,
-  inspect its scope and target clients, and uninstall it.
-- **Local Builds**: list OCI artifacts you've built locally from a folder on
-  your machine, install them into a client, or remove them from your local
-  store.
+- **Registry**: browse skills from the configured registry and install them.
+- **Installed**: see every skill ToolHive has added to your AI clients, and
+  uninstall them.
+- **Local Builds**: list OCI artifacts you've built locally, install them into a
+  client, or remove them from your local store.
 
-You can switch each tab between a card grid and a table using the view toggle in
-the top-right corner. Your preference is remembered per tab.
-
-Each skill detail page shows the rendered `SKILL.md` content alongside a summary
-panel with action buttons, so you can read what a skill does before installing
-it.
+Each tab supports a card/table view toggle in the top-right corner; your
+preference is remembered per tab. Clicking a skill or build opens a detail page
+with the rendered `SKILL.md` content alongside a summary panel with the
+available actions.
 
 ## Where to start
 
@@ -63,5 +52,5 @@ local builds to a remote OCI registry.
   `SKILL.md` format reference
 - [Manage skills in the registry](../guides-registry/skills.mdx) to publish
   skills from a ToolHive Registry Server
-- [Client compatibility](../reference/client-compatibility.mdx) for the list of
-  AI clients that support skills
+- [Client compatibility](../reference/client-compatibility.mdx) for clients that
+  support skills

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -58,6 +58,23 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'toolhive/guides-ui/client-configuration',
+        {
+          type: 'category',
+          label: 'Skills',
+          description:
+            'How to install, build, and manage agent skills from the ToolHive UI',
+          collapsed: false,
+          collapsible: false,
+          link: {
+            type: 'doc',
+            id: 'toolhive/guides-ui/skills',
+          },
+          items: [
+            'toolhive/guides-ui/skills-browse-install',
+            'toolhive/guides-ui/skills-build',
+            'toolhive/guides-ui/skills-manage',
+          ],
+        },
         'toolhive/guides-ui/cli-access',
         'toolhive/guides-ui/playground',
       ],


### PR DESCRIPTION
### Description

Documents the Skills feature shipped in ToolHive UI. Adds a new **Skills** category under **ToolHive UI** with four pages covering the three tabs on the Skills page (Registry, Local Builds, Installed) and the install / build / uninstall dialogs.

New pages under `docs/toolhive/guides-ui/`:

- `skills.mdx` - category index introducing the three-tab Skills page, with a `<DocCardList />` for navigation and a CLI cross-link.
- `skills-browse-install.mdx` - Registry tab walkthrough (search, view toggle, pagination), the skill detail page with rendered `SKILL.md`, and the **Install skill** dialog covering reference, scope (User vs Project tooltip copy), Git-repo project root requirement, and skill-supporting clients multi-select.
- `skills-build.mdx` - Local Builds tab (hidden toolbar when empty), the **Build skill** dialog with both folder picker and pasted/typed paths plus the dot-folder caveat, post-build "Install now" toast flow, the build detail page with version/`latest`/tag/digest badges, list/remove flows, and a pointer to the CLI for pushing to a remote OCI registry.
- `skills-manage.mdx` - Installed tab card/table contents (status, scope icon, project root, client `+N` overflow), uninstall confirmation, and troubleshooting `<details>` blocks.

Sidebar (`sidebars.ts`) gets a non-collapsible **Skills** category right after **Client configuration**, with the index page and the three sub-pages as children.

Cross-links added to `guides-ui/index.mdx`, `concepts/skills.mdx`, and `guides-cli/skills-management.mdx` so readers can jump between the UI, CLI, and conceptual coverage.

### Type of change

- New documentation
- Navigation/structure change

### Related issues/PRs

- stacklok/docs-website#771 - [Gap]: Document Skills management UI
- stacklok/toolhive-studio#1878 - feat(skills): add skills page with list, install, uninstall and build (and follow-ups #1980, #1993, #1995, #2020, #2027, #2045-#2047, #2063, #2064, #2078, #2080, #2097, #2098, #2102, #2119, #2122-#2128)

### Screenshots

N/A in this PR. Screenshot capture for the Skills page tabs, install dialog (with the User vs Project tooltip), build dialog, and skill detail page is a planned follow-up; the pages will pick up `ThemedImage` with `useBaseUrl` once the WebP files exist under `static/img/`.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

#### Navigation

- [x] New pages include a frontmatter section with title and description at a minimum
- [x] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] Redirects added to `vercel.json` for moved, renamed, or deleted pages (N/A - new pages only)