### PR TITLE
Drop 5-reviewer cap in upstream-release-docs

### DIFF
--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -1019,20 +1019,10 @@ jobs:
           # Per-user attempts sidestep both issues: the authoritative
           # answer is "does GitHub accept this as a reviewer right now"
           # and we ask the API that question directly.
-          #
-          # Cap attempts at 5 to avoid review fatigue on big releases.
-          TRIED=0
           ASSIGN_LIST=""
           MENTION_LIST=""
           while IFS= read -r login; do
             [ -z "$login" ] && continue
-            if [ "$TRIED" -ge 5 ]; then
-              # Over the review-fatigue cap -- mention any additional
-              # contributors instead of trying to assign them.
-              MENTION_LIST="${MENTION_LIST:+$MENTION_LIST }@$login"
-              continue
-            fi
-            TRIED=$((TRIED + 1))
             if gh pr edit "$PR_NUMBER" --add-reviewer "$login" 2>/dev/null; then
               ASSIGN_LIST="${ASSIGN_LIST:+$ASSIGN_LIST,}$login"
               echo "Assigned: $login"
@@ -1049,7 +1039,7 @@ jobs:
           {
             echo "mention_block<<MENTION_EOF"
             if [ -n "$MENTION_LIST" ]; then
-              echo "Release contributors we couldn't auto-assign as reviewers (review fatigue cap or GitHub rejected the assignment). Mentioning them so they see the PR documenting their work:"
+              echo "Release contributors we couldn't auto-assign as reviewers (GitHub rejected the assignment). Mentioning them so they see the PR documenting their work:"
               echo ""
               echo "$MENTION_LIST"
             fi


### PR DESCRIPTION
### Description

The reviewer-assignment step in `.github/workflows/upstream-release-docs.yml` stops attempting assignments after the first 5 candidates. Combined with `jq`'s case-sensitive alphabetic sort on the candidate list, this means contributors whose login sorts late (e.g. `tgrunnagle`, `yrobla`) get dumped into the "Additional release contributors" mention block on big releases without an assignment attempt — even when GitHub would have accepted them. On smaller releases the same logins land inside the first 5 and get assigned normally, so the same person appears as a reviewer one week and as an @-mention the next.

This PR drops the cap entirely and attempts every non-bot release contributor. The per-user attempt loop already isolates 422s, so removing the cap is safe — anyone GitHub rejects still falls through to the mention block. The mention-block copy is updated to drop the now-stale "review fatigue cap" wording.

The remaining cause of inconsistency — GitHub returning 422 for stackers whose only access is via the `stackers` team when called with `GITHUB_TOKEN` — is documented in the comment above the loop and will be addressed in a separate PR (likely by switching to a token with `read:org`).

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up: replace `GITHUB_TOKEN` for the reviewer-assignment step with a token that has `read:org`, to reduce 422s on team-only collaborators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)