### PR TITLE
Document manual app update UX in install guide

### DIFF
--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -90,11 +90,14 @@ and extract it, then run the `ToolHive` binary directly.
 
 When you close the ToolHive application window, it continues running in the
 background so your MCP servers remain available. ToolHive installs a system tray
-icon for quick access. You can use it to:
+icon for quick access. The tray menu includes:
 
-- Enable or disable **Start on login**
-- Show or hide the ToolHive application window
-- Quit ToolHive, which stops all running MCP servers
+- A status indicator showing whether ToolHive is running or stopped
+- The current application version
+- **Check for Updates** to check for and install available updates
+- **Start on login** toggle to launch ToolHive when you log in to your system
+- **Show Window** and **Hide Window** to control the application window
+- **Quit ToolHive** to stop all running MCP servers and exit the application
 
 ## Application settings
 
@@ -111,22 +114,44 @@ window. The settings screen allows you to configure various options:
 - **Skip quit confirmation**: Skip the MCP server shutdown confirmation dialog
   when quitting ToolHive.
 
-From the settings screen, you can also view version information and download the
-application log file for troubleshooting.
+The settings screen also includes a **Version** tab and a **Logs** tab:
+
+- **Version** tab: Displays the Desktop UI version, ToolHive binary version, and
+  build type. A green **Latest** badge appears next to each component when you
+  are running the current version. The Version tab also includes an
+  auto-download toggle that automatically downloads and installs updates when a
+  new release is available (enabled by default). When an update is available, an
+  alert appears with a **Download** button so you can install it manually. A
+  blue indicator icon on the **Version** tab signals that an update is ready.
+- **Logs** tab: Download the application log file for troubleshooting.
 
 ## Upgrade ToolHive
 
-ToolHive automatically checks for updates. When a new version is available,
-you'll see a notification in the application. During the upgrade, ToolHive stops
-all running MCP servers, updates the application, and then restarts itself and
-the MCP servers.
+ToolHive checks for updates automatically. By default, it downloads and installs
+new versions in the background. During the upgrade, ToolHive stops all running
+MCP servers, updates the application, and then restarts itself and the MCP
+servers.
 
-You can also manually install updates by downloading the latest installer for
-your operating system from the
+You can also trigger an update manually:
+
+- **From Settings**: Open **Settings** > **Version** tab and click **Download**
+  when an update is available.
+- **From the system tray**: Click **Check for Updates** in the system tray menu
+  to check for and install the latest version.
+
+:::note[Linux]
+
+On Linux, the **Download** button in the Version tab opens the
 [ToolHive UI releases page](https://github.com/stacklok/toolhive-studio/releases/latest)
-and running it. The installer will upgrade your existing ToolHive installation
-to the latest version. See the [Install ToolHive](#install-toolhive) section for
-direct download links.
+in your browser instead of downloading the update in-app. Download the
+appropriate package and install it using your package manager.
+
+:::
+
+If you prefer, you can disable auto-updates in **Settings** > **Version** and
+download the latest installer manually from the
+[ToolHive UI releases page](https://github.com/stacklok/toolhive-studio/releases/latest).
+See the [Install ToolHive](#install-toolhive) section for direct download links.
 
 ## File locations
 

--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -86,7 +86,7 @@ and extract it, then run the `ToolHive` binary directly.
 </TabItem>
 </Tabs>
 
-## System tray icon
+## System tray
 
 When you close the ToolHive application window, it continues running in the
 background so your MCP servers remain available. ToolHive installs a system tray
@@ -94,7 +94,7 @@ icon for quick access. The tray menu includes:
 
 - A status indicator showing whether ToolHive is running or stopped
 - The current application version
-- **Check for Updates** to check for and install available updates
+- **Check for Updates...** to check for and install available updates
 - **Start on login** toggle to launch ToolHive when you log in to your system
 - **Show Window** and **Hide Window** to control the application window
 - **Quit ToolHive** to stop all running MCP servers and exit the application
@@ -116,13 +116,13 @@ window. The settings screen allows you to configure various options:
 
 The settings screen also includes a **Version** tab and a **Logs** tab:
 
-- **Version** tab: Displays the Desktop UI version, ToolHive binary version, and
-  build type. A green **Latest** badge appears next to each component when you
-  are running the current version. The Version tab also includes an
-  auto-download toggle that automatically downloads and installs updates when a
-  new release is available (enabled by default). When an update is available, an
-  alert appears with a **Download** button so you can install it manually. A
-  blue indicator icon on the **Version** tab signals that an update is ready.
+- **Version** tab: Displays the Desktop UI version and ToolHive binary version.
+  A green **Latest** badge appears next to each component when you are running
+  the current version. The **Downloads** toggle automatically downloads and
+  installs updates when a new release is available (enabled by default). When an
+  update is available, an alert appears with a **Download** button so you can
+  install it manually. A blue indicator icon on the **Version** tab signals that
+  an update is ready.
 - **Logs** tab: Download the application log file for troubleshooting.
 
 ## Upgrade ToolHive
@@ -136,8 +136,8 @@ You can also trigger an update manually:
 
 - **From Settings**: Open **Settings** > **Version** tab and click **Download**
   when an update is available.
-- **From the system tray**: Click **Check for Updates** in the system tray menu
-  to check for and install the latest version.
+- **From the system tray**: Click **Check for Updates...** in the system tray
+  menu to check for and install the latest version.
 
 :::note[Linux]
 

--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -94,7 +94,7 @@ icon for quick access. The tray menu includes:
 
 - A status indicator showing whether ToolHive is running or stopped
 - The current application version
-- **Check for Updates...** to check for and install available updates
+- **Check for Updates...** to find and install available updates
 - **Start on login** toggle to launch ToolHive when you log in to your system
 - **Show Window** and **Hide Window** to control the application window
 - **Quit ToolHive** to stop all running MCP servers and exit the application
@@ -118,11 +118,11 @@ The settings screen also includes a **Version** tab and a **Logs** tab:
 
 - **Version** tab: Displays the Desktop UI version and ToolHive binary version.
   A green **Latest** badge appears next to each component when you are running
-  the current version. The **Downloads** toggle automatically downloads and
-  installs updates when a new release is available (enabled by default). When an
-  update is available, an alert appears with a **Download** button so you can
-  install it manually. A blue indicator icon on the **Version** tab signals that
-  an update is ready.
+  the current version. The **Downloads** toggle controls whether ToolHive
+  automatically downloads and installs updates when a new release is available
+  (enabled by default). If you disable auto-updates, an alert appears when a new
+  version is available with a **Download** button so you can update manually. A
+  blue indicator icon on the **Version** tab signals that an update is ready.
 - **Logs** tab: Download the application log file for troubleshooting.
 
 ## Upgrade ToolHive


### PR DESCRIPTION
## Summary

- Expanded the **System tray icon** section with all tray menu items (status indicator, version display, Check for Updates, Start on login, Show/Hide Window, Quit)
- Replaced the vague "view version information" line in **Application settings** with detailed descriptions of the Version tab (version info with Latest badges, auto-download toggle, update alert with Download button, blue update indicator) and the Logs tab
- Rewrote **Upgrade ToolHive** to document the full update UX: automatic background updates, manual update from Settings > Version tab, manual update from the system tray, Linux browser fallback, and disabling auto-updates

Closes #768

## Test plan

- [ ] Verify the site builds without errors (`npm run build`)
- [ ] Review the three updated sections for accuracy against the ToolHive UI source code
- [ ] Confirm no style guide violations (active voice, no em dashes, sentence case headings, second person)
- [ ] Verify the Linux-specific note in the upgrade section is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)