### PR TITLE
Remove Enterprise Connectors comparison section

### DIFF
--- a/docs/toolhive/enterprise.mdx
+++ b/docs/toolhive/enterprise.mdx
@@ -125,19 +125,6 @@ them.
 | Proactive security advisories                  |     —     |     ✓      |
 | Onboarding & integration assistance            |     —     |     ✓      |
 
-### Enterprise Connectors (MCP Servers)
-
-| Attribute                                   |  Community  |              Enterprise              |
-| :------------------------------------------ | :---------: | :----------------------------------: |
-| Base image                                  | Open source |       Chainguard or equivalent       |
-| Signing & attestations                      |      —      | SigStore signed with SLSA provenance |
-| Customized tools (tuned to agent workflows) |      —      |                  ✓                   |
-| Streamable HTTP transport                   |      —      |                  ✓                   |
-| SBOM & dependency vetting                   |      —      |                  ✓                   |
-| Qualified for target workload               |      —      |                  ✓                   |
-| Maintained on enterprise release cadence    |      —      |                  ✓                   |
-| Backported security patches                 |      —      |                  ✓                   |
-
 Seen enough to want a closer look? [Schedule a demo](#schedule-a-demo) to walk
 through the capabilities that matter most to your team.
 


### PR DESCRIPTION
### Description

Removes the "Enterprise Connectors (MCP Servers)" H3 and its comparison table from the [enterprise landing page](docs/toolhive/enterprise.mdx).

The "Enterprise Connectors" SKU still appears in the **Product offerings** table further down the page (and in the paragraph that introduces it). Per the request, this PR is surgical and leaves those Product offerings references untouched.

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)