### PR TITLE
Tighten auth-framework concept page against current MCP spec

### DIFF
--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -330,10 +330,10 @@ while others provide enterprise-grade authentication for production deployments.
 When selecting an MCP client for authenticated workflows, look for clients that
 implement the OAuth 2.1 authorization profile defined by the MCP specification.
 
-ToolHive's OIDC-based authentication approach aligns with industry standards and
-works with clients that support modern authentication protocols. As the MCP
-ecosystem continues to mature, we expect authentication support to become more
-standardized across clients.
+ToolHive's OAuth/OIDC-based authentication approach aligns with industry
+standards and works with clients that support modern authentication protocols.
+As the MCP ecosystem continues to mature, we expect authentication support to
+become more standardized across clients.
 
 ## Related information
 

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -328,8 +328,7 @@ focus primarily on local, unauthenticated MCP servers for development workflows,
 while others provide enterprise-grade authentication for production deployments.
 
 When selecting an MCP client for authenticated workflows, look for clients that
-support the MCP authentication standards, including OAuth 2.1 and
-transport-level authentication mechanisms.
+implement the OAuth 2.1 authorization profile defined by the MCP specification.
 
 ToolHive's OIDC-based authentication approach aligns with industry standards and
 works with clients that support modern authentication protocols. As the MCP

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -160,8 +160,9 @@ The authentication process follows these steps:
 
 1. **Token acquisition:** You obtain an access token from your identity
    provider.
-2. **Token presentation:** You include the token in your requests to ToolHive
-   (typically in the Authorization header).
+2. **Token presentation:** You include the token in the `Authorization` header
+   on every request to ToolHive. Per the MCP specification, access tokens must
+   not appear in URI query strings.
 3. **Token validation:** ToolHive validates the token using either:
    - **Local validation:** For JWT tokens, verifying the signature, expiration,
      and claims using the provider's public keys (JWKS)

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -90,21 +90,18 @@ without an existing relationship, is planned.
 
 ## Authentication framework
 
-ToolHive uses OAuth-based authentication with support for both OAuth 2.1 and
-OpenID Connect (OIDC), enabling both JWT tokens and opaque token validation.
-This lets you connect ToolHive to any OAuth 2.1 or OIDC-compliant identity
-provider (IdP), such as Google, GitHub, Microsoft Entra ID (Azure AD), Okta,
-Auth0, or even Kubernetes service accounts. ToolHive never handles your raw
-passwords or credentials; instead, it relies on access tokens issued by your
-trusted provider, either self-contained JWT tokens or opaque tokens validated
-through token introspection.
+ToolHive uses OAuth-based authentication and accepts access tokens issued by any
+OAuth 2.0 or OIDC-compliant identity provider (IdP), such as Google, GitHub,
+Microsoft Entra ID (Azure AD), Okta, Auth0, or Kubernetes service accounts.
+ToolHive supports both self-contained JWT tokens and opaque tokens (validated
+through introspection), and never handles your raw passwords or credentials.
 
 ### Why use OAuth-based authentication?
 
 OAuth-based authentication provides several key advantages for securing MCP
 servers:
 
-- **Standard and interoperable:** You can connect ToolHive to any OAuth 2.1 or
+- **Standard and interoperable:** You can connect ToolHive to any OAuth 2.0 or
   OIDC-compliant IdP without custom code, supporting both human users and
   automated services.
 - **Proven and secure:** Authentication is delegated to battle-tested identity
@@ -204,7 +201,7 @@ For Kubernetes setup instructions, see
 
 ### Identity providers
 
-ToolHive can integrate with any provider that supports OAuth 2.1 or OIDC,
+ToolHive can integrate with any provider that supports OAuth 2.0 or OIDC,
 including:
 
 - Google

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -225,13 +225,13 @@ identity providers:
   tokens locally using the provider's JWKS endpoint. This verifies the token's
   signature, expiration, and claims without calling the identity provider for
   each request.
-- **Token introspection:** For providers that issue opaque tokens, ToolHive
-  validates tokens by querying the provider's introspection endpoint. This
-  supports RFC 7662 (OAuth 2.0 Token Introspection) for compliant providers,
-  plus provider-specific token-validation endpoints such as Google's `tokeninfo`
-  endpoint and GitHub's token-check REST API. The latter two are not OAuth
-  introspection in the RFC 7662 sense; they're vendor APIs that return similar
-  information.
+- **Remote token validation:** For providers that issue opaque tokens, ToolHive
+  validates tokens by calling the provider's token-validation endpoint. For
+  OAuth-compliant providers, this is RFC 7662 (OAuth 2.0 Token Introspection).
+  ToolHive also supports provider-specific endpoints, such as Google's
+  `tokeninfo` endpoint and GitHub's token-check REST API. The vendor endpoints
+  are not OAuth introspection in the RFC 7662 sense; they're proprietary APIs
+  that return similar information.
 
 ToolHive automatically detects the token type. It first attempts JWT validation,
 and if that fails, it falls back to token introspection. This means you don't

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -140,7 +140,8 @@ information within the token itself. JWTs are validated locally using
 cryptographic signatures and consist of three parts:
 
 1. **Header:** Metadata about the token
-2. **Payload:** Claims about the entity (typically you or your service)
+2. **Payload:** Claims about the subject and the token, such as issuer,
+   audience, and expiration
 3. **Signature:** Ensures the token hasn't been altered
 
 **Opaque tokens:** Reference tokens that don't contain identity information

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -51,11 +51,14 @@ server acts as an OAuth resource server. While authorization is optional in MCP,
 HTTP-transport implementations that adopt it must follow this profile. In
 practice, this model creates significant operational challenges:
 
-- **OAuth client registration burden:** OAuth 2.0 requires pre-registered
-  redirect URIs at each identity provider. Many providers (such as Google,
-  GitHub, and Atlassian) require manual registration of OAuth clients to obtain
-  a client ID and client secret. If each user client (for example, an IDE) were
-  its own OAuth client, the registration burden would be impractical at scale.
+- **OAuth client registration burden:** Many identity providers (such as Google,
+  GitHub, and Atlassian) require manual pre-registration of OAuth clients to
+  obtain a client ID and client secret. The MCP specification addresses this gap
+  with a priority order of registration mechanisms (pre-registered client info,
+  Client ID Metadata Documents, and Dynamic Client Registration), but most
+  existing identity providers don't yet implement the latter two. If each user
+  client (for example, an IDE) had to pre-register at every provider, the burden
+  would be impractical at scale.
 - **No federation with external services:** While token exchange (RFC 8693) and
   federated identity providers work when the upstream service is in the same
   trust domain as the MCP server or has an established trust relationship with

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -45,10 +45,11 @@ and securely.
 ## Why ToolHive centralizes authentication
 
 The
-[official MCP specification](https://modelcontextprotocol.io/docs/tutorials/security/authorization)
-recommends OAuth 2.1-based authorization for HTTP transports, where each MCP
-server acts as an OAuth resource server. In practice, this model creates
-significant operational challenges:
+[official MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+defines an OAuth 2.1 authorization profile for HTTP transports, where each MCP
+server acts as an OAuth resource server. While authorization is optional in MCP,
+HTTP-transport implementations that adopt it must follow this profile. In
+practice, this model creates significant operational challenges:
 
 - **OAuth client registration burden:** OAuth 2.0 requires pre-registered
   redirect URIs at each identity provider. Many providers (such as Google,

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -84,7 +84,7 @@ token acquisition and management.
 
 To eliminate the client registration burden, the embedded authorization server
 currently implements Dynamic Client Registration (DCR), which the MCP
-specification lists as the backwards-compatibility fallback. Support for Client
+specification lists as the backward compatibility fallback. Support for Client
 ID Metadata Documents, the spec's preferred mechanism for clients and servers
 without an existing relationship, is planned.
 

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -76,12 +76,17 @@ management.
 
 The [embedded authorization server](#embedded-authorization-server) addresses
 the remaining challenges. It exposes standard OAuth endpoints and handles the
-full OAuth web flow, eliminating the client registration burden through Dynamic
-Client Registration (DCR) and solving the federation gap by obtaining tokens
-directly from external providers like GitHub or Atlassian. ToolHive delegates
+full OAuth web flow, and solves the federation gap by obtaining tokens directly
+from external providers like GitHub or Atlassian. ToolHive delegates
 authentication to the upstream provider and issues its own tokens, giving MCP
 clients a spec-compliant OAuth experience while centralizing the complexity of
 token acquisition and management.
+
+To eliminate the client registration burden, the embedded authorization server
+currently implements Dynamic Client Registration (DCR), which the MCP
+specification lists as the backwards-compatibility fallback. Support for Client
+ID Metadata Documents, the spec's preferred mechanism for clients and servers
+without an existing relationship, is planned.
 
 ## Authentication framework
 

--- a/docs/toolhive/concepts/auth-framework.mdx
+++ b/docs/toolhive/concepts/auth-framework.mdx
@@ -226,8 +226,11 @@ identity providers:
   each request.
 - **Token introspection:** For providers that issue opaque tokens, ToolHive
   validates tokens by querying the provider's introspection endpoint. This
-  supports RFC 7662 (OAuth 2.0 Token Introspection), Google's tokeninfo API, and
-  GitHub's token validation API.
+  supports RFC 7662 (OAuth 2.0 Token Introspection) for compliant providers,
+  plus provider-specific token-validation endpoints such as Google's `tokeninfo`
+  endpoint and GitHub's token-check REST API. The latter two are not OAuth
+  introspection in the RFC 7662 sense; they're vendor APIs that return similar
+  information.
 
 ToolHive automatically detects the token type. It first attempts JWT validation,
 and if that fails, it falls back to token introspection. This means you don't


### PR DESCRIPTION
### Description

Editorial accuracy fixes to `docs/toolhive/concepts/auth-framework.mdx` against the current MCP authorization specification (2025-11-25). None of these changes affect ToolHive's behavior — they tighten wording that drifted slightly from what the spec actually says.

The four points raised in #825 are addressed in commits 1-4. While doing the spec pass, an MCP-protocol + OAuth-expert review surfaced four additional editorial issues on the same page (commits 5-8); folding them in here keeps the spec-alignment pass coherent.

**Spec-alignment commits** (issue #825):

- `925fe1d` Tighten MCP spec OAuth profile framing — re-points the link from the tutorial to the dated spec URL, replaces "recommends OAuth 2.1" with "defines an OAuth 2.1 authorization profile," and clarifies that authorization is optional but conformance is required when adopted.
- `aa64c27` Acknowledge MCP spec client registration mechanisms — drops the "OAuth 2.0 requires pre-registered redirect URIs" phrasing (OAuth 2.1 also requires it; the real gap is lack of DCR/CIMD), and names the spec's three-mechanism priority order.
- `bf08560` Note DCR today, CIMD planned for embedded auth server — splits the embedded-AS paragraph so the registration story is honest about today's behavior (DCR shipped, CIMD planned).
- `b8b20fd` Require Authorization header for token presentation — drops "typically" on the Authorization header and adds the spec's MUST NOT for query strings.

**Additional editorial findings on the same page** (surfaced by the spec pass):

- `241d678` Correct OAuth 2.0/OIDC compatibility framing — OIDC builds on OAuth 2.0, not 2.1; GitHub's OAuth is 2.0; the parallel "OAuth 2.1 or OIDC" framing didn't hold up.
- `e8d49d9` Distinguish vendor token-validation APIs from RFC 7662 — Google's `tokeninfo` is a proprietary GET endpoint (predates RFC 7662); GitHub's token-check API is a REST endpoint requiring HTTP Basic with client creds. Neither is RFC 7662 introspection.
- `193faf1` Tighten JWT payload claims description — RFC 7519 claims cover subject, issuer, audience, and expiration, not just "the entity."
- `6ba6a47` Reference MCP OAuth profile in client selection guidance — fixes a redundant phrasing ("MCP standards including OAuth 2.1") since the MCP standard *is* an OAuth 2.1 profile.

### Type of change

- Documentation update

### Related issues/PRs

Closes #825.

A follow-up issue will track deeper structural findings (RFC 9728 PRM + 401 challenge, RFC 8707 audience binding, PKCE callout, no-passthrough rule, mermaid-diagram cleanup, JWT-vs-introspection fallback wording, JWKS/`kid` mechanics, Kubernetes-vs-embedded-AS caveat) that go beyond editorial accuracy and warrant their own review.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)