### PR TITLE
Promote authServerRef tip to a subsection in K8s auth guide

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -612,10 +612,21 @@ kubectl apply -f mcp-server-embedded-auth.yaml
 The `authServerRef` field is a `TypedLocalObjectReference` that requires both
 `kind` and `name`. This field is also available on `MCPRemoteProxy` resources.
 
-:::tip[Combining embedded auth with outgoing auth]
+:::note
 
-Use `authServerRef` for the embedded auth server and `externalAuthConfigRef` for
-any outgoing auth (such as AWS STS) on the same resource:
+The embedded authorization server exposes a JWKS endpoint that the proxy uses to
+validate the JWTs it issues. The proxy also exposes OAuth discovery endpoints
+(`/.well-known/oauth-authorization-server`) so MCP clients can discover the
+authorization endpoints automatically.
+
+:::
+
+### Combine embedded auth with outgoing token exchange
+
+A single MCP server can use the embedded authorization server for incoming
+client authentication and token exchange for outgoing calls to backend services
+(such as AWS STS). Set both `authServerRef` and `externalAuthConfigRef` on the
+same `MCPServer` or `MCPRemoteProxy` resource:
 
 ```yaml
 spec:
@@ -630,20 +641,8 @@ spec:
     name: embedded-auth-oidc
 ```
 
-For a complete example, see
+For a complete walkthrough, see
 [Combine embedded auth with AWS STS](../integrations/aws-sts.mdx#combine-embedded-auth-with-aws-sts).
-
-:::
-
-:::note
-
-The MCPOIDCConfig issuer must match the `issuer` in your
-`MCPExternalAuthConfig`. The embedded authorization server exposes a JWKS
-endpoint that the proxy uses to validate the JWTs it issues. The proxy also
-exposes OAuth discovery endpoints (`/.well-known/oauth-authorization-server`) so
-MCP clients can discover the authorization endpoints automatically.
-
-:::
 
 ### Configure session storage
 


### PR DESCRIPTION
### Description

Promotes the `:::tip[Combining embedded auth with outgoing auth]` block in `docs/toolhive/guides-k8s/auth-k8s.mdx` to a proper H3 subsection titled "Combine embedded auth with outgoing token exchange" under the embedded authorization server section.

The tip wrapped ~25 lines of primary feature documentation (with a full YAML example and a link to the AWS STS walkthrough) and was the only place this configuration pattern was documented outside the auto-generated CRD spec. Promoting it makes the section:

- discoverable via the page table of contents
- visually equivalent to the other H3 subsections (Configure session storage, Using an OAuth 2.0 upstream provider, etc.)
- correctly framed as a real configuration path rather than a "nice to know" aside

The note about MCPOIDCConfig issuer matching has been kept directly under Step 5 since it's required context for the basic setup, with the new H3 subsection placed immediately after it as the first subsection of the embedded auth section.

### Type of change

- Documentation update

### Related issues/PRs

Closes #689

Identified during editorial review of #685 (Part 1: Update docs for ToolHive v0.17.0).

### Screenshots

n/a - prose/structure change only.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)