### PR TITLE
Refresh UI troubleshooting guidance

### DIFF
--- a/docs/toolhive/guides-ui/cli-access.mdx
+++ b/docs/toolhive/guides-ui/cli-access.mdx
@@ -104,10 +104,10 @@ If `thv` is not recognized after installing ToolHive UI:
 1. **Open a new terminal window**: PATH changes only take effect in new terminal
    sessions.
 
-1. **Check the Settings > CLI page**: verify that the PATH Configuration shows
+1. **Check the Settings > CLI page**: Verify that the PATH Configuration shows
    "Valid" status. If it doesn't, click **Reinstall**.
 
-1. **Source your shell configuration as a fallback**: if you can't open a new
+1. **Source your shell configuration as a fallback**: If you can't open a new
    terminal, reload your current shell:
 
    ```bash

--- a/docs/toolhive/guides-ui/cli-access.mdx
+++ b/docs/toolhive/guides-ui/cli-access.mdx
@@ -82,6 +82,18 @@ The page displays:
 Use the **Reinstall** button if the CLI becomes unavailable or the symlink
 breaks (for example, after moving the ToolHive UI application).
 
+## Next steps
+
+- [Run MCP servers](./run-mcp-servers.mdx) from the ToolHive UI
+- Explore the full [CLI guides](../guides-cli/index.mdx) for terminal-based
+  workflows
+
+## Related information
+
+- [CLI guides](../guides-cli/index.mdx)
+- [CLI command reference](../reference/cli/thv.md)
+- [CLI conflict resolution](../guides-cli/install.mdx#cli-conflict-resolution)
+
 ## Troubleshooting
 
 <details>
@@ -89,26 +101,20 @@ breaks (for example, after moving the ToolHive UI application).
 
 If `thv` is not recognized after installing ToolHive UI:
 
-1. **Open a new terminal window**: The PATH changes only take effect in new
-   terminal sessions.
+1. **Open a new terminal window**: PATH changes only take effect in new terminal
+   sessions.
 
-1. **Check the Settings > CLI page**: Verify that the PATH Configuration shows
-   "Valid" status.
+1. **Check the Settings > CLI page**: verify that the PATH Configuration shows
+   "Valid" status. If it doesn't, click **Reinstall**.
 
-1. **Manually source your shell configuration**:
+1. **Source your shell configuration as a fallback**: if you can't open a new
+   terminal, reload your current shell:
 
    ```bash
-   # Bash
-   source ~/.bashrc
-
-   # Zsh
-   source ~/.zshrc
-
-   # Fish
-   source ~/.config/fish/config.fish
+   source ~/.bashrc       # Bash
+   source ~/.zshrc        # Zsh
+   source ~/.config/fish/config.fish  # Fish
    ```
-
-1. **Reinstall the CLI**: Go to Settings > CLI and click **Reinstall**.
 
 </details>
 
@@ -133,15 +139,3 @@ CLI installed. See
 the error message and resolution steps.
 
 </details>
-
-## Next steps
-
-- [Run MCP servers](./run-mcp-servers.mdx) from the ToolHive UI
-- Explore the full [CLI guides](../guides-cli/index.mdx) for terminal-based
-  workflows
-
-## Related information
-
-- [CLI guides](../guides-cli/index.mdx)
-- [CLI command reference](../reference/cli/thv.md)
-- [CLI conflict resolution](../guides-cli/install.mdx#cli-conflict-resolution)

--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -260,5 +260,5 @@ extension. The ToolHive icon should then appear in your system tray.
 </details>
 
 For other installation issues, check the
-[ToolHive Studio issues](https://github.com/stacklok/toolhive-studio/issues) on
+[ToolHive UI issues](https://github.com/stacklok/toolhive-studio/issues) on
 GitHub or join the [Discord community](https://discord.gg/stacklok).

--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -223,26 +223,23 @@ ToolHive UI includes the CLI for terminal access and advanced features. See
 ## Troubleshooting
 
 <details>
-<summary>Connection Refused error on startup</summary>
+<summary>"Connection Refused" error on startup</summary>
 
-If you see a "Connection Refused" error when starting ToolHive, your container
-runtime (Docker, Podman, or Colima) is likely not installed, not running, or not
-configured correctly.
+A "Connection Refused" error on startup usually means your container runtime
+(Docker, Podman, or Colima) isn't installed, isn't running, or isn't configured
+correctly.
 
 Follow the instructions in the error message to install or start your container
 runtime. For example, if you're using Docker Desktop, make sure it's running and
-that the Docker daemon is active.
-
-If the retry button doesn't work, restart ToolHive.
+the Docker daemon is active. If the retry button doesn't work, restart ToolHive.
 
 </details>
 
 <details>
 <summary>No system tray icon on Linux</summary>
 
-Recent versions of Fedora Linux and other distributions have removed the
-AppIndicator extension from their default installations. ToolHive requires this
-extension for the system tray icon to work properly.
+Recent versions of Fedora and some other distributions ship without the
+AppIndicator GNOME extension that ToolHive needs to render its system tray icon.
 
 On Fedora, install the `gnome-shell-extension-appindicator` package:
 
@@ -250,22 +247,18 @@ On Fedora, install the `gnome-shell-extension-appindicator` package:
 sudo dnf install gnome-shell-extension-appindicator
 ```
 
-You'll need to log out and log back in to activate the extension.
+Log out and log back in to activate the extension.
 
 Alternatively, install the
-[Extension Manager](https://github.com/mjakeman/extension-manager) app. It's
-available as a native package in many distributions, or you can install it from
-[Flathub](https://flathub.org/apps/com.mattjakeman.ExtensionManager). Then, use
-Extension Manager to install the
-[AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/)
-extension (listed as "AppIndicator and KStatusNotifierItem Support").
-
-The ToolHive icon should now appear in your system tray.
+[Extension Manager](https://github.com/mjakeman/extension-manager) app from your
+distribution or
+[Flathub](https://flathub.org/apps/com.mattjakeman.ExtensionManager) and use it
+to install the
+[AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/)
+extension. The ToolHive icon should then appear in your system tray.
 
 </details>
 
-### Other issues
-
 For other installation issues, check the
-[GitHub issues page](https://github.com/stacklok/toolhive-studio/issues) or join
-the [Discord community](https://discord.gg/stacklok).
+[ToolHive Studio issues](https://github.com/stacklok/toolhive-studio/issues) on
+GitHub or join the [Discord community](https://discord.gg/stacklok).

--- a/docs/toolhive/guides-ui/playground.mdx
+++ b/docs/toolhive/guides-ui/playground.mdx
@@ -201,54 +201,6 @@ and identify any issues with tool implementation or configuration.
 4. **Error handling**: Intentionally trigger error conditions to validate proper
    error handling
 
-## Troubleshooting
-
-### Common issues
-
-<details>
-<summary>Provider not working</summary>
-
-If your provider isn't working:
-
-1. **For API key-based providers** (OpenAI, Anthropic, Google, xAI, OpenRouter):
-   - Verify the API key is correct and has proper permissions
-   - Check that you have sufficient quota or credits with the provider
-   - Ensure the API key hasn't expired or been revoked
-   - Try creating a new API key from the provider's dashboard
-
-2. **For local providers** (Ollama, LM Studio):
-   - Verify the server is running and accessible at the configured URL
-   - Check that the server URL is correct and includes the port number
-   - Ensure no firewall or network settings are blocking the connection
-   - For LM Studio, confirm you started the server in the **Developer** section
-
-</details>
-
-<details>
-<summary>MCP tools not appearing</summary>
-
-If your MCP server tools aren't showing up:
-
-1. Verify the MCP server is running (check the **MCP Servers** page)
-2. Click the tools icon and ensure the server's tools are enabled
-3. Try restarting the MCP server if it shows as unhealthy
-4. Check the server logs for any error messages
-
-</details>
-
-<details>
-<summary>Tool execution failing</summary>
-
-If tools are failing to execute:
-
-1. Check the tool's parameter requirements in the audit log
-2. Verify any required secrets or environment variables are configured
-3. Ensure the MCP server has necessary permissions (network access, file system
-   access)
-4. Review the server logs for detailed error information
-
-</details>
-
 ## Next steps
 
 - Learn about [client configuration](./client-configuration.mdx) to connect
@@ -264,3 +216,54 @@ If tools are failing to execute:
 
 - [Run MCP servers](./run-mcp-servers.mdx)
 - [Install ToolHive](./install.mdx)
+
+## Troubleshooting
+
+<details>
+<summary>Provider not working</summary>
+
+If a provider isn't working:
+
+1. **For API key-based providers** (OpenAI, Anthropic, Google, xAI, OpenRouter):
+   - If you see a 401 or "invalid API key" error, double-check the key in the
+     provider's API keys dashboard. The key may have been rotated, revoked, or
+     scoped to the wrong project.
+   - If you see a 429 or quota error, check your billing and usage in the
+     provider's dashboard.
+   - Confirm the key has access to the model you selected.
+
+2. **For local providers** (Ollama, LM Studio):
+   - Verify the server is running and reachable at the configured URL, including
+     the port (for example, `http://localhost:11434`).
+   - For LM Studio, confirm you started the server from the **Developer**
+     section.
+   - Check that no firewall or VPN is blocking localhost traffic.
+
+</details>
+
+<details>
+<summary>MCP tools not appearing</summary>
+
+If your MCP server tools aren't showing up:
+
+1. Verify the MCP server is running on the **MCP Servers** page.
+2. Click the tools icon in the playground and confirm the server's tools are
+   enabled for this session.
+3. Restart the MCP server if it shows as unhealthy.
+4. Check the server logs for errors.
+
+</details>
+
+<details>
+<summary>Tool execution failing</summary>
+
+If tools fail to execute:
+
+1. Check the tool's parameter requirements in the audit log.
+2. Verify any required secrets or environment variables are configured for the
+   server. See [Secrets management](./secrets-management.mdx).
+3. Ensure the MCP server has the permissions it needs (network access, file
+   system access). See [Network isolation](./network-isolation.mdx).
+4. Review the server logs for detailed error information.
+
+</details>

--- a/docs/toolhive/guides-ui/quickstart.mdx
+++ b/docs/toolhive/guides-ui/quickstart.mdx
@@ -153,24 +153,27 @@ integration, and hardened images for teams deploying MCP at scale.
 <details>
 <summary>Server fails to start</summary>
 
-If the server fails to start, check:
+If the server fails to start:
 
-- Is Docker, Podman, or Colima running?
-- Do you have internet access to pull the container image?
+- Confirm Docker, Podman, or Colima is running.
+- Confirm you have internet access to pull the container image.
+
+For more startup issues, see the
+[Install ToolHive](./install.mdx#troubleshooting) troubleshooting section.
 
 </details>
 
 <details>
 <summary>Client can't use the server</summary>
 
-If your AI client application can't use the server:
+If your AI client can't use the server:
 
-- Make sure your client is connected to ToolHive (see Step 4)
-- Restart your client to pick up the new configuration
-- Verify the server is running on the **MCP Servers** page
-- Disconnect and reconnect the client in ToolHive to refresh the configuration
+- Make sure your client is connected to ToolHive (see Step 4).
+- Restart your client to pick up the new configuration.
+- Verify the server is running on the **MCP Servers** page.
+- Disconnect and reconnect the client in ToolHive to refresh the configuration.
 
 </details>
 
-If you encounter any problems, please join our
-[Discord community](https://discord.gg/stacklok) for help.
+For other issues, join the [Discord community](https://discord.gg/stacklok) for
+help.

--- a/docs/toolhive/guides-ui/skills-manage.mdx
+++ b/docs/toolhive/guides-ui/skills-manage.mdx
@@ -98,10 +98,10 @@ skill files into it, to prevent installs in arbitrary folders.
 <summary>Uninstall removes the skill but the client still references it</summary>
 
 Some AI clients cache their skills index on startup. After uninstalling, restart
-the client so it reloads the skills directory.
+the client so it reloads its skills directory.
 
-If the skill files are still present on disk, run
-[`thv skill list`](../guides-cli/skills-management.mdx#list-installed-skills) in
-a terminal to confirm ToolHive's view, then remove any leftover files manually.
+If you still see the skill files in the directories listed above, run
+[`thv skill list`](../guides-cli/skills-management.mdx#list-installed-skills) to
+confirm ToolHive's view, then delete any leftover files manually.
 
 </details>


### PR DESCRIPTION
### Description

Tightens the troubleshooting sections in five `guides-ui/` pages as part of the
broader cross-section troubleshooting refresh.

Highlights:

- `cli-access.mdx`: moved Troubleshooting below Next steps and Related
  information to match the project's closing-section ordering. Tightened the
  "CLI not found" item by combining the source-shell-config fallback into a
  single block (matches what the page itself instructs above).
- `playground.mdx`: same closing-section reorder. Sharpened the "Provider not
  working" item to point at the provider's API keys dashboard with example
  errors (401/429) rather than speculating about expired or revoked keys.
  Cross-linked secrets and network isolation from the tool-execution item.
- `install.mdx`: tightened both troubleshooting items, replaced the dangling
  "Other issues" h3 with a closing paragraph, and corrected the link label to
  "ToolHive UI issues".
- `quickstart.mdx`: tightened wording, cross-linked to the install
  troubleshooting section for deeper startup issues.
- `skills-manage.mdx`: tightened the "client still references skill after
  uninstall" item to reference the directory paths already listed earlier on
  the page.

No screenshots changed. No new pages or sidebar changes.

### Type of change

- Documentation update

### Related issues/PRs

Refs #362.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)