### PR TITLE
Document proxy mode and proxy port fields

### DIFF
--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -104,10 +104,10 @@ remaining required information and adjust any optional settings as needed:
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
    Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the MCP server uses the `stdio` transport and is not
-   configured for bearer-token authentication. For `sse` and `streamable-http`
-   transports, the MCP server already speaks HTTP, so no proxy mode selection is
-   needed.
+   option appears only when the MCP server uses the `stdio` transport and the
+   **Authorization method** is not **Bearer Token**. For `sse` and
+   `streamable-http` transports, the MCP server already speaks HTTP, so no proxy
+   mode selection is needed.
 
 1. **Proxy port** [Optional]:\
    Port for the HTTP proxy to listen on. If not specified, ToolHive will
@@ -307,8 +307,8 @@ On the configuration form, enter:
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
    Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the **transport protocol** is `stdio` and you're not
-   using bearer-token authentication.
+   option appears only when the **transport protocol** is `stdio` and the
+   **Authorization method** is not **Bearer Token**.
 
 1. **Proxy port** [Optional]:\
    Port for the HTTP proxy to listen on. If not specified, ToolHive will
@@ -381,8 +381,8 @@ On the configuration form, enter:
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
    Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the **transport protocol** is `stdio` and you're not
-   using bearer-token authentication.
+   option appears only when the **transport protocol** is `stdio` and the
+   **Authorization method** is not **Bearer Token**.
 
 1. **Proxy port** [Optional]:\
    Port for the HTTP proxy to listen on. If not specified, ToolHive will

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -103,15 +103,15 @@ remaining required information and adjust any optional settings as needed:
 
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
-   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the MCP server uses the `stdio` transport and the
-   **Authorization method** is not **Bearer Token**. For `sse` and
-   `streamable-http` transports, the MCP server already speaks HTTP, so no proxy
-   mode selection is needed.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`).
+   **Streamable HTTP** is the default. This option appears only when the
+   **transport protocol** is `stdio` and the server is not configured for bearer
+   token authentication. For `sse` and `streamable-http` transports, the MCP
+   server already speaks HTTP, so no proxy mode selection is needed.
 
 1. **Proxy port** [Optional]:\
-   Port for the HTTP proxy to listen on. If not specified, ToolHive will
-   automatically assign a random port. This is the port that AI clients connect
+   Port for the HTTP proxy to listen on. If not specified, ToolHive
+   automatically assigns a random port. This is the port that AI clients connect
    to, which is distinct from the **target port** that the MCP server itself
    listens on inside the container.
 
@@ -215,8 +215,8 @@ remaining required information and adjust any optional settings as needed:
      one.
 
 1. **Proxy port** [Optional]:\
-   Port for the HTTP proxy to listen on. If not specified, ToolHive will
-   automatically assign a random port. **Proxy mode** is not shown for remote
+   Port for the HTTP proxy to listen on. If not specified, ToolHive
+   automatically assigns a random port. **Proxy mode** is not shown for remote
    MCP servers because remote transports are always HTTP-based (SSE or
    Streamable HTTP).
 
@@ -301,20 +301,20 @@ On the configuration form, enter:
    transports only). [Optional]\
    If the MCP server uses a specific port, enter it here. If not specified,
    ToolHive will use a random port that is exposed to the container with the
-   `MCP_PORT` and `FASTMCP_PORT` environment variables. Selecting `stdio` hides
-   this field, since `stdio` servers don't expose a port from the container.
+   `MCP_PORT` and `FASTMCP_PORT` environment variables.
 
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
-   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the **transport protocol** is `stdio` and the
-   **Authorization method** is not **Bearer Token**.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`).
+   **Streamable HTTP** is the default. This option appears only when the
+   **transport protocol** is `stdio` and the server is not configured for bearer
+   token authentication.
 
 1. **Proxy port** [Optional]:\
-   Port for the HTTP proxy to listen on. If not specified, ToolHive will
-   automatically assign a random port. This is the port that AI clients connect
-   to, separate from the **target port** that the MCP server itself listens on
-   inside the container.
+   Port for the HTTP proxy to listen on. If not specified, ToolHive
+   automatically assigns a random port. This is the port that AI clients connect
+   to, which is distinct from the **target port** that the MCP server itself
+   listens on inside the container.
 
 1. The Docker **image name** and tag (e.g., `my-mcp-server:latest`). [Required]\
    You can use any valid Docker image, including those hosted on Docker Hub or
@@ -375,20 +375,20 @@ On the configuration form, enter:
    transports only). [Optional]\
    If the MCP server uses a specific port, enter it here. If not specified,
    ToolHive will use a random port that is exposed to the container with the
-   `MCP_PORT` and `FASTMCP_PORT` environment variables. Selecting `stdio` hides
-   this field, since `stdio` servers don't expose a port from the container.
+   `MCP_PORT` and `FASTMCP_PORT` environment variables.
 
 1. **Proxy mode** [Conditional]:\
    The proxy transport mode that clients should use to connect to this server.
-   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
-   option appears only when the **transport protocol** is `stdio` and the
-   **Authorization method** is not **Bearer Token**.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`).
+   **Streamable HTTP** is the default. This option appears only when the
+   **transport protocol** is `stdio` and the server is not configured for bearer
+   token authentication.
 
 1. **Proxy port** [Optional]:\
-   Port for the HTTP proxy to listen on. If not specified, ToolHive will
-   automatically assign a random port. This is the port that AI clients connect
-   to, separate from the **target port** that the MCP server itself listens on
-   inside the container.
+   Port for the HTTP proxy to listen on. If not specified, ToolHive
+   automatically assigns a random port. This is the port that AI clients connect
+   to, which is distinct from the **target port** that the MCP server itself
+   listens on inside the container.
 
 1. The package **protocol** (`npx`, `uvx`, or `go`). [Required]
 
@@ -452,8 +452,8 @@ On the configuration form, enter:
    real-time communication. The protocol must match what the MCP server
    supports.
 5. **Proxy port** [Optional]:\
-   Port for the HTTP proxy to listen on. If not specified, ToolHive will
-   automatically assign a random port. **Proxy mode** is not shown for remote
+   Port for the HTTP proxy to listen on. If not specified, ToolHive
+   automatically assigns a random port. **Proxy mode** is not shown for remote
    MCP servers because remote transports are always HTTP-based (SSE or
    Streamable HTTP).
 6. **Authorization method**: Choose how ToolHive should authenticate with the

--- a/docs/toolhive/guides-ui/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-ui/run-mcp-servers.mdx
@@ -101,6 +101,20 @@ remaining required information and adjust any optional settings as needed:
    external networks. See the [Network isolation](./network-isolation.mdx) guide
    for details.
 
+1. **Proxy mode** [Conditional]:\
+   The proxy transport mode that clients should use to connect to this server.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
+   option appears only when the MCP server uses the `stdio` transport and is not
+   configured for bearer-token authentication. For `sse` and `streamable-http`
+   transports, the MCP server already speaks HTTP, so no proxy mode selection is
+   needed.
+
+1. **Proxy port** [Optional]:\
+   Port for the HTTP proxy to listen on. If not specified, ToolHive will
+   automatically assign a random port. This is the port that AI clients connect
+   to, which is distinct from the **target port** that the MCP server itself
+   listens on inside the container.
+
 :::note
 
 Refer to the MCP server's documentation for the required configuration
@@ -200,6 +214,12 @@ remaining required information and adjust any optional settings as needed:
      name and either select an existing secret or enter a new value to create
      one.
 
+1. **Proxy port** [Optional]:\
+   Port for the HTTP proxy to listen on. If not specified, ToolHive will
+   automatically assign a random port. **Proxy mode** is not shown for remote
+   MCP servers because remote transports are always HTTP-based (SSE or
+   Streamable HTTP).
+
 Click **Install server** to connect to the remote MCP server.
 
 <details id="remote-mcp-examples">
@@ -281,7 +301,20 @@ On the configuration form, enter:
    transports only). [Optional]\
    If the MCP server uses a specific port, enter it here. If not specified,
    ToolHive will use a random port that is exposed to the container with the
-   `MCP_PORT` and `FASTMCP_PORT` environment variables.
+   `MCP_PORT` and `FASTMCP_PORT` environment variables. Selecting `stdio` hides
+   this field, since `stdio` servers don't expose a port from the container.
+
+1. **Proxy mode** [Conditional]:\
+   The proxy transport mode that clients should use to connect to this server.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
+   option appears only when the **transport protocol** is `stdio` and you're not
+   using bearer-token authentication.
+
+1. **Proxy port** [Optional]:\
+   Port for the HTTP proxy to listen on. If not specified, ToolHive will
+   automatically assign a random port. This is the port that AI clients connect
+   to, separate from the **target port** that the MCP server itself listens on
+   inside the container.
 
 1. The Docker **image name** and tag (e.g., `my-mcp-server:latest`). [Required]\
    You can use any valid Docker image, including those hosted on Docker Hub or
@@ -342,7 +375,20 @@ On the configuration form, enter:
    transports only). [Optional]\
    If the MCP server uses a specific port, enter it here. If not specified,
    ToolHive will use a random port that is exposed to the container with the
-   `MCP_PORT` and `FASTMCP_PORT` environment variables.
+   `MCP_PORT` and `FASTMCP_PORT` environment variables. Selecting `stdio` hides
+   this field, since `stdio` servers don't expose a port from the container.
+
+1. **Proxy mode** [Conditional]:\
+   The proxy transport mode that clients should use to connect to this server.
+   Choose **SSE** (`sse`) or **Streamable HTTP** (`streamable-http`). This
+   option appears only when the **transport protocol** is `stdio` and you're not
+   using bearer-token authentication.
+
+1. **Proxy port** [Optional]:\
+   Port for the HTTP proxy to listen on. If not specified, ToolHive will
+   automatically assign a random port. This is the port that AI clients connect
+   to, separate from the **target port** that the MCP server itself listens on
+   inside the container.
 
 1. The package **protocol** (`npx`, `uvx`, or `go`). [Required]
 
@@ -405,7 +451,12 @@ On the configuration form, enter:
    ToolHive supports server-sent events (SSE) and Streamable HTTP (default) for
    real-time communication. The protocol must match what the MCP server
    supports.
-5. **Authorization method**: Choose how ToolHive should authenticate with the
+5. **Proxy port** [Optional]:\
+   Port for the HTTP proxy to listen on. If not specified, ToolHive will
+   automatically assign a random port. **Proxy mode** is not shown for remote
+   MCP servers because remote transports are always HTTP-based (SSE or
+   Streamable HTTP).
+6. **Authorization method**: Choose how ToolHive should authenticate with the
    remote server.\
    The default is **Auto-Discovered**. Use this option for MCP servers that
    fully implement the MCP authorization spec including dynamic client
@@ -459,9 +510,9 @@ On the configuration form, enter:
    - **PKCE**: Enable Proof Key for Code Exchange (RFC 7636) for enhanced
      security without requiring a client secret. [Optional]
 
-6. The **callback port** for the authentication redirect. [Optional]
+7. The **callback port** for the authentication redirect. [Optional]
 
-7. **Custom headers** [Optional]:\
+8. **Custom headers** [Optional]:\
    Add custom HTTP headers to inject into requests to the remote MCP server.
    - **Plaintext headers**: Add static key-value pairs for headers like
      `X-Tenant-ID` or correlation IDs. These values are stored and transmitted


### PR DESCRIPTION
### Description

Closes #772.

## Summary

- Document **Proxy mode** (stdio + non-Bearer-Token only; **SSE** / **Streamable HTTP**) and **Proxy port** (optional HTTP proxy listener) across the registry **Local MCP** and **Remote MCP** tabs and both **Custom local MCP** flows in `run-mcp-servers.mdx`.
- Document **Proxy port** under **Custom remote MCP** and explicitly note that **Proxy mode** is not shown for remote transports.
- Clarify that **Target port** is the container port and **Proxy port** is the HTTP proxy ToolHive listens on, so the two are no longer conflated.
- Verified UI strings against `stacklok/toolhive-studio` at tag `v0.30.0`.

## Test plan

- [ ] `npm run build` passes
- [ ] Verify the new bullets render in both tab variants and the renumbered Custom remote MCP list reads correctly

### Type of change

- Documentation update

### Related issues/PRs

Closes #772

### Submitter checklist

#### Content and formatting

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Made with [Cursor](https://cursor.com)