### PR TITLE
Refresh CLI troubleshooting guidance

### DIFF
--- a/docs/toolhive/guides-cli/build-containers.mdx
+++ b/docs/toolhive/guides-cli/build-containers.mdx
@@ -418,31 +418,38 @@ thv build --tag my-server:dev go:///path/to/my-project
 <details>
 <summary>Build fails with network errors</summary>
 
-If builds fail with network connectivity issues:
+If `thv build` can't reach a package registry, the build runs inside a container
+and uses the same network the container runtime sees:
 
-1. **Check internet connectivity** for downloading packages
-2. **Configure CA certificates** for corporate environments:
+1. Confirm you can reach the registry from your machine. The build container
+   inherits the host's DNS and networking through Docker or Podman.
+2. In corporate environments with TLS inspection, configure ToolHive to trust
+   your CA certificate:
 
    ```bash
    thv config set-ca-cert /path/to/corporate-ca.crt
    ```
 
-3. **Use proxy settings** if required by your network
-4. **Verify package names** and versions exist in the respective registries
+3. If your network requires HTTP/HTTPS proxy settings, set them in the container
+   runtime (for example, in Docker Desktop's proxy settings) so the build
+   container picks them up.
+4. Inspect the generated Dockerfile to confirm the package reference is what you
+   expect:
+
+   ```bash
+   thv build --dry-run <PROTOCOL_SCHEME>
+   ```
 
 </details>
 
 <details>
 <summary>Invalid image tag format</summary>
 
-If you get image tag validation errors:
+If `thv build --tag` rejects your tag, the value must be a valid Docker
+reference: `name:tag` or `registry/name:tag`, with lowercase names and only
+hyphens, underscores, and dots as separators.
 
-1. **Use valid Docker image tag format**: `name:tag` or `registry/name:tag`
-2. **Avoid special characters** except hyphens, underscores, and dots
-3. **Use lowercase names** for compatibility
-4. **Check tag length limits** (typically 128 characters)
-
-Example valid tags:
+Examples that work:
 
 ```bash
 thv build --tag my-server:latest uvx://package
@@ -454,23 +461,25 @@ thv build --tag ghcr.io/org/server:v1.0.0 npx://package
 <details>
 <summary>Package not found errors</summary>
 
-If the build fails because a package cannot be found:
+If the build fails because a package can't be found, the package reference in
+your protocol scheme is most likely wrong.
 
-1. **Verify package exists** in the respective registry:
-   - Python: Check [PyPI](https://pypi.org/)
-   - Node.js: Check [npm](https://www.npmjs.com/)
-   - Go: Verify the module path and version
+1. Confirm the package exists in the right registry:
+   - Python (`uvx://`): [PyPI](https://pypi.org/)
+   - Node.js (`npx://`): [npm](https://www.npmjs.com/)
+   - Go (`go://`): the module path must resolve through the Go proxy
 
-2. **Check version specifiers**:
+2. Check the version syntax. The `@` separator picks a version, and `latest`
+   resolves to the most recent published version where supported:
 
    ```bash
-   # Correct version formats
    thv build uvx://package@1.0.0
    thv build npx://package@latest
    thv build go://github.com/user/repo@v1.0.0
    ```
 
-3. **For Go modules**, ensure the path includes the correct import path
+3. For Go modules, the path must point at a `main` package. Building a library
+   path will fail.
 
 </details>
 
@@ -479,23 +488,25 @@ If the build fails because a package cannot be found:
 
 If your custom package registry configuration isn't being applied:
 
-1. **Verify your build environment configuration**:
+1. Verify the build environment variables are set:
 
    ```bash
    thv config get-build-env
    ```
 
-2. **Check the environment variable names** match what your package manager
-   expects (for example, `NPM_CONFIG_REGISTRY` for npm, `GOPROXY` for Go)
+2. Check the variable names match what your package manager expects. For
+   example, `NPM_CONFIG_REGISTRY` for npm, `GOPROXY` for Go, `PIP_INDEX_URL` for
+   pip/uv.
 
-3. **Use `--dry-run` to inspect the generated Dockerfile** and verify your
-   environment variables are being injected:
+3. Use `--dry-run` to inspect the generated Dockerfile and confirm the variables
+   are being injected into the build:
 
    ```bash
    thv build --dry-run uvx://my-package
    ```
 
-4. **Ensure network connectivity** to your custom registry from inside the
-   container build environment
+4. Make sure the build container can reach your custom registry. If your
+   registry requires VPN or proxy access, configure that at the container
+   runtime level.
 
 </details>

--- a/docs/toolhive/guides-cli/build-containers.mdx
+++ b/docs/toolhive/guides-cli/build-containers.mdx
@@ -434,10 +434,11 @@ and uses the same network the container runtime sees:
    runtime (for example, in Docker Desktop's proxy settings) so the build
    container picks them up.
 4. Inspect the generated Dockerfile to confirm the package reference is what you
-   expect:
+   expect. Pass the full protocol URI, not just the scheme:
 
    ```bash
-   thv build --dry-run <PROTOCOL_SCHEME>
+   thv build --dry-run uvx://<PACKAGE>
+   # or npx://<PACKAGE>, go://<PACKAGE>, go://./<LOCAL_PATH>
    ```
 
 </details>

--- a/docs/toolhive/guides-cli/client-configuration.mdx
+++ b/docs/toolhive/guides-cli/client-configuration.mdx
@@ -221,7 +221,11 @@ thv mcp list tools --server <SERVER_NAME>
 ```
 
 - If the server returns the tools you expect, the issue is on the client side.
-  Re-register the client with `thv client setup` and restart it.
+  Re-register the client by running
+  [`thv client remove <CLIENT_IDENTIFIER>`](../reference/cli/thv_client_remove.md),
+  followed by
+  [`thv client register <CLIENT_IDENTIFIER>`](../reference/cli/thv_client_register.md),
+  and restart it.
 - If the server returns nothing or an error, check the server logs for startup
   issues like missing environment variables or authentication failures:
 

--- a/docs/toolhive/guides-cli/client-configuration.mdx
+++ b/docs/toolhive/guides-cli/client-configuration.mdx
@@ -200,40 +200,40 @@ If your client can't connect to the MCP server:
    See [Test MCP servers](./test-mcp-servers.mdx) for help testing the MCP
    server's availability.
 
-2. Check if the client is registered:
+2. Check that the client is registered:
 
    ```bash
    thv client status
    ```
 
-3. Restart your client application.
+3. Restart your client application so it picks up the latest configuration.
 
 </details>
 
 <details>
 <summary>Client can connect but tools aren't available</summary>
 
-If your client connects to the MCP server but tools aren't available:
+If your client connects to the MCP server but tools aren't available, ask the
+server directly what it advertises:
 
-1. Make sure the MCP server is running and accessible:
+```bash
+thv mcp list tools --server <SERVER_NAME>
+```
 
-   ```bash
-   thv list
-   ```
+- If the server returns the tools you expect, the issue is on the client side.
+  Re-register the client with `thv client setup` and restart it.
+- If the server returns nothing or an error, check the server logs for startup
+  issues like missing environment variables or authentication failures:
 
-   See [Test MCP servers](./test-mcp-servers.mdx) for help testing the MCP
-   server's functionality.
+  ```bash
+  thv logs <SERVER_NAME>
+  ```
 
-2. Check the MCP server logs:
+- If the MCP server requires authentication or has authorization policies
+  applied, make sure the client passes a token with the necessary permissions.
 
-   ```bash
-   thv logs <SERVER_NAME>
-   ```
-
-3. Make sure you properly configured the MCP server in your client.
-4. If the MCP server requires authentication or has authorization policies
-   applied, make sure the client has the necessary permissions to access the
-   tools.
+See [Test MCP servers](./test-mcp-servers.mdx) for more ways to validate an MCP
+server.
 
 </details>
 

--- a/docs/toolhive/guides-cli/filesystem-access.mdx
+++ b/docs/toolhive/guides-cli/filesystem-access.mdx
@@ -238,19 +238,25 @@ thv run --volume ~/my-database.db:/data/my-database.db sqlite -- --db /data/my-d
 
 If your MCP server can't access the file system as expected:
 
-1. Verify that the paths in your profile or volume flag are correct
-2. Ensure the host paths exist and have the correct permissions
-   - The MCP server runs as a specific user inside the container, so the host
-     paths must be accessible to that user
-3. Check that the permissions are set correctly (read/write)
-4. Inspect the container's mounted paths to ensure they match your expectations:
+1. Verify the paths in your profile or `--volume` flag are correct, and that
+   they're absolute paths on your host. Permission profiles do not support `~`
+   or relative paths.
+2. Ensure the host paths exist and are readable by the user the container runs
+   as (most MCP servers don't run as root inside the container).
+3. Confirm the permission direction matches what you need (`read` is read-only;
+   `write` implies read and write).
+4. Inspect the container's mounted paths to verify they match your expectations:
 
    ```bash
    docker inspect <SERVER_NAME>
    ```
 
-   Look for the `Mounts` section to see how paths are mapped.
+   Look at the `Mounts` section to see how host paths map into the container.
 
-5. Restart the server with the updated profile or corrected volume mount
+5. If you're using a `.thvignore` file to mask sensitive paths, run the server
+   with `--print-resolved-overlays` to see exactly what's being hidden. See
+   [Hide sensitive files](./thvignore.mdx) for details.
+
+6. Restart the server after updating the profile or volume mount.
 
 </details>

--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -412,17 +412,16 @@ If you see "permission denied" errors when running ToolHive:
    chmod +x /path/to/thv
    ```
 
-2. If using Docker on Linux, make sure your user has permission to access the
-   Docker socket:
+2. If you're using Docker on Linux, make sure your user has permission to access
+   the Docker socket:
 
    ```bash
    sudo usermod -aG docker $USER
    ```
 
-   (Log out and back in or run `newgrp docker` for this to take effect)
-
+   Log out and back in (or run `newgrp docker`) for the change to take effect.
    See
-   [Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
+   [Docker's post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)
    for more details.
 
 </details>
@@ -430,8 +429,9 @@ If you see "permission denied" errors when running ToolHive:
 <details>
 <summary>Upgrade error on Windows</summary>
 
-If you encounter an error when upgrading ToolHive on Windows, it may be due to
-the ToolHive executable being locked by a running MCP server proxy.
+On Windows, the `thv.exe` binary is locked while any MCP server proxy is
+running. If you try to upgrade with servers still running, you'll see an error
+like this:
 
 ```text title="Error example"
 An unexpected error occurred while executing the command:
@@ -447,17 +447,16 @@ To resolve this:
    thv stop --all
    ```
 
-2. After stopping all servers, run the upgrade command again:
+2. Re-run the upgrade:
 
    ```powershell
    winget upgrade stacklok.thv
    ```
 
-3. If you still encounter issues, check if any ToolHive processes are still
-   running in the background. You can use Task Manager to end any lingering
-   `thv.exe` processes.
+3. If the error persists, end any lingering `thv.exe` processes in Task Manager,
+   then re-run the upgrade.
 
-4. Restart your MCP servers:
+4. After the upgrade completes, restart your MCP servers:
 
    ```powershell
    thv list --all
@@ -467,8 +466,6 @@ To resolve this:
 
 </details>
 
-### Other issues
-
-For other installation issues, check the
+If you encounter a different installation issue, check the
 [GitHub issues page](https://github.com/stacklok/toolhive/issues) or join the
 [Discord community](https://discord.gg/stacklok).

--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -335,26 +335,34 @@ default behavior of allowing traffic only from the container's own hostname,
 <details>
 <summary>Network connectivity issues</summary>
 
-If your MCP server can't connect to external services:
+If your MCP server can't reach an external service when network isolation is
+enabled, the egress proxy is the source of truth for what's allowed and what
+gets denied.
 
-1. Verify that your profile allows the necessary hosts and ports
-2. Check that the transport protocol (TCP/UDP) is allowed
-3. Check the logs of the egress proxy container for blocked requests:
+1. Confirm your profile lists the host and port the server is trying to reach.
+   Network isolation only supports HTTP and HTTPS, so direct TCP/UDP connections
+   (databases, custom protocols) won't work behind the egress proxy.
+
+2. Check the egress proxy logs for the blocked request. ToolHive launches the
+   egress container as `<SERVER_NAME>-egress`:
 
    ```bash
    docker logs <SERVER_NAME>-egress
    ```
 
-   Look for messages indicating denied connections.
+   Look for denied or `403`-style entries that name the host and port the server
+   attempted to reach.
 
-4. Try temporarily using the default `network` profile to confirm it's a
-   permissions issue:
+3. To prove it's a permissions issue and not a different failure, run the server
+   temporarily with the built-in `network` profile, which allows all outbound
+   HTTP/HTTPS:
 
    ```bash
    thv run --isolate-network --permission-profile network <SERVER>
    ```
 
-5. If the default profile works, review the egress proxy logs to identify which
-   specific permissions are missing in your custom profile.
+   If the server works with this profile, copy the host and port from the denied
+   entries in step 2 into your custom profile's `network.outbound.allow_host`
+   and `allow_port` lists.
 
 </details>

--- a/docs/toolhive/guides-cli/quickstart.mdx
+++ b/docs/toolhive/guides-cli/quickstart.mdx
@@ -317,34 +317,18 @@ production-ready MCP servers, that's where Stacklok Enterprise comes in.
 
 ## Troubleshooting
 
-<details>
-<summary>Server fails to start</summary>
+If something doesn't work as expected, the
+[Run MCP servers troubleshooting section](./run-mcp-servers.mdx#troubleshooting)
+covers the common failure modes (server fails to start, no tools showing up in
+the client, port conflicts, etc.).
 
-If the server fails to start, check:
+A few quick checks specific to this tutorial:
 
-- Is Docker, Podman, or Colima running?
-- Do you have internet access to pull the container image?
-- Is the port already in use by another application?
+- Confirm Docker, Podman, or Colima is running before `thv run fetch`.
+- If port 15266 is already in use, pass a specific port with `--proxy-port`, for
+  example `thv run --proxy-port 8081 fetch`.
+- After running `thv client setup`, restart your AI client so it picks up the
+  new configuration.
 
-Try running with a specific port:
-
-```bash
-thv run --proxy-port 8081 fetch
-```
-
-</details>
-
-<details>
-<summary>Client can't use the server</summary>
-
-If your AI client application can't use the server:
-
-- Make sure your client is registered with ToolHive (see Step 5)
-- Check that your client is supported
-- Restart your client to pick up the new configuration
-- Verify the server is running with [`thv list`](../reference/cli/thv_list.md)
-
-</details>
-
-If you encounter any problems, please join our
+If you're still stuck, please join our
 [Discord community](https://discord.gg/stacklok) for help.

--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -1064,10 +1064,13 @@ If you can't connect to a remote MCP server:
    curl -I https://api.example.com/mcp
    ```
 
-2. Check what the remote server is actually advertising through ToolHive:
+2. Check what the remote server is actually advertising through ToolHive. For
+   remote-backed servers, pass the proxy URL from `thv list` rather than the
+   server name (the `--server` flag currently resolves names only for local
+   servers; see [Test MCP servers](./test-mcp-servers.mdx)):
 
    ```bash
-   thv mcp list tools --server <SERVER_NAME>
+   thv mcp list tools --server <PROXY_URL>
    ```
 
 3. Review the server logs for connection or authentication errors:

--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -971,8 +971,11 @@ thv mcp list resources --server <SERVER_NAME>
 ```
 
 If the server returns the tools you expect, the issue is on the client side:
-re-run [`thv client setup`](../reference/cli/thv_client_setup.md) and restart
-the client. If the server returns nothing or errors, check
+remove the client by running
+[`thv client remove <CLIENT_IDENTIFIER>`](../reference/cli/thv_client_remove.md),
+re-register the client by running
+[`thv client register <CLIENT_IDENTIFIER>`](../reference/cli/thv_client_register.md),
+and restart it. If the server returns nothing or errors, check
 `thv logs <SERVER_NAME>` for missing environment variables, failed
 authentication, or other startup problems.
 

--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -941,28 +941,64 @@ The configuration file must contain all server settings.
 
 If a server fails to start:
 
-1. Check if Docker, Podman, or Colima is running
-2. Verify you have internet access to pull images
-3. Check if the port is already in use
-4. Look at the error message for specific issues
-
-</details>
-
-<details>
-<summary>Server starts but isn't accessible</summary>
-
-If a server starts but isn't accessible:
-
-1. Check the server logs:
+1. Check that Docker, Podman, or Colima is running.
+2. Verify you have internet access to pull the image.
+3. Check whether the proxy port is already in use. To pick a specific port, use
+   `--proxy-port`.
+4. Inspect the server logs for the specific error:
 
    ```bash
    thv logs <SERVER_NAME>
    ```
 
-2. Verify the port isn't blocked by a firewall
+</details>
 
-3. Make sure clients are properly configured (see
-   [Client configuration](./client-configuration.mdx))
+<details>
+<summary>Server runs but no tools appear in the client</summary>
+
+If `thv list` shows the server as running but your AI client sees no tools, ask
+the server directly what it advertises:
+
+```bash
+thv mcp list tools --server <SERVER_NAME>
+```
+
+You can also list the prompts and resources the server exposes:
+
+```bash
+thv mcp list prompts --server <SERVER_NAME>
+thv mcp list resources --server <SERVER_NAME>
+```
+
+If the server returns the tools you expect, the issue is on the client side:
+re-run [`thv client setup`](../reference/cli/thv_client_setup.md) and restart
+the client. If the server returns nothing or errors, check
+`thv logs <SERVER_NAME>` for missing environment variables, failed
+authentication, or other startup problems.
+
+If you're using `--tools` to filter the tool list, make sure the names you
+passed match the tools the server actually advertises.
+
+</details>
+
+<details>
+<summary>Server starts but isn't accessible from the client</summary>
+
+If the server is running but a client can't reach it:
+
+1. Confirm the server is healthy and check what it exposes:
+
+   ```bash
+   thv list
+   thv mcp list tools --server <SERVER_NAME>
+   ```
+
+2. Check the proxy URL and port shown by `thv list` and try reaching it
+   directly. For Streamable HTTP servers, a quick `curl -I` against the URL
+   confirms the proxy is reachable.
+
+3. Make sure the client is registered for this server. See
+   [Client configuration](./client-configuration.mdx).
 
 </details>
 
@@ -983,9 +1019,15 @@ If a server crashes or exits unexpectedly:
    thv logs <SERVER_NAME>
    ```
 
-3. Check if the server requires any secrets or environment variables
+   Look for missing environment variable, secret, or argument errors. Many MCP
+   servers exit immediately if a required token isn't set.
 
-4. Verify the server's configuration and arguments
+3. Confirm the server's required secrets and arguments against its registry
+   entry:
+
+   ```bash
+   thv registry info <SERVER_NAME>
+   ```
 
 </details>
 
@@ -996,15 +1038,14 @@ If a remote MCP server authentication fails:
 
 1. Check the server logs for authentication errors (see
    [View server logs](./manage-mcp-servers.mdx#view-server-logs) for the correct
-   log file path on your platform)
+   log file path on your platform).
 
-2. Verify the issuer URL is correct and accessible
+2. Verify the issuer URL is correct and reachable from your machine.
 
-3. Check if the OAuth client ID and secret are valid
+3. Confirm the OAuth client ID and secret are valid and that the redirect URI
+   matches what's registered with your identity provider.
 
-4. Ensure the remote server supports the OAuth flow you're using
-
-5. Try re-authenticating by restarting the server:
+4. Re-authenticate by restarting the server:
 
    ```bash
    thv restart <SERVER_NAME>
@@ -1017,23 +1058,25 @@ If a remote MCP server authentication fails:
 
 If you can't connect to a remote MCP server:
 
-1. Verify the remote server URL is correct and accessible
-
-2. Check your network connectivity:
+1. Confirm the remote server URL is correct and reachable from your machine:
 
    ```bash
    curl -I https://api.example.com/mcp
    ```
 
-3. Check if the remote server requires specific headers or authentication
+2. Check what the remote server is actually advertising through ToolHive:
 
-4. Review the server logs for connection errors:
+   ```bash
+   thv mcp list tools --server <SERVER_NAME>
+   ```
+
+3. Review the server logs for connection or authentication errors:
 
    ```bash
    thv logs <SERVER_NAME>
    ```
 
-5. Try running with debug mode for more detailed logs:
+4. Re-run with debug logging if you need more detail:
 
    ```bash
    thv run --debug https://api.example.com/mcp --name my-server

--- a/docs/toolhive/guides-cli/secrets-management.mdx
+++ b/docs/toolhive/guides-cli/secrets-management.mdx
@@ -303,29 +303,31 @@ If you run into errors related to the system keyring:
 <details>
 <summary>Secret not available to MCP server</summary>
 
-If your MCP server can't access a secret:
+ToolHive injects each `--secret` value into the container as an environment
+variable named by the `target=` portion of the flag. If your MCP server can't
+access a secret, work backward from there:
 
-1. Verify the secret exists:
+1. Verify the secret exists in your secret store:
 
    ```bash
    thv secret list
    ```
 
-2. Verify the secret value:
+2. Confirm the value resolves correctly:
 
    ```bash
    thv secret get <SECRET_NAME>
    ```
 
-3. Check that you're using the correct secret name and target environment
-   variable. Inspect the MCP server's expected environment variables in the
-   registry:
+3. Check that the `target=` env var matches what the MCP server expects. The
+   server's registry entry lists the variables it reads:
 
    ```bash
    thv registry info <SERVER_NAME>
    ```
 
-4. Inspect the server logs for any errors:
+4. Inspect the server logs for "missing env var" or unauthorized-style errors,
+   which usually mean the secret never made it to the right variable name:
 
    ```bash
    thv logs <SERVER_NAME>

--- a/docs/toolhive/guides-cli/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-cli/telemetry-and-metrics.mdx
@@ -430,9 +430,12 @@ Telemetry adds minimal overhead when properly configured:
 
 If traces aren't showing up in your backend:
 
-1. Confirm the endpoint URL and authentication headers. The `--otel-endpoint`
-   flag takes a hostname and optional port, with no scheme or path. For example,
-   `api.honeycomb.io`, not `https://api.honeycomb.io/v1/traces`.
+1. Confirm the endpoint URL and authentication headers. `--otel-endpoint`
+   accepts a full URL (for example, `https://api.honeycomb.io`) or a bare
+   `host:port`. Don't append the OTLP signal path like `/v1/traces`. ToolHive
+   appends that automatically; if you include a base path (for example,
+   `https://cloud.langfuse.com/api/public/otel`) it is preserved and the OTLP
+   suffix is appended to it.
 2. Set the sampling rate to `1.0` temporarily so you can rule out a sampling
    issue:
 

--- a/docs/toolhive/guides-cli/telemetry-and-metrics.mdx
+++ b/docs/toolhive/guides-cli/telemetry-and-metrics.mdx
@@ -430,37 +430,60 @@ Telemetry adds minimal overhead when properly configured:
 
 If traces aren't showing up in your backend:
 
-1. Verify the endpoint URL and authentication headers
-2. Check network connectivity to the OTLP endpoint
-3. Ensure sampling rate isn't too low (set to `1.0` temporarily for testing)
-4. Check the ToolHive log file for errors related to telemetry (the log file
-   path is displayed when you start a server with `thv run`)
-5. If your endpoint uses a self-signed certificate or a certificate from a
-   custom CA, use the `--thv-ca-bundle` flag to add your CA or self-signed
-   certificate.
+1. Confirm the endpoint URL and authentication headers. The `--otel-endpoint`
+   flag takes a hostname and optional port, with no scheme or path. For example,
+   `api.honeycomb.io`, not `https://api.honeycomb.io/v1/traces`.
+2. Set the sampling rate to `1.0` temporarily so you can rule out a sampling
+   issue:
+
+   ```bash
+   thv run --otel-sampling-rate 1.0 --otel-endpoint <ENDPOINT> <SERVER>
+   ```
+
+3. Check the ToolHive log file for telemetry export errors. The log path is
+   printed when you start a server with `thv run`, and you can also view it
+   with:
+
+   ```bash
+   thv logs <SERVER_NAME>
+   ```
+
+4. If your endpoint uses a self-signed certificate or a certificate from a
+   custom CA, pass the bundle with `--thv-ca-bundle`. For local collectors
+   served over plain HTTP, use `--otel-insecure` instead.
 
 </details>
 
 <details>
 <summary>Prometheus metrics not available</summary>
 
-If the `/metrics` endpoint isn't accessible:
+If the `/metrics` endpoint isn't reachable:
 
-1. Confirm `--otel-enable-prometheus-metrics-path` is set
-2. Check that you're accessing the correct port
-3. Verify no firewall is blocking the port
+1. Confirm the server was started with `--otel-enable-prometheus-metrics-path`.
+   You can verify by re-checking `thv list` and curling the URL it shows with
+   `/metrics` appended:
+
+   ```bash
+   thv list
+   curl http://127.0.0.1:<PORT>/metrics
+   ```
+
+2. The `/metrics` endpoint is served on the same proxy port as the MCP server.
+   If `curl` returns connection refused, the server isn't running on that port
+   at all - check `thv list` again and look for the actual port.
 
 </details>
 
 <details>
 <summary>High CPU or memory usage</summary>
 
-If telemetry is consuming too many resources on your system:
+If telemetry is consuming too many resources:
 
-1. Reduce the sampling rate with `--otel-sampling-rate` for specific servers or
-   globally with `thv config otel set-sampling-rate`
-2. Only enable telemetry for servers you need to monitor
-3. Monitor the resource usage of the OpenTelemetry Collector or other backend
-   services
+1. Lower the sampling rate, either per-server with `--otel-sampling-rate` or
+   globally with `thv config otel set-sampling-rate`. A rate of `0.01` (1%) is a
+   reasonable starting point for high-traffic servers.
+2. Only enable telemetry for the servers you actually need to observe.
+3. If the load is on your collector or backend, check its own resource metrics,
+   not ToolHive's.
 
 </details>

--- a/docs/toolhive/guides-cli/thvignore.mdx
+++ b/docs/toolhive/guides-cli/thvignore.mdx
@@ -107,27 +107,6 @@ example, `.env*`, build artifacts) in your project's local `.thvignore`.
 
 :::
 
-## Troubleshooting
-
-<details>
-<summary>Overlays didn't apply</summary>
-
-- Ensure `.thvignore` exists in the mount source directory (not elsewhere)
-- Confirm patterns match actual names relative to the mount source
-- Run with `--print-resolved-overlays` and check the workload's log file path
-  displayed by `thv run`
-
-</details>
-
-<details>
-<summary>Can't list a parent directory</summary>
-
-- On SELinux systems, listing a parent directory may fail even though specific
-  files are accessible. Probe individual paths instead (for example, `stat` or
-  `cat`).
-
-</details>
-
 ## Next steps
 
 - [Restrict network access](./network-isolation.mdx) to control outbound
@@ -139,3 +118,39 @@ example, `.env*`, build artifacts) in your project's local `.thvignore`.
 - [Run MCP servers](./run-mcp-servers.mdx)
 - [Network isolation](./network-isolation.mdx)
 - [`thv run` command reference](../reference/cli/thv_run.md)
+
+## Troubleshooting
+
+<details>
+<summary>Overlays didn't apply</summary>
+
+If a path you expected to be hidden is still visible inside the container:
+
+- Make sure `.thvignore` is in the directory you mounted (not a parent or
+  subdirectory).
+- Confirm your patterns match real names relative to the mount source. Remember,
+  `**/*.env` is not supported, only entries directly under the mount source.
+- Re-run with `--print-resolved-overlays` and check the workload's log file for
+  the resolved overlay list:
+
+  ```bash
+  thv run --volume ./my-project:/projects \
+    --print-resolved-overlays \
+    filesystem
+  thv logs filesystem
+  ```
+
+If the file you expect to mount isn't showing up in the container at all (as
+opposed to being hidden), see
+[File system access troubleshooting](./filesystem-access.mdx#troubleshooting).
+
+</details>
+
+<details>
+<summary>Can't list a parent directory</summary>
+
+On SELinux systems, listing a parent directory may fail even though specific
+files within it are accessible. Probe individual paths instead (for example,
+`stat <PATH>` or `cat <PATH>`) rather than `ls <PARENT>`.
+
+</details>


### PR DESCRIPTION
### Description

Refresh the troubleshooting sections across the CLI guides so they reflect real diagnostic flows instead of speculative bullets. Part of the troubleshooting refresh tracked by #362; sibling PRs cover the UI, K8s, and misc sections.

Highlights:

- **`run-mcp-servers.mdx`**: replace generic "check logs / curl" guidance with `thv mcp list tools|prompts|resources --server <NAME>` as the canonical check that the server is actually advertising what you expect. Add a new "Server runs but no tools appear in the client" item.
- **`client-configuration.mdx`**: pivot the "Client can't see the server" item to use `thv mcp list tools` to disambiguate server-side vs client-side issues. Drop the speculative "make sure your client is supported" bullet (the supported-clients table is on the same page).
- **`quickstart.mdx`**: trim the speculative items and point to `Run MCP servers` troubleshooting to avoid duplication, keeping only the quickstart-specific notes.
- **`secrets-management.mdx`**: explain that `--secret target=ENV_VAR` injects the secret as an env var into the container, making `thv logs` the right diagnostic for "missing env var" patterns.
- **`filesystem-access.mdx` + `thvignore.mdx`**: cross-link troubleshooting between the two pages and surface `--print-resolved-overlays` from the filesystem side. Reorder `thvignore.mdx` so Troubleshooting comes after Next steps and Related information.
- **`install.mdx`, `build-containers.mdx`, `network-isolation.mdx`, `telemetry-and-metrics.mdx`**: tighten and de-speculate existing items, and sharpen vague "check logs" instructions with concrete commands and expected output.

`auth.mdx` and `skills-management.mdx` were left untouched - the auth troubleshooting lives in a shared partial owned by another PR, and the skills items are already concrete.

### Type of change

- Documentation update

### Related issues/PRs

Refs #362.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)