### PR TITLE
Fix upstream PR refs in release-docs skill

### DIFF
--- a/.claude/skills/upstream-release-docs/SKILL.md
+++ b/.claude/skills/upstream-release-docs/SKILL.md
@@ -28,6 +28,14 @@ Parse the argument to extract:
 - `<OWNER>/<REPO>`: the upstream repository (e.g., `stacklok/toolhive-registry-server`)
 - `<TAG>` (optional): the release tag (e.g., `v0.6.3`). If omitted, fetch the latest release.
 
+## Output conventions
+
+Any output that may be rendered as a GitHub comment, PR body, or Markdown file in the docs-website repo (progress narration, `SUMMARY.md`, `GAPS.md`, commit messages, PR descriptions) **must** fully qualify references to the upstream repo. GitHub auto-links bare `#NNN` relative to the repo the text lives in, so a bare `#777` in a docs-website comment links to docs-website PR #777, not the upstream PR.
+
+- Refer to upstream PRs and issues as `<OWNER>/<REPO>#NNN` (e.g., `stacklok/toolhive#777`), never bare `#NNN`.
+- When the release notes body contains bare `#NNN`, expand them to `<OWNER>/<REPO>#NNN` before echoing them back.
+- Full PR/issue URLs are also fine.
+
 ## Phase 1: Discovery
 
 1. Fetch the release:
@@ -42,7 +50,7 @@ Parse the argument to extract:
    gh release view --repo <OWNER>/<REPO> --json tagName,name,body,publishedAt
    ```
 
-2. Extract PR numbers from the release notes body (look for `#NNN` patterns or full PR URLs).
+2. Extract PR numbers from the release notes body (look for `#NNN` patterns or full PR URLs). When referring to these PRs in any subsequent output, always fully qualify them as `<OWNER>/<REPO>#NNN` (see "Output conventions" above).
 
 3. Categorize changes into:
    - **New features**: entirely new capabilities


### PR DESCRIPTION
### Description

Progress narration on docs-website PRs (the sticky `track_progress` comment posted by `claude-code-action`) was emitting bare `#NNN` PR references when listing PRs in the upstream release notes. GitHub auto-links bare `#NNN` relative to the repo the comment lives in, so on the docs-website PR the references resolved to docs-website PRs instead of the upstream `stacklok/toolhive` / `stacklok/toolhive-registry-server` PRs. This was hidden until docs-website PR numbers caught up to upstream numbers; the recent `stacklok/docs-website#860` made it visible.

Add an explicit "Output conventions" section to `SKILL.md` requiring fully-qualified `<OWNER>/<REPO>#NNN` references in any output that may render as a docs-website comment, PR body, or Markdown file (progress narration, `SUMMARY.md`, `GAPS.md`, commit messages, PR descriptions). Reinforce the rule at the Phase 1 extraction step where PR numbers first enter the working set.

The fix lives in the skill rather than the workflow prompt because the rule is a general property of the skill: any time it runs in a different-repo context the same trap applies.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Surfaced on `stacklok/docs-website#860` (renovate bump of `toolhive-registry-server` to v1.4.2).

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style

🤖 Generated with [Claude Code](https://claude.com/claude-code)