### PR TITLE
Fix secrets location in UI docs

### DIFF
--- a/docs/toolhive/guides-ui/secrets-management.mdx
+++ b/docs/toolhive/guides-ui/secrets-management.mdx
@@ -12,8 +12,8 @@ files.
 ToolHive encrypts secrets using a randomly generated password that is stored in
 your operating system's secure keyring.
 
-You can add new secrets on the **Secrets** page or during MCP server
-installation.
+You can add new secrets on the **Secrets** tab in **Settings** or during MCP
+server installation.
 
 :::note
 
@@ -40,7 +40,8 @@ To set the secret value, you can:
 
 ## Manage secrets
 
-Your ToolHive secrets are managed on the **Secrets** page. Here you can:
+Your ToolHive secrets are managed on the **Secrets** tab in **Settings**. Here
+you can:
 
 - Click the **Add secret** button to create a new secret. Enter a friendly name
   for the secret and its value.


### PR DESCRIPTION
## Summary

- Update secrets management docs to reflect that Secrets moved from a top-level page to a **tab in Settings** in the ToolHive UI (Studio commit `f1ae0b90`)

Closes #626

## Test plan

- [ ] Verify the site builds successfully
- [ ] Review the updated wording on the [secrets management page](/toolhive/guides-ui/secrets-management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)