### PR TITLE
Suppress Renovate edited notification on autogen-docs PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -93,6 +93,7 @@
       "ignoreUnstable": true,
       "rebaseWhen": "never",
       "recreateWhen": "never",
+      "suppressNotifications": ["prEditedNotification"],
       "commitMessageTopic": "{{depName}}",
       "labels": ["autogen-docs"],
       "prBodyNotes": [


### PR DESCRIPTION
### Description

The `upstream-release-docs` workflow always pushes commits onto Renovate's PR for `.github/upstream-projects.yaml` updates, which triggers Renovate's "Edited/Blocked Notification" comment on every run. Example: [comment on #826](https://github.com/stacklok/docs-website/pull/826#issuecomment-4348123218).

We already have `rebaseWhen: never` and `recreateWhen: never` set on this packageRule, so the warning telling us Renovate won't rebase is purely noise. This adds `suppressNotifications: ["prEditedNotification"]` to the same rule so the comment is no longer posted on these PRs.

Scoped to the `upstream-projects.yaml` custom manager only - other Renovate PRs still get the notification if a human edits the branch.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Example of the noise comment this suppresses: https://github.com/stacklok/docs-website/pull/826#issuecomment-4348123218

🤖 Generated with [Claude Code](https://claude.com/claude-code)