### PR TITLE
Make CRD example YAMLs admission-valid

### DIFF
--- a/docs/toolhive/reference/crds/mcpexternalauthconfig.mdx
+++ b/docs/toolhive/reference/crds/mcpexternalauthconfig.mdx
@@ -20,7 +20,12 @@ metadata:
   name: my-mcpexternalauthconfig
   namespace: default
 spec:
-  type: tokenExchange
+  type: embeddedAuthServer
+  embeddedAuthServer:
+    issuer: https://example.com
+    upstreamProviders:
+      - name: example
+        type: oidc
 ```
 
 ## Schema

--- a/docs/toolhive/reference/crds/mcpoidcconfig.mdx
+++ b/docs/toolhive/reference/crds/mcpoidcconfig.mdx
@@ -20,7 +20,9 @@ metadata:
   name: my-mcpoidcconfig
   namespace: default
 spec:
-  type: kubernetesServiceAccount
+  type: inline
+  inline:
+    issuer: <string>
 ```
 
 ## Schema

--- a/docs/toolhive/reference/crds/mcpremoteproxy.mdx
+++ b/docs/toolhive/reference/crds/mcpremoteproxy.mdx
@@ -20,7 +20,7 @@ metadata:
   name: my-mcpremoteproxy
   namespace: default
 spec:
-  remoteUrl: <string>
+  remoteUrl: https://example.com
 ```
 
 ## Schema

--- a/docs/toolhive/reference/crds/mcpserverentry.mdx
+++ b/docs/toolhive/reference/crds/mcpserverentry.mdx
@@ -22,7 +22,7 @@ metadata:
 spec:
   groupRef:
     name: <string>
-  remoteUrl: <string>
+  remoteUrl: https://example.com
   transport: sse
 ```
 

--- a/scripts/extract-crd-schemas.mjs
+++ b/scripts/extract-crd-schemas.mjs
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 import yaml from 'yaml';
+import { intros } from './lib/crd-intros.mjs';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -45,12 +46,36 @@ if (!fs.existsSync(srcDir)) {
 
 fs.mkdirSync(outDir, { recursive: true });
 
+// Pattern-aware string placeholders. The default `<string>` token doesn't
+// satisfy schema-level `pattern` validators, which makes the example fail
+// admission for fields like `spec.remoteUrl` (^https?://...). Add entries
+// here as new patterns surface in required-field positions; we don't try to
+// generate a value from an arbitrary regex.
+const PATTERN_PLACEHOLDERS = [
+  {
+    test: (p) => p.startsWith('^https?://') || p.startsWith('^https://'),
+    value: 'https://example.com',
+  },
+  // DNS-1123 label (lowercase alphanumeric + hyphens, edge anchored).
+  {
+    test: (p) => p === '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$',
+    value: 'example',
+  },
+];
+
 // Placeholder values for leaf types with no default/enum.
 function placeholder(schema) {
   const t = schema.type;
   if (schema.default !== undefined) return schema.default;
   if (Array.isArray(schema.enum) && schema.enum.length) return schema.enum[0];
-  if (t === 'string') return '<string>';
+  if (t === 'string') {
+    if (typeof schema.pattern === 'string') {
+      for (const { test, value } of PATTERN_PLACEHOLDERS) {
+        if (test(schema.pattern)) return value;
+      }
+    }
+    return '<string>';
+  }
   if (t === 'integer' || t === 'number') return 0;
   if (t === 'boolean') return false;
   if (t === 'array') return [];
@@ -58,7 +83,47 @@ function placeholder(schema) {
   return '<value>';
 }
 
-function buildRequiredExample(schema) {
+// When an array has `minItems`, an empty list fails admission. Generate that
+// many copies of an example item so the skeleton stays valid. Items typically
+// have their own required-fields shape, which we recurse into.
+function arrayExample(schema) {
+  const minItems = schema.minItems ?? 0;
+  if (minItems <= 0 || !schema.items) return [];
+  const item =
+    schema.items.type === 'object' && schema.items.properties
+      ? buildRequiredExample(schema.items)
+      : placeholder(schema.items);
+  return Array.from({ length: minItems }, () => item);
+}
+
+// Match the kubebuilder discriminator idiom:
+//   self.<discriminator> == '<value>' ? has(self.<sibling>) : !has(self.<sibling>)
+// Rules with this shape mean "when discriminator equals value, the sibling
+// block must be present." We use them to materialize the sibling on top of
+// what `required` alone would emit. Other CEL shapes (cross-field guards,
+// !has preconditions, enum-style 'any of', leaf range checks) are ignored.
+const DISCRIMINATOR_RULE_RE =
+  /^\s*self\.(\w+)\s*==\s*'([^']+)'\s*\?\s*has\(self\.(\w+)\)/;
+
+function parseDiscriminatorRules(schema) {
+  const validations = schema['x-kubernetes-validations'];
+  if (!Array.isArray(validations)) return [];
+  const rules = [];
+  for (const v of validations) {
+    if (typeof v?.rule !== 'string') continue;
+    const m = v.rule.match(DISCRIMINATOR_RULE_RE);
+    if (!m) continue;
+    rules.push({ discriminator: m[1], value: m[2], sibling: m[3] });
+  }
+  return rules;
+}
+
+// `picks` lets callers override which enum value gets emitted for a given
+// required property. Used to swap `spec.type` away from `enum[0]` when an
+// intros entry sets `preferredType`. Only applied at the level it's passed in
+// at; we don't recurse it because every override case so far targets the spec
+// discriminator directly.
+function buildRequiredExample(schema, picks = {}) {
   if (schema.type !== 'object' || !schema.properties)
     return placeholder(schema);
   const required = Array.isArray(schema.required) ? schema.required : [];
@@ -66,12 +131,33 @@ function buildRequiredExample(schema) {
   for (const key of required) {
     const child = schema.properties[key];
     if (!child) continue;
-    if (child.type === 'object' && child.properties) {
+    if (
+      Object.prototype.hasOwnProperty.call(picks, key) &&
+      Array.isArray(child.enum) &&
+      child.enum.includes(picks[key])
+    ) {
+      out[key] = picks[key];
+    } else if (child.type === 'object' && child.properties) {
       out[key] = buildRequiredExample(child);
     } else if (child.type === 'array') {
-      out[key] = [];
+      out[key] = arrayExample(child);
     } else {
       out[key] = placeholder(child);
+    }
+  }
+  for (const { discriminator, value, sibling } of parseDiscriminatorRules(
+    schema
+  )) {
+    if (out[discriminator] !== value) continue;
+    if (sibling in out) continue;
+    const siblingSchema = schema.properties[sibling];
+    if (!siblingSchema) continue;
+    if (siblingSchema.type === 'array') {
+      out[sibling] = arrayExample(siblingSchema);
+    } else if (siblingSchema.type === 'object' && siblingSchema.properties) {
+      out[sibling] = buildRequiredExample(siblingSchema);
+    } else {
+      out[sibling] = placeholder(siblingSchema);
     }
   }
   return out;
@@ -87,7 +173,9 @@ function buildYamlSkeleton({ group, version, kind, scope, schema }) {
     },
   };
   if (schema.properties?.spec) {
-    example.spec = buildRequiredExample(schema.properties.spec);
+    const preferredType = intros[kind]?.preferredType;
+    const picks = preferredType ? { type: preferredType } : {};
+    example.spec = buildRequiredExample(schema.properties.spec, picks);
     if (example.spec === undefined) example.spec = {};
   }
   return yaml.stringify(example, { indent: 2, lineWidth: 0 });

--- a/scripts/extract-crd-schemas.mjs
+++ b/scripts/extract-crd-schemas.mjs
@@ -96,12 +96,14 @@ function arrayExample(schema) {
   return Array.from({ length: minItems }, () => item);
 }
 
-// Match the kubebuilder discriminator idiom:
-//   self.<discriminator> == '<value>' ? has(self.<sibling>) : !has(self.<sibling>)
-// Rules with this shape mean "when discriminator equals value, the sibling
-// block must be present." We use them to materialize the sibling on top of
-// what `required` alone would emit. Other CEL shapes (cross-field guards,
-// !has preconditions, enum-style 'any of', leaf range checks) are ignored.
+// Match CEL rules whose true branch is `has(self.<sibling>)` - the
+// kubebuilder discriminator idiom, regardless of whether the false branch
+// is `!has(self.<sibling>)` (exclusive-or) or `true` (constraint-only).
+// In both cases the rule means "when discriminator equals value, the
+// sibling must be present", which is all we need to know to materialize
+// the sibling on top of what `required` alone would emit. Other CEL
+// shapes (cross-field guards, !has preconditions, leaf range checks) are
+// ignored.
 const DISCRIMINATOR_RULE_RE =
   /^\s*self\.(\w+)\s*==\s*'([^']+)'\s*\?\s*has\(self\.(\w+)\)/;
 

--- a/scripts/lib/crd-intros.mjs
+++ b/scripts/lib/crd-intros.mjs
@@ -22,6 +22,12 @@
 //                 cross-CRD links should use [Kind](./slug.mdx) form.
 //                 Default: cleaned upstream schema description, or a
 //                 generic fallback if only boilerplate is present upstream.
+//   preferredType - Override the discriminator value used in the generated
+//                 example YAML. Useful when `spec.type` has several enum
+//                 variants and the alphabetical first pick is not the most
+//                 representative. The value must be one of the enum's values
+//                 and the matching sibling block must satisfy admission with
+//                 default placeholders.
 
 export const groupLabels = {
   core: 'Core workloads',
@@ -97,6 +103,7 @@ export const intros = {
       'Schema reference for MCPOIDCConfig, which configures OIDC-based incoming authentication for MCP servers.',
     intro:
       '`MCPOIDCConfig` defines OIDC authentication settings that can be shared across multiple MCP workloads. [MCPServer](./mcpserver.mdx), [MCPRemoteProxy](./mcpremoteproxy.mdx), and [VirtualMCPServer](./virtualmcpserver.mdx) reference an `MCPOIDCConfig` via `spec.oidcConfigRef` to validate incoming tokens.',
+    preferredType: 'inline',
   },
   MCPExternalAuthConfig: {
     slug: 'mcpexternalauthconfig',
@@ -106,6 +113,7 @@ export const intros = {
       'Schema reference for MCPExternalAuthConfig, which configures external authentication for MCP servers and proxies.',
     intro:
       '`MCPExternalAuthConfig` configures how an MCP server or proxy authenticates to external services via token exchange or an embedded authorization server. It is referenced by [MCPServer](./mcpserver.mdx), [MCPRemoteProxy](./mcpremoteproxy.mdx), [MCPServerEntry](./mcpserverentry.mdx), and [VirtualMCPServer](./virtualmcpserver.mdx).',
+    preferredType: 'embeddedAuthServer',
   },
   MCPTelemetryConfig: {
     slug: 'mcptelemetryconfig',

--- a/static/api-specs/crds/mcpexternalauthconfigs.example.yaml
+++ b/static/api-specs/crds/mcpexternalauthconfigs.example.yaml
@@ -4,4 +4,9 @@ metadata:
   name: my-mcpexternalauthconfig
   namespace: default
 spec:
-  type: tokenExchange
+  type: embeddedAuthServer
+  embeddedAuthServer:
+    issuer: https://example.com
+    upstreamProviders:
+      - name: example
+        type: oidc

--- a/static/api-specs/crds/mcpoidcconfigs.example.yaml
+++ b/static/api-specs/crds/mcpoidcconfigs.example.yaml
@@ -4,4 +4,6 @@ metadata:
   name: my-mcpoidcconfig
   namespace: default
 spec:
-  type: kubernetesServiceAccount
+  type: inline
+  inline:
+    issuer: <string>

--- a/static/api-specs/crds/mcpremoteproxies.example.yaml
+++ b/static/api-specs/crds/mcpremoteproxies.example.yaml
@@ -4,4 +4,4 @@ metadata:
   name: my-mcpremoteproxy
   namespace: default
 spec:
-  remoteUrl: <string>
+  remoteUrl: https://example.com

--- a/static/api-specs/crds/mcpserverentries.example.yaml
+++ b/static/api-specs/crds/mcpserverentries.example.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   groupRef:
     name: <string>
-  remoteUrl: <string>
+  remoteUrl: https://example.com
   transport: sse


### PR DESCRIPTION
### Description

The minimal example each CRD reference page renders is generated by `buildRequiredExample()` walking the schema's `required` field. That walk ignored three things admission cares about, so several examples failed `kubectl apply --dry-run=server`:

- **`x-kubernetes-validations` CEL rules** of the form `self.X == 'lit' ? has(self.Y) : !has(self.Y)`. Materialize the required sibling block when the picked discriminator value matches. Fixes `MCPExternalAuthConfig` and `MCPOIDCConfig`.
- **String `pattern` validators.** The default `<string>` placeholder doesn't satisfy `^https?://...`. Added a small extensible registry of pattern -> example-value mappings (URL, DNS-1123 label). Fixes `MCPRemoteProxy.spec.remoteUrl` and `MCPServerEntry.spec.remoteUrl`.
- **Array `minItems`.** Recurse into the items schema and emit that many example items, instead of `[]`.

Also added a `preferredType` override in `scripts/lib/crd-intros.mjs` so the discriminator pick is editorial when alphabetical `enum[0]` isn't representative. Set `inline` for MCPOIDCConfig and `embeddedAuthServer` for MCPExternalAuthConfig - both more useful canonical examples than the alphabetical defaults.

After this change, all 12 CRD examples pass server-side dry-run apply.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Closes #739.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)