### PR TITLE
Fix stale ToolHive Studio.app path

### DIFF
--- a/docs/toolhive/guides-cli/install.mdx
+++ b/docs/toolhive/guides-cli/install.mdx
@@ -168,7 +168,7 @@ while ToolHive UI is installed shows a conflict error:
 Error: CLI conflict detected
 
 The ToolHive Desktop application manages a CLI installation at:
-  /Applications/ToolHive Studio.app/Contents/Resources/bin/darwin-arm64/thv
+  /Applications/ToolHive.app/Contents/Resources/bin/darwin-arm64/thv
 
 You are running a different CLI binary at:
   /usr/local/bin/thv


### PR DESCRIPTION
## Summary

The macOS app bundle is `ToolHive.app`, not `ToolHive Studio.app`. Updates the example error output in the CLI conflict resolution section to match reality. Verified against `/Applications/` on a current install.

## Test plan

- [x] `npm run build` (no broken-link or rendering changes)