### PR TITLE
Document Bearer Token auth for remote MCP servers

### DIFF
--- a/docs/toolhive/_partials/_remote-mcp-auth-examples.mdx
+++ b/docs/toolhive/_partials/_remote-mcp-auth-examples.mdx
@@ -19,7 +19,8 @@ that supports this feature:
 #### Remote MCP server with Bearer Token authentication
 
 Bearer Token authentication is the simplest option for MCP servers that accept a
-static API key or token. Brave Search's remote MCP server is one example:
+bearer token in the `Authorization` header. Brave Search's remote MCP server is
+one example:
 
 1. Configuration settings:
    - **Server name**: `brave-search`
@@ -28,7 +29,7 @@ static API key or token. Brave Search's remote MCP server is one example:
    - **Authorization method**: Bearer Token
    - **Bearer token**: Your Brave Search API key
 1. When you install the server, ToolHive stores the token securely and injects
-   it as an `Authorization` header on every request.
+   it as an `Authorization: Bearer <token>` header on every request.
 1. The remote MCP server appears in your server list with a "Running" status.
 
 #### Remote MCP server with OAuth2 authentication

--- a/docs/toolhive/_partials/_remote-mcp-auth-examples.mdx
+++ b/docs/toolhive/_partials/_remote-mcp-auth-examples.mdx
@@ -16,6 +16,21 @@ that supports this feature:
 1. Your browser opens for authentication. After you authorize access, the remote
    MCP server appears in your server list with a "Running" status.
 
+#### Remote MCP server with Bearer Token authentication
+
+Bearer Token authentication is the simplest option for MCP servers that accept a
+static API key or token. Brave Search's remote MCP server is one example:
+
+1. Configuration settings:
+   - **Server name**: `brave-search`
+   - **Server URL**: `https://mcp.bravesearch.com/sse`
+   - **Transport**: SSE
+   - **Authorization method**: Bearer Token
+   - **Bearer token**: Your Brave Search API key
+1. When you install the server, ToolHive stores the token securely and injects
+   it as an `Authorization` header on every request.
+1. The remote MCP server appears in your server list with a "Running" status.
+
 #### Remote MCP server with OAuth2 authentication
 
 GitHub's remote MCP server requires manual OAuth configuration. You'll need to

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -145,9 +145,18 @@ remaining required information and adjust any optional settings as needed:
    - Obtains and manages client credentials
    - Handles token lifecycle automatically
 
-   For MCP servers that require manual configuration, ToolHive supports OAuth2
-   and OIDC authentication. Obtain the necessary information from the MCP
-   server's documentation or administrator.
+   For MCP servers that use a static API key or token, select **Bearer Token**.
+   ToolHive stores the token securely and injects it as an
+   `Authorization: Bearer <token>` header on every request.
+
+   **Bearer Token authentication options:**
+   - **Bearer token**: The token value. Enter a value to create a new secret or
+     select an existing secret from the provider. Secrets are stored securely
+     and can be used by the MCP server without exposing them in plaintext. See
+     [Secrets management](./secrets-management.mdx) for details. [Required]
+
+   For MCP servers that require OAuth2 or OIDC authentication, obtain the
+   necessary information from the MCP server's documentation or administrator.
 
    **OAuth2 authentication options:**
    - **Authorize URL**: The URL where users are redirected to authenticate and
@@ -405,9 +414,18 @@ On the configuration form, enter:
    - Obtains and manages client credentials
    - Handles token lifecycle automatically
 
-   For MCP servers that require manual configuration, ToolHive supports OAuth2
-   and OIDC authentication. Obtain the necessary information from the MCP
-   server's documentation or administrator.
+   For MCP servers that use a static API key or token, select **Bearer Token**.
+   ToolHive stores the token securely and injects it as an
+   `Authorization: Bearer <token>` header on every request.
+
+   **Bearer Token authentication options:**
+   - **Bearer token**: The token value. Enter a value to create a new secret or
+     select an existing secret from the provider. Secrets are stored securely
+     and can be used by the MCP server without exposing them in plaintext. See
+     [Secrets management](./secrets-management.mdx) for details. [Required]
+
+   For MCP servers that require OAuth2 or OIDC authentication, obtain the
+   necessary information from the MCP server's documentation or administrator.
 
    **OAuth2 authentication options:**
    - **Authorize URL**: The URL where users are redirected to authenticate and

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -152,7 +152,7 @@ remaining required information and adjust any optional settings as needed:
    **Bearer Token authentication options:**
    - **Bearer token**: The token value. Enter a value to create a new secret or
      select an existing secret from the provider. Secrets are stored securely
-     and can be used by the MCP server without exposing them in plaintext. See
+     and are not exposed in plaintext in configuration files. See
      [Secrets management](./secrets-management.mdx) for details. [Required]
 
    For MCP servers that require OAuth2 or OIDC authentication, obtain the
@@ -421,7 +421,7 @@ On the configuration form, enter:
    **Bearer Token authentication options:**
    - **Bearer token**: The token value. Enter a value to create a new secret or
      select an existing secret from the provider. Secrets are stored securely
-     and can be used by the MCP server without exposing them in plaintext. See
+     and are not exposed in plaintext in configuration files. See
      [Secrets management](./secrets-management.mdx) for details. [Required]
 
    For MCP servers that require OAuth2 or OIDC authentication, obtain the

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -145,9 +145,11 @@ remaining required information and adjust any optional settings as needed:
    - Obtains and manages client credentials
    - Handles token lifecycle automatically
 
-   For MCP servers that use a static API key or token, select **Bearer Token**.
-   ToolHive stores the token securely and injects it as an
-   `Authorization: Bearer <token>` header on every request.
+   For MCP servers that accept a bearer token in the `Authorization` header,
+   select **Bearer Token**. ToolHive stores the token securely and sends it as
+   an `Authorization: Bearer <token>` header on every request. For servers that
+   expect a different header (such as `X-API-Key`), use **Custom headers**
+   instead.
 
    **Bearer Token authentication options:**
    - **Bearer token**: The token value. Enter a value to create a new secret or
@@ -414,9 +416,11 @@ On the configuration form, enter:
    - Obtains and manages client credentials
    - Handles token lifecycle automatically
 
-   For MCP servers that use a static API key or token, select **Bearer Token**.
-   ToolHive stores the token securely and injects it as an
-   `Authorization: Bearer <token>` header on every request.
+   For MCP servers that accept a bearer token in the `Authorization` header,
+   select **Bearer Token**. ToolHive stores the token securely and sends it as
+   an `Authorization: Bearer <token>` header on every request. For servers that
+   expect a different header (such as `X-API-Key`), use **Custom headers**
+   instead.
 
    **Bearer Token authentication options:**
    - **Bearer token**: The token value. Enter a value to create a new secret or

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -167,9 +167,9 @@ remaining required information and adjust any optional settings as needed:
      provider. [Required]
    - **Client secret**: The secret key that proves your application's identity.
      Enter a value to create a new secret or select an existing secret from the
-     provider. Secrets are stored securely and can be used by the MCP server
-     without exposing them in plaintext. See
-     [Secrets management](./secrets-management.mdx) for details. [Optional]
+     provider. Secrets are stored securely and are not exposed in plaintext in
+     configuration files. See [Secrets management](./secrets-management.mdx) for
+     details. [Optional]
    - **Scopes**: List of permissions your application is requesting. [Optional]
    - **PKCE**: Enable Proof Key for Code Exchange (RFC 7636) for enhanced
      security without requiring a client secret. [Optional]
@@ -180,9 +180,9 @@ remaining required information and adjust any optional settings as needed:
      provider. [Required]
    - **Client secret**: The secret key that proves your application's identity.
      Enter a value to create a new secret or select an existing secret from the
-     provider. Secrets are stored securely and can be used by the MCP server
-     without exposing them in plaintext. See
-     [Secrets management](./secrets-management.mdx) for details. [Optional]
+     provider. Secrets are stored securely and are not exposed in plaintext in
+     configuration files. See [Secrets management](./secrets-management.mdx) for
+     details. [Optional]
    - **PKCE**: Enable Proof Key for Code Exchange (RFC 7636) for enhanced
      security without requiring a client secret. [Optional]
 
@@ -436,9 +436,9 @@ On the configuration form, enter:
      provider. [Required]
    - **Client secret**: The secret key that proves your application's identity.
      Enter a value to create a new secret or select an existing secret from the
-     provider. Secrets are stored securely and can be used by the MCP server
-     without exposing them in plaintext. See
-     [Secrets management](./secrets-management.mdx) for details. [Optional]
+     provider. Secrets are stored securely and are not exposed in plaintext in
+     configuration files. See [Secrets management](./secrets-management.mdx) for
+     details. [Optional]
    - **Scopes**: List of permissions your application is requesting. [Optional]
 
    **OIDC authentication options:**
@@ -447,9 +447,9 @@ On the configuration form, enter:
      provider. [Required]
    - **Client secret**: The secret key that proves your application's identity.
      Enter a value to create a new secret or select an existing secret from the
-     provider. Secrets are stored securely and can be used by the MCP server
-     without exposing them in plaintext. See
-     [Secrets management](./secrets-management.mdx) for details. [Optional]
+     provider. Secrets are stored securely and are not exposed in plaintext in
+     configuration files. See [Secrets management](./secrets-management.mdx) for
+     details. [Optional]
    - **PKCE**: Enable Proof Key for Code Exchange (RFC 7636) for enhanced
      security without requiring a client secret. [Optional]
 

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -444,6 +444,8 @@ On the configuration form, enter:
      configuration files. See [Secrets management](./secrets-management.mdx) for
      details. [Optional]
    - **Scopes**: List of permissions your application is requesting. [Optional]
+   - **PKCE**: Enable Proof Key for Code Exchange (RFC 7636) for enhanced
+     security without requiring a client secret. [Optional]
 
    **OIDC authentication options:**
    - **Issuer URL**: The base URL of the OIDC provider. [Required]


### PR DESCRIPTION
## Summary

- Add Bearer Token authentication documentation to the remote MCP server configuration sections (both add and edit flows) in `run-mcp-servers.mdx`
- Add a Bearer Token example (using Brave Search) to the remote auth examples partial
- Update transition text to reflect all four auth methods (Auto-Discovered, Bearer Token, OAuth2, OIDC)
- Clarify that Bearer Token sends an `Authorization: Bearer <token>` header specifically, and that servers expecting other headers (e.g. `X-API-Key`) should use Custom headers
- Add missing PKCE option to OAuth2 fields in the custom remote MCP section for consistency with the registry remote MCP section

Closes #767

## Test plan

- [ ] Verify the Bearer Token section renders correctly on the "Run MCP servers" page
- [ ] Verify the Bearer Token example appears in the collapsible auth examples
- [ ] Confirm field descriptions match the ToolHive Studio UI
- [ ] Confirm OAuth2 fields (including PKCE) are consistent between registry and custom remote sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)