### PR TITLE
Promote unlabeled resources from warning to subhead

### DIFF
--- a/docs/toolhive/guides-registry/authorization.mdx
+++ b/docs/toolhive/guides-registry/authorization.mdx
@@ -209,12 +209,11 @@ caller's claims must be a superset of the resource's claims. For example:
 | `{}` (no claims)                  | `{org: "acme"}`                   | Denied (default-deny on unlabeled) |
 | `{org: "acme"}`                   | `{org: "contoso"}`                | Denied                             |
 
-:::warning[Unlabeled resources are invisible when authorization is enabled]
+### Unlabeled resources
 
 When `auth.authz` is configured, sources, registries, and entries with no claims
 are treated as **default-deny**: invisible to every authenticated caller except
-a super-admin. The list endpoints and the single-resource gate agree, so a
-resource is either visible everywhere or nowhere.
+a super-admin.
 
 Anonymous mode and [auth-only mode](#auth-only-mode) bypass the gate entirely,
 so unlabeled resources remain accessible there.
@@ -223,15 +222,13 @@ To make a resource reachable under full authorization, attach claims to it:
 
 - **Sources and registries**: set the `claims` field on the source or registry
   in your configuration file.
-- **Entries from synced sources**: tag the source so its claims are inherited
+- **Entries from synced sources**: set claims on the source so they're inherited
   during sync.
 - **Entries on Kubernetes sources**: use the
   [`authz-claims` annotation](./configuration.mdx#per-entry-claims-via-annotation)
   on the CRD.
-- **Entries on managed sources**: include `claims` in the publish payload or
+- **Entries on managed sources**: include `claims` in the publish payload, or
   call `PUT /v1/entries/{type}/{name}/claims` from a super-admin.
-
-:::
 
 :::info[Upgrading from earlier releases]
 


### PR DESCRIPTION
### Description

In the registry server authorization guide, the "Unlabeled resources are
invisible when authorization is enabled" content was inside a `:::warning`
admonition. After PR #845 expanded it, the block carried multiple paragraphs
and a four-item bulleted list of how to attach claims to each resource type.

That's primary reference content, not a callout:

- The default-deny behavior is core to how authorization works, not a side
  gotcha worth flagging.
- The bulleted list is action-oriented ("how to make a resource reachable") -
  readers will look for it in the TOC and via search, where admonition
  content doesn't surface as well.
- Embedding a multi-paragraph + list block inside a warning admonition hurts
  scannability.

This PR promotes the content to a `### Unlabeled resources` subhead under
"Claim containment". The heading is kept short to match the parallel pattern
of neighboring subheads ("Source claims", "Registry claims", "Claim
containment"). The follow-on `:::info[Upgrading from earlier releases]`
admonition right below stays as-is, since transient release-specific guidance
is exactly what an admonition is for.

Light copy polish on the way through:

- Dropped "The list endpoints and the single-resource gate agree, so a
  resource is either visible everywhere or nowhere" - in the current model
  the consistency is just how it works; calling it out reads as alluding to
  the prior inconsistency, which is what the upgrade note below is for.
- "tag the source so its claims are inherited" → "set claims on the source
  so they're inherited" (matches the field name; parallels the bullet above)
- Added a comma before "or" in the managed-sources bullet

### Type of change

- Documentation update

### Related issues/PRs

Follow-up to #845.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style