### PR TITLE
Restore registry-schema redirect with new target

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -92,6 +92,11 @@
       "permanent": true
     },
     {
+      "source": "/toolhive/reference/registry-schema-toolhive",
+      "destination": "/toolhive/reference/registry-schema-upstream",
+      "permanent": true
+    },
+    {
       "source": "/toolhive/reference/crd-spec",
       "destination": "/toolhive/reference/crds",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -87,6 +87,11 @@
       "permanent": true
     },
     {
+      "source": "/toolhive/reference/registry-schema",
+      "destination": "/toolhive/reference/registry-schema-upstream",
+      "permanent": true
+    },
+    {
       "source": "/toolhive/reference/crd-spec",
       "destination": "/toolhive/reference/crds",
       "permanent": true


### PR DESCRIPTION
### Description

PR #871 removed the redirect from `/toolhive/reference/registry-schema` to `/toolhive/reference/registry-schema-toolhive` due to the removal of the legacy ToolHive format.

This restores the redirect but updates the destination to the `registry-schema-upstream` page instead.

Also introduces a redirect from the deleted `registry-schema-toolhive` to the upstream page.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Related to #871

### Submitter checklist

#### Content and formatting

N/A

#### Navigation

- [x] Redirects added to `vercel.json` for moved, renamed, or deleted pages (i.e., if the URL slug changed)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>