### PR TITLE
Refresh FAQ for current platform

### DIFF
--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -158,13 +158,11 @@ HTTP transports for remote servers. For Kubernetes, see
 
 ### Which AI clients work with ToolHive?
 
-ToolHive works with any AI client that supports MCP. Tested clients span several
-categories:
+ToolHive works with any AI client that supports MCP. Tested clients include:
 
-- **Coding assistants in your IDE** like GitHub Copilot, Cursor, Windsurf,
-  Cline, Continue, and Zed
-- **Terminal-based coding agents** like Claude Code, OpenAI Codex, Gemini CLI,
-  and Goose
+- **Coding assistants** like GitHub Copilot, Cursor, Windsurf, Claude Code,
+  OpenAI Codex, Google Antigravity, Cline, Goose, and Zed, available as IDE
+  extensions, terminal CLIs, and native apps
 - **Desktop AI apps** like Claude Desktop, ChatGPT Desktop, and LM Studio
 - **Agent frameworks** like PydanticAI
 

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -85,8 +85,8 @@ aggregation on your machine.
 ### What's the difference between the built-in registry and the Registry Server?
 
 The **built-in registry** is the default catalog of vetted MCP servers shipped
-with the ToolHive UI and CLI. Browse it from the **Registry** tab in the UI or run
-`thv registry list` in the CLI. No deployment is required.
+with the ToolHive UI and CLI. Browse it from the **Registry** tab in the UI or
+run `thv registry list` in the CLI. No deployment is required.
 
 The [**ToolHive Registry Server**](./guides-registry/index.mdx) is a separate
 component you deploy yourself to host your own catalog of MCP servers and
@@ -158,12 +158,20 @@ HTTP transports for remote servers. For Kubernetes, see
 
 ### Which AI clients work with ToolHive?
 
-ToolHive works with any AI client that supports MCP, including Claude Code,
-GitHub Copilot, Cursor, Windsurf, VS Code, Zed, Cline, Continue, Roo Code,
-Goose, LM Studio, and OpenAI Codex. Many clients support automatic configuration
-so you can connect without manual setup. See the
+ToolHive works with any AI client that supports MCP. Tested clients span several
+categories:
+
+- **Coding assistants in your IDE** like GitHub Copilot, Cursor, Windsurf,
+  Cline, Continue, and Zed
+- **Terminal-based coding agents** like Claude Code, OpenAI Codex, Gemini CLI,
+  and Goose
+- **Desktop AI apps** like Claude Desktop, ChatGPT Desktop, and LM Studio
+- **Agent frameworks** like PydanticAI
+
+Many clients support automatic configuration so you can connect without manual
+setup. See the
 [client compatibility reference](./reference/client-compatibility.mdx) for the
-full list.
+full list, minimum versions, and per-client notes.
 
 ### What container runtimes does ToolHive support?
 

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -11,9 +11,10 @@ description:
 ### What is ToolHive?
 
 ToolHive is an open source platform for running, securing, and managing Model
-Context Protocol (MCP) servers. It runs MCP servers in isolated containers and
-gives you a desktop app, command-line tool, and Kubernetes operator to manage
-them, plus a gateway and registry server for team and enterprise deployments.
+Context Protocol (MCP) servers and agent skills. It runs MCP servers in isolated
+containers and gives you a desktop app, command-line tool, and Kubernetes
+operator to manage them, plus a gateway and registry server for team and
+enterprise deployments.
 
 ### What is the Model Context Protocol (MCP)?
 
@@ -47,9 +48,10 @@ evaluating MCP.
 
 [Stacklok Enterprise](./enterprise.mdx) is a hardened, semantically versioned
 distribution of ToolHive built for production use. It adds turnkey identity
-provider integrations (Okta, Entra ID), backported security patches, hardened
-container images, an enterprise cloud UI, and SLA-backed support. It's
-self-hosted, so your data stays in your environment.
+provider integrations (Okta, Entra ID), built-in functionality for day-2 and
+day-3 operations, backported security patches, hardened container images, an
+enterprise cloud UI, and SLA-backed support. It's self-hosted, so your data
+stays in your environment.
 
 If you're running MCP in production at organizational scale, need SSO and
 governance, or have compliance requirements,
@@ -129,6 +131,10 @@ popular services and platforms such as:
 - **Notion** - connect to Notion workspaces
 - And many more
 
+Don't see what you need? See
+[How do I get my MCP server added to the ToolHive registry?](#how-do-i-get-my-mcp-server-added-to-the-toolhive-registry)
+below.
+
 ### Can I run MCP servers that aren't in the registry?
 
 Yes. You can run any MCP server from a container image or source package, even
@@ -139,6 +145,10 @@ the [CLI guide](./guides-cli/run-mcp-servers.mdx#run-a-custom-mcp-server).
 
 The Kubernetes Operator also supports custom MCP servers packaged as container
 images.
+
+ToolHive can also proxy remote (hosted) MCP servers; see
+[Does ToolHive support remote MCP servers?](#does-toolhive-support-remote-mcp-servers)
+below.
 
 :::tip
 
@@ -334,6 +344,8 @@ Yes. ToolHive supports corporate environments with:
 ### Where can I get help if I'm stuck?
 
 - **Documentation** - check the comprehensive guides and reference documentation
+- **Lok, our AI assistant** - chat with Lok on
+  [stacklok.com](https://stacklok.com) for quick answers
 - **GitHub Issues** - report bugs or request features on the
   [ToolHive GitHub repository](https://github.com/stacklok/toolhive/issues)
 - **Discord community** - join the

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -344,8 +344,8 @@ Yes. ToolHive supports corporate environments with:
 ### Where can I get help if I'm stuck?
 
 - **Documentation** - check the comprehensive guides and reference documentation
-- **Lok, our AI assistant** - chat with Lok on
-  [stacklok.com](https://stacklok.com) for quick answers
+- **Lok, our AI assistant** - chat with Lok using the widget on this site for
+  quick answers
 - **GitHub Issues** - report bugs or request features on the
   [ToolHive GitHub repository](https://github.com/stacklok/toolhive/issues)
 - **Discord community** - join the

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -2,96 +2,188 @@
 title: Frequently asked questions
 sidebar_label: FAQ
 description:
-  Answers to common questions about ToolHive setup, MCP servers, and
-  troubleshooting.
+  Answers to common questions about ToolHive, its components, MCP server
+  management, security, and enterprise use.
 ---
 
 ## General questions
 
 ### What is ToolHive?
 
-ToolHive is an open source platform that simplifies the deployment and
-management of Model Context Protocol (MCP) servers. It runs MCP servers in
-secure, isolated containers and provides tools to manage them easily. You can
-run ToolHive as a graphical desktop app, command-line tool, or Kubernetes
-operator.
+ToolHive is an open source platform for running, securing, and managing Model
+Context Protocol (MCP) servers. It runs MCP servers in isolated containers and
+gives you a desktop app, command-line tool, and Kubernetes operator to manage
+them, plus a gateway and registry server for team and enterprise deployments.
 
 ### What is the Model Context Protocol (MCP)?
 
-MCP is a protocol that allows AI applications to connect to external data
-sources and tools. It provides a standardized way for AI models to access
-real-world context like APIs, source code repositories, databases, and other
-systems. Think of it as a bridge between AI models and the external systems
-where your data and applications live.
+MCP is an open protocol that lets AI applications connect to external data
+sources and tools in a standard way. It gives AI models access to real-world
+context like APIs, source code repositories, databases, and other systems. Think
+of it as a bridge between AI models and the systems where your data and
+applications live. For more background, see the
+[MCP primer](./concepts/mcp-primer.mdx).
 
 ### Do I need to know how to code to use ToolHive?
 
-No. ToolHive includes a graphical interface that doesn't require coding
-knowledge. However, some MCP servers may require configuration or secrets, such
-as API keys, that you'll need to set up. The ToolHive CLI is more technical but
-comes with comprehensive documentation.
+No. The ToolHive desktop app doesn't require coding knowledge. Some MCP servers
+need configuration or secrets like API keys that you'll set up through the UI.
+The CLI is more technical but is fully documented if you prefer a terminal
+workflow.
 
 ### Is ToolHive free to use?
 
-Yes, ToolHive is open source (Apache 2.0 licensed) and free to use. You can find
-the source code on GitHub and use it without any licensing fees.
+Yes. ToolHive is open source under the Apache 2.0 license and free to use, with
+the source code on [GitHub](https://github.com/stacklok/toolhive). Stacklok also
+offers a paid commercial distribution called Stacklok Enterprise; see "What's
+the difference between ToolHive and Stacklok Enterprise?" below.
 
-### Can I use ToolHive UI and the CLI together?
+### What's the difference between ToolHive and Stacklok Enterprise?
 
-Yes, but ToolHive UI manages the CLI automatically. When you install ToolHive
-UI, it creates a symlink to its bundled CLI and configures your PATH. Running
-the `thv` command from your terminal uses the UI-managed version.
+ToolHive is the open source project: a complete platform for running MCP servers
+locally or in Kubernetes, free to use, with community support through GitHub and
+Discord. It's the right starting point for individual developers and teams
+evaluating MCP.
 
-If you have a standalone CLI installed separately (via Homebrew, WinGet, or
-manually), it will conflict with the UI-managed version and show an error.
-Uninstall the standalone version to resolve this.
+[Stacklok Enterprise](./enterprise.mdx) is a hardened, semantically versioned
+distribution of ToolHive built for production use. It adds turnkey identity
+provider integrations (Okta, Entra ID), backported security patches, hardened
+container images, an enterprise cloud UI, and SLA-backed support. It's
+self-hosted, so your data stays in your environment.
 
-For more information, see the [CLI access guide](./guides-ui/cli-access.mdx) and
+If you're running MCP in production at organizational scale, need SSO and
+governance, or have compliance requirements,
+[Stacklok Enterprise](./enterprise.mdx) is the supported path.
+
+### Can I use the ToolHive UI and CLI together?
+
+Yes, but the desktop app manages the CLI for you. When you install the UI, it
+creates a symlink to its bundled CLI and configures your PATH so that running
+`thv` from your terminal uses the UI-managed version.
+
+If you also have a standalone CLI installed (via Homebrew, WinGet, or a manual
+install), it conflicts with the UI-managed version and shows an error. Uninstall
+the standalone version to resolve this.
+
+For details, see the [CLI access guide](./guides-ui/cli-access.mdx) and
 [CLI conflict resolution](./guides-cli/install.mdx#cli-conflict-resolution).
+
+## ToolHive components
+
+### What is the Virtual MCP Server (vMCP)?
+
+The [Virtual MCP Server (vMCP)](./guides-vmcp/index.mdx) is ToolHive's MCP
+gateway. It aggregates multiple backend MCP servers behind a single endpoint so
+clients connect once instead of juggling many URLs, credentials, and overlapping
+tool surfaces. vMCP also centralizes authentication, authorization, and tool
+filtering, and supports multi-step composite workflows across backends.
+
+vMCP runs as part of the ToolHive Kubernetes Operator for cluster deployments. A
+[local CLI](./guides-vmcp/local-cli.mdx) version is available for evaluating
+aggregation on your machine.
+
+### What's the difference between the built-in registry and the Registry Server?
+
+The **built-in registry** is the default catalog of vetted MCP servers shipped
+with the ToolHive UI and CLI. Browse it from the Registry tab in the UI or run
+`thv registry list` in the CLI. No deployment is required.
+
+The [**ToolHive Registry Server**](./guides-registry/index.mdx) is a separate
+component you deploy yourself to host your own catalog of MCP servers and
+skills. Use it when you want to curate a private or team-specific registry,
+publish internal MCP servers, aggregate entries from multiple sources, or apply
+authentication and authorization to registry access. It implements the official
+[MCP Registry API](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/generic-registry-api.md).
+
+### What are skills?
+
+[Skills](./concepts/skills.mdx) are reusable, versioned bundles of instructions,
+prompts, and configuration that teach an AI agent how to perform a specific
+task. Where MCP servers provide the raw tools an agent can call, skills provide
+the knowledge of when, why, and how to use those tools together.
+
+ToolHive lets you run skills locally, manage them from the UI or CLI, and
+publish them through the Registry Server alongside your MCP servers. Skills
+follow the open [Agent Skills](https://agentskills.io/) specification supported
+by clients like Claude Code, GitHub Copilot, and Cursor.
 
 ## Using MCP servers
 
 ### How do I find available MCP servers?
 
-ToolHive includes a curated registry of verified MCP servers. You can browse
-them from the **Registry** tab in the UI or by running `thv registry list` in
-the CLI.
+ToolHive includes a curated registry of vetted MCP servers. Browse it from the
+**Registry** tab in the UI or run `thv registry list` in the CLI.
 
 ### What MCP servers are available?
 
-The registry includes servers for common use cases, such as retrieving content
-from the web using the
-[GoFetch MCP server](https://github.com/StacklokLabs/gofetch), and for popular
-services and platforms like:
+The registry includes servers for common use cases like web content retrieval
+with the [GoFetch MCP server](https://github.com/StacklokLabs/gofetch), and for
+popular services and platforms such as:
 
-- **Atlassian** - Access Jira and Confluence
-- **AWS Documentation** - Query AWS service documentation
-- **GitHub** - Access repositories, issues, and pull requests
-- **Kubernetes** - Interact with Kubernetes clusters via the
+- **Atlassian** - access Jira and Confluence
+- **AWS Documentation** - query AWS service documentation
+- **GitHub** - access repositories, issues, and pull requests
+- **Kubernetes** - interact with Kubernetes clusters via the
   [MKP MCP server](https://github.com/StacklokLabs/mkp)
-- **MongoDB**, **PostgreSQL**, **Redis** - Connect to databases
-- **Notion** - Connect to Notion workspaces
+- **MongoDB**, **PostgreSQL**, **Redis** - connect to databases
+- **Notion** - connect to Notion workspaces
 - And many more
 
 ### Can I run MCP servers that aren't in the registry?
 
 Yes. You can run any MCP server from a container image or source package, even
-if it's not in the registry. Just provide the image name or package details when
-starting the server using the CLI or UI. See the custom MCP server section in
+if it's not in the registry. Provide the image name or package details when
+starting the server through the CLI or UI. See the custom MCP server sections in
 the [UI guide](./guides-ui/run-mcp-servers.mdx#install-a-custom-mcp-server) and
-[CLI guide](./guides-cli/run-mcp-servers.mdx#run-a-custom-mcp-server) for more
-details.
+the [CLI guide](./guides-cli/run-mcp-servers.mdx#run-a-custom-mcp-server).
 
-The Kubernetes operator also supports custom MCP servers that are packaged as
-container images.
+The Kubernetes Operator also supports custom MCP servers packaged as container
+images.
 
 :::tip
 
-You can use the ToolHive CLI to run a custom MCP server from a source package
-once, then export the Docker image for import into your container registry or
-Kubernetes cluster to use it with the operator.
+You can use the CLI to run a custom MCP server from a source package once, then
+export the resulting container image to your registry or Kubernetes cluster to
+use it with the operator.
 
 :::
+
+### Does ToolHive support remote MCP servers?
+
+Yes. ToolHive can proxy remote (hosted) MCP servers so you can manage them
+alongside locally-run servers using the same configuration, authentication, and
+observability. ToolHive supports both Server-Sent Events (SSE) and Streamable
+HTTP transports for remote servers. For Kubernetes, see
+[Remote MCP server proxying](./guides-k8s/remote-mcp-proxy.mdx).
+
+### Which AI clients work with ToolHive?
+
+ToolHive works with any AI client that supports MCP, including Claude Code,
+GitHub Copilot, Cursor, Windsurf, VS Code, Zed, Cline, Continue, Roo Code,
+Goose, LM Studio, and OpenAI Codex. Many clients support automatic configuration
+so you can connect without manual setup. See the
+[client compatibility reference](./reference/client-compatibility.mdx) for the
+full list.
+
+### What container runtimes does ToolHive support?
+
+For local use (UI and CLI), ToolHive supports:
+
+- Docker / Docker Desktop
+- Podman / Podman Desktop
+- Colima with the Docker runtime
+- Rancher Desktop with the dockerd/moby runtime (experimental)
+
+For cluster deployments, the ToolHive Kubernetes Operator runs MCP servers as
+standard Kubernetes pods using whatever container runtime your cluster is
+configured with.
+
+### How do I get my MCP server added to the ToolHive registry?
+
+The registry has [inclusion criteria](./concepts/registry-criteria.mdx) such as
+being open source, following good security practices, and maintaining code
+quality. Review the criteria and
+[submit your server for consideration](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md).
 
 ## Privacy and data collection
 
@@ -149,19 +241,25 @@ before running new or untrusted MCP servers.
 
 ### How does ToolHive handle secrets like API keys?
 
-ToolHive provides secure secrets management:
+ToolHive provides secure secrets management with several backend options:
 
-- Secrets are encrypted and stored securely on your system
-- They're passed to MCP servers as environment variables
-- Secrets never appear in plaintext in configuration files
-- Integration with 1Password is also supported
+- A built-in **encrypted store** that uses your operating system's keyring to
+  protect a local secrets file
+- **1Password** integration for retrieving secrets from a 1Password vault
+- **HashiCorp Vault** integration for Kubernetes deployments
+
+Secrets are passed to MCP servers as environment variables and never appear in
+plaintext in configuration files. See the secrets management guides for the
+[CLI](./guides-cli/secrets-management.mdx),
+[UI](./guides-ui/secrets-management.mdx), and the
+[Vault integration](./integrations/vault.mdx) for Kubernetes.
 
 ### Can I control what an MCP server can access?
 
 Yes. ToolHive uses permission profiles to control:
 
-- **File system access** - Which directories the server can read or write
-- **Network access** - Which hosts and ports the server can connect to
+- **File system access** - which directories the server can read or write
+- **Network access** - which hosts and ports the server can connect to
 
 You can use built-in profiles or create custom ones for specific security
 requirements.
@@ -173,35 +271,49 @@ outbound connections from MCP servers. Use the `--isolate-network` flag when
 running servers that need strict network controls, especially in enterprise
 environments.
 
-## Enterprise and advanced usage
+### Does ToolHive integrate with my identity provider for SSO?
 
-### Can I use ToolHive in my company?
+Yes. ToolHive supports OIDC-based authentication for MCP servers, so you can
+front your servers with any OIDC-compliant identity provider and use Cedar
+policies for fine-grained authorization. For details, see
+[Authentication and authorization](./concepts/auth-framework.mdx) and the auth
+guides for the [CLI](./guides-cli/auth.mdx) and
+[Kubernetes Operator](./guides-k8s/auth-k8s.mdx).
 
-Yes. ToolHive is designed for both individual developers and enterprise teams.
-The Kubernetes Operator provides centralized management, security controls, and
-integration with existing infrastructure for enterprise deployments.
+[Stacklok Enterprise](./enterprise.mdx) adds turnkey integrations for Okta and
+Entra ID, including IdP group to ToolHive role mapping and canonical policy
+packs.
+
+### Can I see who called what tools?
+
+Yes. ToolHive includes built-in OpenTelemetry instrumentation that captures
+detailed traces and metrics for every MCP request and tool call, plus audit
+logging for compliance and security review. See
+[Observability](./concepts/observability.mdx) and the
+[OpenTelemetry integration guide](./integrations/opentelemetry.mdx) for the full
+picture.
+
+## Operations and enterprise
+
+### Can I use ToolHive in my organization?
+
+Yes. ToolHive is built to scale from a single developer's machine to enterprise
+deployments. Small teams can run the CLI or desktop app locally; larger
+deployments use the [Kubernetes Operator](./guides-k8s/index.mdx) for
+centralized management, the [vMCP gateway](./guides-vmcp/index.mdx) for unified
+access, and the [Registry Server](./guides-registry/index.mdx) for a governed
+catalog.
+
+If you need turnkey IdP integration, hardened images, semantic versioning,
+backported security patches, or SLA-backed support, see
+[Stacklok Enterprise](./enterprise.mdx).
 
 ### How do I deploy ToolHive in Kubernetes?
 
 Use the ToolHive Kubernetes Operator to deploy and manage MCP servers as
 Kubernetes resources. See the [Kubernetes guides](./guides-k8s/index.mdx) for
-detailed instructions. The Kubernetes operator is currently experimental.
-
-### Can I run my own custom MCP servers?
-
-Yes. You can run custom MCP servers from Docker images or source packages.
-ToolHive supports:
-
-- Docker images from public or private registries
-- Source packages from package managers like npm, PyPI, or Go modules
-
-### How do I get my MCP server added to the ToolHive registry?
-
-The ToolHive registry has specific
-[inclusion criteria](./concepts/registry-criteria.mdx), such as being open
-source, following good security practices, and maintaining code quality. Review
-the criteria and
-[submit your server for consideration](https://github.com/stacklok/toolhive-catalog/issues/new?template=add-an-mcp-server.md).
+detailed instructions, including a quickstart, authentication setup, and
+production patterns like rate limiting and Redis-backed session storage.
 
 ### Can I use ToolHive behind a corporate firewall?
 
@@ -209,31 +321,31 @@ Yes. ToolHive supports corporate environments with:
 
 - Custom CA certificate configuration for TLS inspection
 - Network isolation and permission profiles
-- Integration with secret management systems like 1Password
+- Integration with secret management systems
 
 ## Getting help
 
 ### Where can I get help if I'm stuck?
 
-- **Documentation** - Check the comprehensive guides and reference documentation
-- **GitHub Issues** - Report bugs or request features on the
+- **Documentation** - check the comprehensive guides and reference documentation
+- **GitHub Issues** - report bugs or request features on the
   [ToolHive GitHub repository](https://github.com/stacklok/toolhive/issues)
-- **Discord Community** - Join the
+- **Discord community** - join the
   [Stacklok Discord](https://discord.gg/stacklok) for community support
-- **Troubleshooting sections** - Each guide includes troubleshooting tips for
+- **Troubleshooting sections** - each guide includes troubleshooting tips for
   common issues
 
 ### How do I report a bug or request a feature?
 
 Open an issue in the appropriate GitHub repository:
 
-- [**ToolHive UI**](https://github.com/stacklok/toolhive-studio/issues) - For
-  issues specific to the graphical desktop app
-- [**ToolHive CLI & Kubernetes**](https://github.com/stacklok/toolhive/issues) -
-  For issues related to the CLI tool or Kubernetes operator
+- [**ToolHive UI**](https://github.com/stacklok/toolhive-studio/issues) - for
+  issues specific to the desktop app
+- [**ToolHive CLI and Kubernetes**](https://github.com/stacklok/toolhive/issues) -
+  for the CLI, Kubernetes Operator, vMCP, or Registry Server
 
 ### Is there a community I can join?
 
-Yes! Join the [Stacklok Discord community](https://discord.gg/stacklok) to
-connect with other ToolHive users, ask questions, and share your experiences.
-There's a dedicated `#toolhive-developers` channel for technical discussions.
+Yes. Join the [Stacklok Discord](https://discord.gg/stacklok) to connect with
+other ToolHive users, ask questions, and share your experiences. There's a
+dedicated `#toolhive-developers` channel for technical discussions.

--- a/docs/toolhive/faq.mdx
+++ b/docs/toolhive/faq.mdx
@@ -85,7 +85,7 @@ aggregation on your machine.
 ### What's the difference between the built-in registry and the Registry Server?
 
 The **built-in registry** is the default catalog of vetted MCP servers shipped
-with the ToolHive UI and CLI. Browse it from the Registry tab in the UI or run
+with the ToolHive UI and CLI. Browse it from the **Registry** tab in the UI or run
 `thv registry list` in the CLI. No deployment is required.
 
 The [**ToolHive Registry Server**](./guides-registry/index.mdx) is a separate


### PR DESCRIPTION
### Description

Refreshes the FAQ to reflect the current ToolHive platform: vMCP, Registry Server, skills, Stacklok Enterprise, and the maturing Kubernetes operator. Replaces stale answers, deduplicates, and reorganizes for navigability.

**Refreshed / fixed**

- "Is ToolHive free?" now acknowledges Stacklok Enterprise as the paid commercial distribution
- Secrets answer covers encrypted store + 1Password + Vault (was just 1Password)
- "Can I use ToolHive in my organization?" now layers in vMCP, Registry Server, and Enterprise
- Dropped the "experimental" qualifier from Kubernetes deployment
- Removed the duplicate "Can I run my own custom MCP servers?" entry
- Bug-report links updated to call out vMCP and Registry Server live in the toolhive repo

**New entries**

- ToolHive vs. Stacklok Enterprise (General)
- vMCP, built-in registry vs. Registry Server, skills (new "ToolHive components" section)
- Remote MCP server support, AI client compatibility, container runtimes (Using MCP servers)
- IdP/SSO integration, audit/observability (Security)

**Restructured**

- New "ToolHive components" section between General and Using MCP servers
- "Enterprise and advanced usage" → "Operations and enterprise"

Out of scope: the `FAQPage` JSON-LD structured data discussed in the issue comment. That's a custom-component task; happy to file as a follow-up.

### Type of change

- Documentation update

### Related issues/PRs

Closes #355

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)