### PR TITLE
Refresh K8s troubleshooting guidance

### DIFF
--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -898,17 +898,22 @@ MCP server usage and performance.
 <summary>Ingress returns 503 Service Unavailable</summary>
 
 A 503 from the Ingress means the controller has no healthy backend to forward
-to. Check the Service has endpoints, which requires a Ready proxy pod:
+to. Check the Service exists and has endpoints:
 
 ```bash
+kubectl describe svc -n toolhive-system mcp-fetch-proxy
 kubectl get endpoints -n toolhive-system mcp-fetch-proxy
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch --show-labels
 kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
 ```
 
-If endpoints are empty:
+If the Service is missing, the operator hasn't reconciled the MCPServer yet (see
+[Run MCP servers in Kubernetes › Troubleshooting](./run-mcp-k8s.mdx#troubleshooting)).
+If endpoints are empty, possible causes include:
 
 - The proxy pod isn't Ready. The pod logs show why.
+- The Service selector doesn't match the proxy pod's labels (compare
+  `kubectl describe svc` selector with `kubectl get pods --show-labels`).
 - The Ingress backend Service name doesn't match the
   [service naming convention](#connect-from-outside-the-cluster) (for example,
   `mcp-<MCPSERVER_NAME>-proxy`).
@@ -994,10 +999,14 @@ If a pod can't reach the proxy Service, first confirm the Service exists and has
 endpoints:
 
 ```bash
+kubectl describe svc -n toolhive-system mcp-fetch-proxy
 kubectl get endpoints -n toolhive-system mcp-fetch-proxy
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch --show-labels
 ```
 
-Empty endpoints means the proxy pod isn't Ready. If endpoints look correct, test
+If endpoints are empty, the proxy pod isn't Ready, or the Service selector
+doesn't match the proxy pod's labels (compare the `Selector:` line from
+`describe svc` with the labels from `get pods`). If endpoints look correct, test
 DNS and connectivity from a temporary pod:
 
 ```bash

--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -897,28 +897,22 @@ MCP server usage and performance.
 <details>
 <summary>Ingress returns 503 Service Unavailable</summary>
 
-If your Ingress returns a 503 error:
+A 503 from the Ingress means the controller has no healthy backend to forward
+to. Check the Service has endpoints, which requires a Ready proxy pod:
 
 ```bash
-# Check if the service exists
-kubectl get service -n toolhive-system mcp-fetch-proxy
-
-# Check the proxy pod is running
+kubectl get endpoints -n toolhive-system mcp-fetch-proxy
 kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch
-
-# Check pod logs for errors
 kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
 ```
 
-Common causes:
+If endpoints are empty:
 
-- **Proxy pod not running**: Ensure the MCPServer resource was created
-  successfully
-- **Wrong service name**: The Ingress backend service name must follow the
-  naming conventions defined above
-- **Wrong port**: The Ingress backend port must match the `proxyPort` in the
-  MCPServer spec
-- **Pod health check failing**: Check the proxy pod logs for errors
+- The proxy pod isn't Ready. The pod logs show why.
+- The Ingress backend Service name doesn't match the
+  [service naming convention](#connect-from-outside-the-cluster) (for example,
+  `mcp-<MCPSERVER_NAME>-proxy`).
+- The Ingress backend port doesn't match `spec.proxyPort` on the MCPServer.
 
 </details>
 
@@ -994,52 +988,37 @@ For detailed OAuth setup and troubleshooting, see the
 </details>
 
 <details>
-<summary>Cannot connect from within cluster</summary>
+<summary>Cannot connect from within the cluster</summary>
 
-If pods cannot connect to the MCP server service:
+If a pod can't reach the proxy Service, first confirm the Service exists and has
+endpoints:
 
 ```bash
-# Verify service exists
-kubectl get service -n toolhive-system mcp-fetch-proxy
+kubectl get endpoints -n toolhive-system mcp-fetch-proxy
+```
 
-# Check that pods are running
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch
+Empty endpoints means the proxy pod isn't Ready. If endpoints look correct, test
+DNS and connectivity from a temporary pod:
 
-# Test DNS resolution from a pod
+```bash
 kubectl run test-dns -n toolhive-system --image=busybox --restart=Never -- \
   nslookup mcp-fetch-proxy.toolhive-system.svc.cluster.local
-
-# Check the DNS test results
 kubectl logs -n toolhive-system test-dns
-
-# Clean up the test pod
 kubectl delete pod -n toolhive-system test-dns
 
-# Test connectivity from a pod
 kubectl run test-curl -n toolhive-system --image=curlimages/curl --restart=Never -- \
-  curl -X POST http://mcp-fetch-proxy:8080/mcp \
+  curl -sS -X POST http://mcp-fetch-proxy:8080/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
-
-# Check the connectivity test results
 kubectl logs -n toolhive-system test-curl
-
-# Clean up the test pod
 kubectl delete pod -n toolhive-system test-curl
 ```
 
-Common causes:
-
-- **Network policies blocking traffic**: Check for network policies that might
-  prevent pod-to-pod communication
-- **Wrong namespace**: Ensure you're using the correct service DNS name for
-  cross-namespace access
-- **Service not created**: The operator automatically creates services, but
-  verify it exists
-- **Wrong port**: Ensure you're using the `proxyPort` value from the MCPServer
-  spec
-- **Wrong service name**: Remember the service name follows the naming
-  conventions defined above
+If DNS fails, verify the [service naming convention](#service-dns-names) and use
+the full `<SERVICE>.<NAMESPACE>.svc.cluster.local` form for cross-namespace
+calls. If DNS resolves but the request hangs or is refused, a NetworkPolicy is
+the most likely cause - see
+[Network policies for cross-namespace access](#network-policies-for-cross-namespace-access).
 
 </details>
 

--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -492,17 +492,24 @@ kubectl describe pod -n toolhive-system <TOOLHIVE_OPERATOR_POD_NAME>
 kubectl logs -n toolhive-system <TOOLHIVE_OPERATOR_POD_NAME>
 ```
 
-Common causes include:
+Common causes:
 
-- **Missing CRDs**: Ensure the CRDs were installed successfully before
-  installing the operator. The operator requires the CRDs to function properly.
-- **Configuration errors**: Check your `values.yaml` file for any
-  misconfigurations
-- **Insufficient permissions**: Ensure your cluster has the necessary RBAC
-  permissions for the operator to function
-- **Resource constraints**: Check if the cluster has sufficient CPU and memory
-  resources available
-- **Image pull issues**: Verify that the cluster can pull images from `ghcr.io`
+- **Missing CRDs**: The operator fails to start if the CRDs aren't installed.
+  Confirm they're present:
+
+  ```bash
+  kubectl api-resources --api-group=toolhive.stacklok.dev
+  ```
+
+  If the list is empty, install the CRDs as described in
+  [Install the CRDs](#install-the-crds).
+
+- **Image pull failure**: `kubectl describe pod` shows `ImagePullBackOff` or
+  `ErrImagePull`. Verify the cluster has egress to `ghcr.io` and that any custom
+  `operator.image` value in your `values.yaml` is correct.
+- **Invalid `values.yaml`**: The pod logs show a startup error referencing a
+  specific field. Compare your file against
+  `helm show values oci://ghcr.io/stacklok/toolhive/toolhive-operator`.
 
 </details>
 

--- a/docs/toolhive/guides-k8s/quickstart.mdx
+++ b/docs/toolhive/guides-k8s/quickstart.mdx
@@ -464,39 +464,51 @@ support - built for teams taking MCP from proof of concept to production.
 <details>
 <summary>Operator pod not starting</summary>
 
-If the operator pod isn't starting, check the logs:
+Check the operator logs for the failure reason:
 
 ```bash
 kubectl logs -n toolhive-system deployment/toolhive-operator
 ```
+
+For a deeper walkthrough, see the
+[deploy operator troubleshooting](./deploy-operator.mdx#troubleshooting).
 
 </details>
 
 <details>
 <summary>MCP server stuck in pending state</summary>
 
-Check the operator logs to see what's happening:
-
-```bash
-kubectl logs -n toolhive-system deployment/toolhive-operator -f
-```
-
-Also check if there are any resource constraints:
+Describe the MCPServer to see status conditions and recent events:
 
 ```bash
 kubectl describe mcpserver fetch -n toolhive-system
 ```
 
+If the events don't surface a clear reason, follow the operator logs while you
+re-apply the resource:
+
+```bash
+kubectl logs -n toolhive-system deployment/toolhive-operator -f
+```
+
 </details>
 
 <details>
-<summary>Can't access MCP server</summary>
+<summary>Can't access the MCP server</summary>
 
-Verify the service is created and has endpoints:
+Verify the Service has endpoints. Empty endpoints mean the proxy pod isn't
+Ready:
 
 ```bash
 kubectl get service mcp-fetch-proxy -n toolhive-system
 kubectl get endpoints mcp-fetch-proxy -n toolhive-system
+```
+
+If endpoints are empty, check the proxy pod:
+
+```bash
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch
+kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
 ```
 
 </details>

--- a/docs/toolhive/guides-k8s/quickstart.mdx
+++ b/docs/toolhive/guides-k8s/quickstart.mdx
@@ -496,18 +496,18 @@ kubectl logs -n toolhive-system deployment/toolhive-operator -f
 <details>
 <summary>Can't access the MCP server</summary>
 
-Verify the Service has endpoints. Empty endpoints mean the proxy pod isn't
-Ready:
+Verify the Service exists and has endpoints:
 
 ```bash
-kubectl get service mcp-fetch-proxy -n toolhive-system
+kubectl describe svc mcp-fetch-proxy -n toolhive-system
 kubectl get endpoints mcp-fetch-proxy -n toolhive-system
 ```
 
-If endpoints are empty, check the proxy pod:
+If endpoints are empty, either the proxy pod isn't Ready or the Service selector
+doesn't match the proxy pod's labels. Compare them:
 
 ```bash
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch --show-labels
 kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
 ```
 

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -839,23 +839,21 @@ feature in the ToolHive Registry Server.
 <details>
 <summary>Proxy pod in CrashLoopBackOff</summary>
 
-If the proxy pod is restarting continuously:
+Check the logs of both the current and previous container instance:
 
 ```bash
-# Check pod status
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=analytics-proxy
-
-# Check pod logs
 kubectl logs -n toolhive-system -l app.kubernetes.io/instance=analytics-proxy
+kubectl logs -n toolhive-system -l app.kubernetes.io/instance=analytics-proxy --previous
 ```
 
-Common causes:
+Typical causes:
 
-- **Invalid OIDC configuration**: Verify the MCPOIDCConfig resource is valid and
-  the issuer URL is accessible
-- **Certificate validation issues**: If using a custom CA, ensure `caBundleRef`
-  is set correctly
-- **Resource limits**: Check if the pod has sufficient CPU and memory
+- The MCPOIDCConfig issuer URL isn't reachable from inside the cluster, so JWKS
+  discovery fails on startup. Confirm cluster egress and DNS for the issuer.
+- The remote server uses a private CA but `caBundleRef` is missing or points to
+  a Secret/ConfigMap that doesn't exist.
+- The pod was OOMKilled. `kubectl describe pod` shows `Reason: OOMKilled` in the
+  last terminated state - raise `resources.limits`.
 
 </details>
 
@@ -899,24 +897,19 @@ add padding to the payload.
 <details>
 <summary>Remote server unreachable</summary>
 
-If the proxy cannot connect to the remote MCP server:
+Test connectivity from inside the proxy pod to isolate cluster egress from proxy
+logic:
 
 ```bash
-# Check proxy logs
-kubectl logs -n toolhive-system -l app.kubernetes.io/instance=analytics-proxy
-
-# Test connectivity from the pod
 kubectl exec -n toolhive-system <POD_NAME> -- \
   curl -v https://mcp.analytics.example.com
 ```
 
-Common causes:
-
-- **Network policies**: Check if network policies allow egress to the remote
-  server
-- **DNS resolution**: Verify the remote URL resolves correctly
-- **Firewall rules**: Ensure the cluster can reach the remote server
-- **Certificate issues**: If using HTTPS, verify certificates are valid
+If `curl` fails, the cluster can't reach the remote server. Check for
+NetworkPolicies that block egress from the proxy namespace, and confirm any
+upstream firewall or VPC egress rules permit the destination. If `curl` succeeds
+but the proxy still reports errors, check the proxy logs for the exact failure
+(TLS handshake, HTTP status, transport mismatch).
 
 </details>
 

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -568,222 +568,260 @@ The same 30-second default applies to the backend Deployment.
 
 ## Troubleshooting
 
-<details>
-<summary>MCPServer resource not creating pods</summary>
+Troubleshooting an MCPServer typically falls into one of three failure modes,
+depending on how far the resource has progressed: the operator never picks it
+up, the operator accepts it but pods fail, or pods run but clients can't reach
+the server. Start with `kubectl describe mcpserver <NAME>` to see which stage
+your server is stuck at, then jump to the matching section below.
 
-If your `MCPServer` resource is created but no pods appear, first ensure you
-created the `MCPServer` resource in an allowed namespace. If the operator runs
-in namespace mode and you didn't include the namespace in the
-`allowedNamespaces` list, the operator ignores the resource. Check the
-operator's configuration:
+### MCPServer not picked up by the operator
+
+The resource exists in the cluster but no proxy pod or backend pod is created,
+and `kubectl describe mcpserver` shows no events from the operator.
+
+<details>
+<summary>MCPServer resource is ignored by the operator</summary>
+
+The most common cause is that the operator runs in namespace mode and the
+MCPServer is in a namespace that isn't in `allowedNamespaces`. Check the
+operator configuration:
 
 ```bash
 helm get values toolhive-operator -n toolhive-system
 ```
 
-Check the `operator.rbac.scope` and `operator.rbac.allowedNamespaces`
-properties. If the operator runs in `namespace` mode, add the namespace where
-you created the `MCPServer` to the `allowedNamespaces` list. See
+Look at `operator.rbac.scope` and `operator.rbac.allowedNamespaces`. If the
+scope is `namespace`, add the MCPServer's namespace to `allowedNamespaces` and
+upgrade the chart. See
 [Operator deployment modes](./deploy-operator.mdx#operator-deployment-modes).
 
-If the operator runs in `cluster` mode (default) or the `MCPServer` is in an
-allowed namespace, check the operator logs and resource status:
+If the scope is `cluster` (the default) or the namespace is already allowed,
+verify the operator is actually running and isn't crash-looping:
 
 ```bash
-# Check MCPServer status
-kubectl -n <NAMESPACE> describe mcpserver <NAME>
-
-# Check operator logs
-kubectl -n toolhive-system logs -l app.kubernetes.io/name=toolhive-operator
-
-# Verify the operator is running
 kubectl -n toolhive-system get pods -l app.kubernetes.io/name=toolhive-operator
+kubectl -n toolhive-system logs -l app.kubernetes.io/name=toolhive-operator --tail=100
 ```
 
-Other common causes include:
+Also confirm the CRDs are installed and match the API version your manifest
+uses:
 
-- **Operator not running**: Ensure the ToolHive operator is deployed and running
-- **Invalid image reference**: Verify the container image exists and is
-  accessible
-- **RBAC issues**: The operator automatically creates RBAC resources, but check
-  for cluster-level permission issues
-- **Resource quotas**: Check if namespace resource quotas prevent pod creation
+```bash
+kubectl api-resources --api-group=toolhive.stacklok.dev
+```
+
+If `mcpservers` doesn't appear, the CRDs aren't installed. See
+[Install the CRDs](./deploy-operator.mdx#install-the-crds).
 
 </details>
 
 <details>
-<summary>MCP server pod fails to start</summary>
+<summary>MCPServer status shows a validation error</summary>
 
-If the MCP server pod is created but fails to start or is in `CrashLoopBackOff`:
+If the operator did reconcile but rejected the resource, `kubectl describe`
+shows the reason in events or status conditions:
 
 ```bash
-# Check pod status
-kubectl -n <NAMESPACE> get pods
-
-# Describe the failing pod
-kubectl -n <NAMESPACE> describe pod <POD_NAME>
-
-# Check pod logs
-kubectl -n <NAMESPACE> logs <POD_NAME> -c mcp
+kubectl -n <NAMESPACE> describe mcpserver <NAME>
 ```
 
-Common causes include:
+Common validation failures:
 
-- **Image pull errors**: Verify the container image is accessible and the image
-  name is correct
-- **Missing secrets**: Ensure required secrets exist and are properly referenced
-- **Resource constraints**: Check if the pod has sufficient CPU and memory
-  resources
-- **Permission issues**: Verify the security context and RBAC permissions are
-  correctly configured
-- **Invalid arguments**: Check if the `args` field contains valid arguments for
-  the MCP server
+- A referenced ConfigMap or Secret (for example, `oidcConfigRef`,
+  `toolConfigRef`, `secrets[*].name`) doesn't exist in the same namespace
+- `transport: stdio` is set with `backendReplicas > 1`, which the operator
+  rejects
+- The container name in `podTemplateSpec.containers` is not `mcp`
+
+Fix the referenced field, then reapply the resource.
 
 </details>
 
-<details>
-<summary>Proxy pod connection issues</summary>
+### Resource accepted but pods are failing
 
-If the proxy pod is running but clients cannot connect:
+The operator created the proxy and backend Deployments, but one or both pods are
+not Running. Check pod status first:
 
 ```bash
-# Check proxy pod status
 kubectl -n <NAMESPACE> get pods -l app.kubernetes.io/instance=<MCPSERVER_NAME>
-
-# Check proxy logs
-kubectl -n <NAMESPACE> logs -l app.kubernetes.io/instance=<MCPSERVER_NAME>
-
-# Verify service is created
-kubectl -n <NAMESPACE> get services
-```
-
-Common causes include:
-
-- **Service not created**: Ensure the proxy service exists and has the correct
-  selectors
-- **Port configuration**: Verify the `port` field matches the MCP server's
-  listening port
-- **Transport mismatch**: Ensure the `transport` field
-  (stdio/sse/streamable-http) matches the MCP server's capabilities
-- **Network policies**: Check if network policies are blocking communication
-
-</details>
-
-<details>
-<summary>Secret mounting issues</summary>
-
-If secrets are not being properly mounted or environment variables are missing:
-
-```bash
-# Check if secret exists
-kubectl -n <NAMESPACE> get secret <SECRET_NAME>
-
-# Verify secret content
-kubectl -n <NAMESPACE> describe secret <SECRET_NAME>
-
-# Check environment variables in the pod
-kubectl -n <NAMESPACE> exec <POD_NAME> -c mcp -- env | grep <ENV_VAR_NAME>
-```
-
-Common causes include:
-
-- **Secret doesn't exist**: Create the secret in the correct namespace
-- **Wrong key name**: Ensure the `key` field matches the actual key in the
-  secret
-- **Namespace mismatch**: Secrets must be in the same namespace as the
-  `MCPServer`
-- **Permission issues**: The operator automatically creates the necessary RBAC
-  resources, but verify the ServiceAccount has access to read secrets
-
-</details>
-
-<details>
-<summary>Volume mounting problems</summary>
-
-If persistent volumes or other volumes are not mounting correctly:
-
-```bash
-# Check PVC status
-kubectl -n <NAMESPACE> get pvc
-
-# Describe the PVC
-kubectl -n <NAMESPACE> describe pvc <PVC_NAME>
-
-# Check volume mounts in the pod
 kubectl -n <NAMESPACE> describe pod <POD_NAME>
 ```
 
-Common causes include:
+`kubectl describe pod` surfaces image pull errors, scheduling problems,
+out-of-memory kills, and missing Secret/ConfigMap mounts directly in the events
+section, so check there before drilling deeper.
 
-- **PVC not bound**: Ensure the PersistentVolumeClaim is bound to a
-  PersistentVolume
-- **Namespace mismatch**: The PVC must be in the same namespace as the MCPServer
-- **Storage class issues**: Verify the storage class exists and is available
-- **Access mode conflicts**: Check that the access mode is compatible with your
-  setup
-- **Mount path conflicts**: Ensure mount paths don't conflict with existing
-  directories
+<details>
+<summary>Pod stuck in ImagePullBackOff or ErrImagePull</summary>
+
+The cluster can't pull the container image. Verify the image reference and
+authentication:
+
+```bash
+kubectl -n <NAMESPACE> describe pod <POD_NAME> | grep -A3 -i "failed to pull"
+```
+
+Check that:
+
+- The `spec.image` value is correct, including the registry, repository, and tag
+- The image exists and is publicly accessible, or the cluster has an
+  `imagePullSecrets` reference for a private registry
+- Cluster nodes have network egress to the registry
 
 </details>
 
 <details>
-<summary>Resource limit issues</summary>
+<summary>Pod in CrashLoopBackOff</summary>
 
-If pods are being killed due to resource constraints:
+The container starts but exits repeatedly. Check the logs from the failing
+container, including the previous instance:
 
 ```bash
-# Check resource usage
-kubectl -n <NAMESPACE> top pods
+kubectl -n <NAMESPACE> logs <POD_NAME> -c mcp
+kubectl -n <NAMESPACE> logs <POD_NAME> -c mcp --previous
+```
 
-# Check for resource limit events
+Typical causes:
+
+- Missing or wrong environment variables. If you reference a Secret in
+  `spec.secrets`, confirm the Secret exists in the same namespace and the `key`
+  matches:
+
+  ```bash
+  kubectl -n <NAMESPACE> get secret <SECRET_NAME> -o yaml
+  ```
+
+- Invalid `args` for the MCP server. Many servers fail fast on bad CLI
+  arguments. Compare your `args` to the upstream image documentation.
+- The MCP server expects a writable filesystem or specific volume mounts that
+  aren't provided.
+
+</details>
+
+<details>
+<summary>Pod stuck in Pending</summary>
+
+The pod was created but never scheduled. `kubectl describe pod` shows the
+reason. Common cases:
+
+- A namespace ResourceQuota or LimitRange is blocking pod creation. The events
+  section names the limit that was exceeded.
+- The pod requests more CPU or memory than any node can satisfy. Lower
+  `resources.requests` or add nodes.
+- A `nodeSelector`, `affinity`, or `tolerations` rule in your `podTemplateSpec`
+  doesn't match any node.
+- A PersistentVolumeClaim is unbound. Check PVC status:
+
+  ```bash
+  kubectl -n <NAMESPACE> get pvc
+  ```
+
+</details>
+
+<details>
+<summary>Pod is OOMKilled or terminated by the kubelet</summary>
+
+If `kubectl describe pod` shows `Last State: Terminated, Reason: OOMKilled`, the
+container exceeded its memory limit. Either raise `resources.limits.memory` on
+the MCPServer (or on the `mcp` container in `podTemplateSpec` for the backend),
+or reduce the workload's memory use. Check recent events for context:
+
+```bash
 kubectl -n <NAMESPACE> get events --sort-by='.lastTimestamp'
-
-# Describe the pod for resource information
-kubectl -n <NAMESPACE> describe pod <POD_NAME>
 ```
-
-Solutions:
-
-- **Increase resource limits**: Adjust `resources.limits` in the `MCPServer`
-  spec
-- **Optimize resource requests**: Set appropriate `resources.requests` values
-- **Check node capacity**: Ensure cluster nodes have sufficient resources
-- **Review resource quotas**: Check namespace resource quotas and limits
 
 </details>
 
-<details>
-<summary>Debugging connectivity</summary>
+### Pods running but the server is unreachable
 
-To test connectivity between components:
+Both the proxy and backend pods are Ready, but clients see connection failures
+or empty tool lists. Verify the path from client to proxy to backend.
+
+<details>
+<summary>Client gets connection refused or no response from the Service</summary>
+
+Check the Service exists and has endpoints:
 
 ```bash
-# Port-forward to test direct access to the proxy
-kubectl -n <NAMESPACE> port-forward service/<MCPSERVER_NAME> 8080:8080
+kubectl -n <NAMESPACE> get svc -l app.kubernetes.io/instance=<MCPSERVER_NAME>
+kubectl -n <NAMESPACE> get endpoints -l app.kubernetes.io/instance=<MCPSERVER_NAME>
+```
 
-# Test the connection locally (should return {"status":"healthy",...})
+If endpoints are empty, the Service selector doesn't match any Ready pod.
+Confirm the proxy pod is Ready and not failing readiness probes.
+
+Port-forward and test the proxy locally to isolate cluster networking from the
+proxy itself:
+
+```bash
+kubectl -n <NAMESPACE> port-forward service/mcp-<MCPSERVER_NAME>-proxy 8080:8080
 curl -s http://localhost:8080/health | jq .status
-
-# Check service endpoints
-kubectl -n <NAMESPACE> get endpoints
 ```
+
+A `"healthy"` response confirms the proxy is up. If port-forward works but
+external clients can't reach the Service, see
+[Connect clients to MCP servers](./connect-clients.mdx) for Ingress and Gateway
+API configuration.
 
 </details>
 
 <details>
-<summary>Getting more debug information</summary>
+<summary>Client connects but sees no tools</summary>
 
-For additional debugging information:
+The proxy is reachable but `tools/list` returns nothing, or your MCP client
+shows zero tools. Use the ToolHive CLI's debug subcommand against the
+port-forwarded URL to confirm the server side:
 
 ```bash
-# Get all resources related to your MCP server
+kubectl -n <NAMESPACE> port-forward service/mcp-<MCPSERVER_NAME>-proxy 8080:8080
+thv mcp list tools --server http://localhost:8080/mcp
+```
+
+If `thv mcp list tools` returns the expected tools, the issue is on the client
+or in the path between the client and the cluster (Ingress, network policy,
+auth). If it also returns nothing, check:
+
+- The proxy logs for backend connection errors:
+
+  ```bash
+  kubectl -n <NAMESPACE> logs -l app.kubernetes.io/instance=<MCPSERVER_NAME> -c toolhive
+  ```
+
+- That `transport` matches what the upstream MCP server actually speaks
+  (`stdio`, `sse`, or `streamable-http`)
+- Whether a `toolConfigRef` is filtering tools more aggressively than expected
+
+</details>
+
+<details>
+<summary>NetworkPolicy is blocking traffic</summary>
+
+If the cluster uses NetworkPolicies, a policy may block ingress to the proxy or
+egress from the proxy to the backend. List policies in both namespaces:
+
+```bash
+kubectl -n <NAMESPACE> get networkpolicy
+kubectl -n <CLIENT_NAMESPACE> get networkpolicy
+```
+
+Allow traffic from the client namespace to the proxy Service on `proxyPort`, and
+from the proxy pod to the backend pod on `mcpPort`. See
+[Connect clients to MCP servers](./connect-clients.mdx#network-policies-for-cross-namespace-access)
+for example rules.
+
+</details>
+
+<details>
+<summary>Gather more debug information</summary>
+
+To collect everything related to a single MCPServer for a bug report or deeper
+investigation:
+
+```bash
 kubectl -n <NAMESPACE> get all -l app.kubernetes.io/instance=<MCPSERVER_NAME>
-
-# Check operator events
 kubectl -n <NAMESPACE> get events --field-selector involvedObject.kind=MCPServer
-
-# Export MCPServer resource for inspection
 kubectl -n <NAMESPACE> get mcpserver <NAME> -o yaml
+kubectl -n toolhive-system logs -l app.kubernetes.io/name=toolhive-operator --tail=200
 ```
 
 </details>

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -673,12 +673,20 @@ Check that:
 <details>
 <summary>Pod in CrashLoopBackOff</summary>
 
-The container starts but exits repeatedly. Check the logs from the failing
-container, including the previous instance:
+The container starts but exits repeatedly. The label selector matches both the
+proxy pod (container `toolhive`) and the MCP server pod (container `mcp`), so
+target the failing container explicitly. For the MCP server backend:
 
 ```bash
 kubectl -n <NAMESPACE> logs <POD_NAME> -c mcp
 kubectl -n <NAMESPACE> logs <POD_NAME> -c mcp --previous
+```
+
+For the proxy:
+
+```bash
+kubectl -n <NAMESPACE> logs <POD_NAME> -c toolhive
+kubectl -n <NAMESPACE> logs <POD_NAME> -c toolhive --previous
 ```
 
 Typical causes:
@@ -704,8 +712,6 @@ Typical causes:
 The pod was created but never scheduled. `kubectl describe pod` shows the
 reason. Common cases:
 
-- A namespace ResourceQuota or LimitRange is blocking pod creation. The events
-  section names the limit that was exceeded.
 - The pod requests more CPU or memory than any node can satisfy. Lower
   `resources.requests` or add nodes.
 - A `nodeSelector`, `affinity`, or `tolerations` rule in your `podTemplateSpec`
@@ -715,6 +721,16 @@ reason. Common cases:
   ```bash
   kubectl -n <NAMESPACE> get pvc
   ```
+
+If no Pod exists at all, a namespace `ResourceQuota` may be blocking creation at
+admission time. Check the controller events instead:
+
+```bash
+kubectl -n <NAMESPACE> describe deployment <MCPSERVER_NAME>
+kubectl -n <NAMESPACE> get events --sort-by=.lastTimestamp
+```
+
+Look for `FailedCreate` events naming the exceeded quota.
 
 </details>
 


### PR DESCRIPTION
### Description

Refreshes the troubleshooting sections across the Kubernetes Operator guides as
part of the broader docs cleanup. Trims speculative bullets that `kubectl
describe` already surfaces, restructures the dense troubleshooting in
`run-mcp-k8s.mdx` into clear failure-mode buckets, and tightens the rest of the
section for active voice and concrete next actions.

Highlights:

- `run-mcp-k8s.mdx`: restructured the troubleshooting section into three
  failure-mode buckets ("MCPServer not picked up by the operator", "Resource
  accepted but pods are failing", "Pods running but the server is unreachable")
  with progressive `kubectl` commands and a `thv mcp list tools` debug path
  for the no-tools case.
- `deploy-operator.mdx`: completed the "Operator pod fails to start" common
  causes with a concrete `kubectl api-resources --api-group=toolhive.stacklok.dev`
  CRD check.
- `quickstart.mdx`: tightened the three troubleshooting items so each leads
  with the specific symptom and the next command to run.
- `connect-clients.mdx`: collapsed redundant Service/pod commands into a
  single `kubectl get endpoints` flow and cross-linked the network policy
  section.
- `remote-mcp-proxy.mdx`: replaced generic "common causes" lists with the
  specific signals (OOMKilled, JWKS unreachable, CA missing) that point at
  each cause.

### Type of change

- Documentation update

### Related issues/PRs

Refs #362

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)