### PR TITLE
Document Registry Server API registry type

### DIFF
--- a/docs/toolhive/guides-ui/registry.mdx
+++ b/docs/toolhive/guides-ui/registry.mdx
@@ -117,7 +117,7 @@ file (for example: `/path/myregistry/db.json`).
 
 When you select **Registry Server API**, a **Registry Server API URL** field
 appears where you provide the URL of your Registry Server endpoint (for example:
-`https://registry.example.com:8080/api/registry`). If your Registry Server
+`https://registry.example.com:8080/registry/default`). If your Registry Server
 requires authentication, expand the **Authenticate with your OIDC provider**
 section and enter the following fields:
 

--- a/docs/toolhive/guides-ui/registry.mdx
+++ b/docs/toolhive/guides-ui/registry.mdx
@@ -100,30 +100,45 @@ in the **MCP Servers** page where you can
 ## Registry settings
 
 To configure your registry, ToolHive provides a dedicated **Registry** settings
-section in **Settings** → **Registry** with three options:
+section in **Settings** → **Registry** with four options:
 
 - **Default Registry** - Use ToolHive's built-in verified registry
-- **Remote Registry (URL)** - Specify a custom URL for a remote registry hosted
-  on a web server
-- **Local Registry (File Path)** - Specify a local file path to a JSON registry
-  file on your system
+- **Remote Registry (JSON URL)** - Specify a URL pointing to a static JSON
+  registry file hosted on a web server
+- **Local Registry (JSON File Path)** - Specify a local file path to a JSON
+  registry file on your system
+- **Registry Server API** - Connect to a
+  [ToolHive Registry Server](../guides-registry/index.mdx) endpoint with
+  optional OIDC authentication
 
-When you select **Local Registry (File Path)**, an additional **Registry File
-Path** field appears where you need to provide the absolute path to your local
-JSON registry file (for example: `/path/myregistry/db.json`). Click **Save** to
-apply your configuration.
+When you select **Local Registry (JSON File Path)**, a **Registry File Path**
+field appears where you provide the absolute path to your local JSON registry
+file (for example: `/path/myregistry/db.json`).
+
+When you select **Registry Server API**, a **Registry Server API URL** field
+appears where you provide the URL of your Registry Server endpoint (for example:
+`https://registry.example.com:8080/api/registry`). If your Registry Server
+requires authentication, expand the **Authenticate with your OIDC provider**
+section and enter the following fields:
+
+- **Client ID** - The OAuth client ID registered with your identity provider
+- **Issuer URL** - The OIDC issuer URL for your identity provider (for example:
+  `https://accounts.example.com`)
+
+After you save, ToolHive initiates the OAuth login flow with your OIDC provider.
+
+:::tip
+
+The **Registry Server API** option allows private IP addresses and HTTP
+connections, so you can use it with a locally hosted Registry Server during
+development.
+
+:::
+
+Click **Save** to apply your configuration.
 
 For detailed information on creating a custom registry, see the
 [custom registry tutorial](../tutorials/custom-registry.mdx).
-
-:::tip[Host your own registry]
-
-You can deploy the [ToolHive Registry Server](../guides-registry/index.mdx) to
-host a registry with authentication, multiple data sources, and automatic
-synchronization. Point the **Remote Registry (URL)** setting to your Registry
-Server endpoint.
-
-:::
 
 <ThemedImage
   alt='Registry settings showing Local Registry File Path option selected with Registry File Path input field'


### PR DESCRIPTION
## Summary

- Add the fourth registry option **Registry Server API** to the registry settings documentation, including OIDC authentication fields (`Client ID`, `Issuer URL`) and private IP support
- Replace the outdated tip that directed users to use **Remote Registry (URL)** for Registry Server connections
- Clarify the labels for the existing Remote Registry and Local Registry options to match the current UI

Closes #769

## Test plan

- [ ] Verify the site builds successfully
- [ ] Review the updated [registry settings section](/toolhive/guides-ui/registry#registry-settings) for accuracy against Studio v0.30.0+
- [ ] Confirm OIDC field names and behavior match the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)