### PR TITLE
Switch quickstarts to toolhive-doc-mcp server

### DIFF
--- a/docs/toolhive/guides-cli/quickstart.mdx
+++ b/docs/toolhive/guides-cli/quickstart.mdx
@@ -104,7 +104,7 @@ thv registry list
 You'll see output similar to this:
 
 ```text
-NAME                                          TYPE        DESCRIPTION                                          TIER        STARS   PULLS
+NAME                                          TYPE        DESCRIPTION                                          TIER        STARS
 io.github.stacklok/atlassian                  container   Connect to Atlassian products like Confluence, ...   Community   5002
 io.github.stacklok/fetch                      container   A Model Context Protocol server that provides ...    Community   56714
 io.github.stacklok/github                     container   The GitHub MCP Server provides seamless integr...    Official    16578

--- a/docs/toolhive/guides-cli/quickstart.mdx
+++ b/docs/toolhive/guides-cli/quickstart.mdx
@@ -7,8 +7,8 @@ schema_type: tutorial
 
 In this tutorial, you'll install the ToolHive command-line application and run
 your first MCP server. By the end, you'll have a working MCP server that can
-fetch content from websites and be used by AI applications like GitHub Copilot
-or Cursor.
+answer questions about ToolHive and be used by AI applications like GitHub
+Copilot or Cursor.
 
 ## What you'll learn
 
@@ -104,13 +104,18 @@ thv registry list
 You'll see output similar to this:
 
 ```text
-NAME       DESCRIPTION                                                    TIER        STARS   PULLS
-atlassian  Model Context Protocol (MCP) server for Atlassian product...   Community   2194    7789
-fetch      A Model Context Protocol server that provides web content...   Community   56714   9078
-github     The GitHub MCP Server provides seamless integration with ...   Official    16578   5000
-notion     Official Notion MCP server.                                    Official    2358    1109
+NAME                                          TYPE        DESCRIPTION                                          TIER        STARS   PULLS
+io.github.stacklok/atlassian                  container   Connect to Atlassian products like Confluence, ...   Community   5002
+io.github.stacklok/fetch                      container   A Model Context Protocol server that provides ...    Community   56714
+io.github.stacklok/github                     container   The GitHub MCP Server provides seamless integr...    Official    16578
+io.github.stacklok/notion                     container   Official Notion MCP server.                          Official    2358
+io.github.stacklok/toolhive-doc-mcp           container   Search ToolHive docs for help with using and c...    Official    3
+io.github.stacklok/toolhive-doc-mcp-remote    remote      Search ToolHive docs for help with using and c...    Official    3
 ...
 ```
+
+The `TYPE` column shows whether the server runs as a local `container` or is a
+hosted `remote` endpoint that ToolHive proxies to.
 
 This shows all the MCP servers available in the ToolHive registry.
 
@@ -122,53 +127,54 @@ to help you find and launch servers.
 
 :::
 
-For this tutorial, you'll use the "fetch" server, which is a simple MCP server
-that lets AI agents get the contents of a website. To learn more about the
-server before running it, run:
+For this tutorial, you'll use the `toolhive-doc-mcp` server, which lets AI
+agents search the ToolHive documentation. To learn more about the server before
+running it, run:
 
 ```bash
-thv registry info fetch
+thv registry info toolhive-doc-mcp
 ```
 
 This shows you detailed information about the server, including what tools it
 provides and any configuration options.
 
-## Step 3: Run the Fetch MCP server
+## Step 3: Run the toolhive-doc-mcp server
 
-Now, run the Fetch server:
+Now, run the server:
 
 ```bash
-thv run fetch
+thv run toolhive-doc-mcp
 ```
 
-ToolHive will pull the container image and start the server. You'll see output
-similar to this:
+ToolHive pulls the container image and starts the server in the background.
+You'll see a log line similar to this:
 
 ```text
-8:41AM INF MCP server ghcr.io/stackloklabs/gofetch/server:latest is verified successfully
-8:41AM INF Image ghcr.io/stackloklabs/gofetch/server:latest has 'latest' tag, pulling to ensure we have the most recent version...
-8:41AM INF Pulling image: ghcr.io/stackloklabs/gofetch/server:latest
-Pulling from stackloklabs/gofetch/server: latest
-Digest: sha256:b9cbe3a8367f39e584d3fdd96d9c5046643c5f4798c3372b0c9049ece202cdef
-Status: Image is up to date for ghcr.io/stackloklabs/gofetch/server:latest
-8:41AM INF Successfully pulled image: ghcr.io/stackloklabs/gofetch/server:latest
-8:41AM INF Using target port: 15266
-8:41AM INF Logging to: ~/Library/Application Support/toolhive/logs/fetch.log
-8:41AM INF MCP server is running in the background (PID: 16834)
-8:41AM INF Use 'thv stop fetch' to stop the server
+{"time":"2026-05-18T09:49:14-04:00","level":"INFO","msg":"logging to","path":"~/Library/Application Support/toolhive/logs/toolhive-doc-mcp.log"}
 ```
+
+The full server logs are written to the file shown in the `logging to` line.
 
 :::info[What's happening?]
 
 When you run an MCP server, ToolHive:
 
-- Verifies the MCP server image provenance (if attestation information is
-  available in the registry)
 - Downloads the container image
 - Sets up the container with the necessary security settings and starts it in
   the background
 - Sets up a reverse proxy that lets your AI client applications communicate with
   the server
+
+:::
+
+:::tip[Prefer not to run a container?]
+
+ToolHive also ships a hosted version of the docs server. Run
+`thv run toolhive-doc-mcp-remote` instead to connect to the hosted endpoint at
+`https://toolhive-doc-mcp.stacklok.com/mcp` without pulling an image. ToolHive
+sets up the same kind of proxy, so the rest of this tutorial works the same way,
+but commands that reference the workload name should use
+`toolhive-doc-mcp-remote`.
 
 :::
 
@@ -183,11 +189,12 @@ thv list
 You should see output similar to this:
 
 ```text
-NAME    PACKAGE                                      STATUS    URL                          PORT    TOOL TYPE   CREATED AT
-fetch   ghcr.io/stackloklabs/gofetch/server:latest   running   http://127.0.0.1:15266/mcp   15266   mcp         2025-07-10 08:41:56 -0400 EDT
+NAME               PACKAGE                                                  STATUS    URL                          PORT    GROUP     CREATED
+toolhive-doc-mcp   ghcr.io/stackloklabs/toolhive-doc-mcp:v0.0.14-20260518   running   http://127.0.0.1:19767/mcp   19767   default   2026-05-18 09:49:14 -0400 EDT
 ```
 
-This confirms that the fetch server is running and available on port 15266.
+This confirms that the server is running. ToolHive picks a free local port at
+startup, so your port number will be different.
 
 :::info[What's happening?]
 
@@ -237,22 +244,22 @@ that you run.
 ## Step 6: Use the MCP server with your AI client
 
 If you completed Step 5, you can now use the MCP server with your AI client
-application. Open your supported client (VS Code, Cursor, etc.) and ask the AI
-to fetch content from a website. Note that you might need to restart your client
-for the changes to take effect.
+application. Open your supported client (VS Code, Cursor, etc.) and ask the AI a
+question about ToolHive. Note that you might need to restart your client for the
+changes to take effect.
 
-For example, try asking: "Can you fetch the content from https://toolhive.dev
-and summarize it for me?"
+For example, try asking: "What is a Virtual MCP Server and how do I use it with
+ToolHive?"
 
-The AI should be able to use the Fetch MCP server to retrieve the content and
-provide a summary.
+The AI calls the `query_docs` tool to search the ToolHive documentation and uses
+the results to compose an answer.
 
 :::info[What's happening?]
 
-When you ask the AI to fetch content, it detects that it needs external data. It
-discovers the fetch tool provided by your MCP server, calls the tool with the
-URL you specified, receives the webpage content, and then processes that content
-to create a summary.
+When you ask a question about ToolHive, the AI client discovers the `query_docs`
+and `get_chunk` tools your MCP server exposes, calls them to search the official
+ToolHive documentation, then uses the returned passages to construct a grounded
+answer instead of relying on its training data alone.
 
 :::
 
@@ -261,13 +268,13 @@ to create a summary.
 When you're finished using the server, you can stop it:
 
 ```bash
-thv stop fetch
+thv stop toolhive-doc-mcp
 ```
 
 If you want to remove it completely:
 
 ```bash
-thv rm fetch
+thv rm toolhive-doc-mcp
 ```
 
 :::info[What's happening?]
@@ -324,9 +331,12 @@ the client, port conflicts, etc.).
 
 A few quick checks specific to this tutorial:
 
-- Confirm Docker, Podman, or Colima is running before `thv run fetch`.
-- If port 15266 is already in use, pass a specific port with `--proxy-port`, for
-  example `thv run --proxy-port 8081 fetch`.
+- Confirm Docker, Podman, or Colima is running before `thv run toolhive-doc-mcp`
+  (or use the `toolhive-doc-mcp-remote` variant, which doesn't need a container
+  runtime).
+- ToolHive picks a free local port for the proxy at startup. If you need a
+  specific port, pass `--proxy-port`, for example
+  `thv run --proxy-port 8081 toolhive-doc-mcp`.
 - After running `thv client setup`, restart your AI client so it picks up the
   new configuration.
 

--- a/docs/toolhive/guides-k8s/quickstart.mdx
+++ b/docs/toolhive/guides-k8s/quickstart.mdx
@@ -101,8 +101,8 @@ from your main system and can be easily deleted when you're done.
 
 ## Step 2: Deploy the ToolHive operator
 
-Now deploy the ToolHive operator to your cluster using Helm. The operator will
-watch for MCP server resources and manage their lifecycle automatically.
+Now deploy the ToolHive operator to your cluster using Helm. The operator
+watches for MCP server resources and manages their lifecycle automatically.
 
 First, install the operator CRDs:
 
@@ -143,12 +143,35 @@ in your cluster.
 ## Step 3: Create your first MCP server
 
 Now for the exciting part - create an MCP server using Kubernetes resources.
-You'll deploy the fetch server, which allows AI agents to retrieve web content.
+You'll deploy the `toolhive-doc-mcp` server, which lets AI agents search the
+ToolHive documentation.
 
-Apply the example `fetch` MCP server from the ToolHive repository:
+Define the `MCPServer` resource:
+
+```yaml title="toolhive-docs.yaml"
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: toolhive-docs
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/toolhive-doc-mcp
+  transport: streamable-http
+  proxyPort: 8080
+  mcpPort: 8080
+  resources:
+    limits:
+      cpu: '100m'
+      memory: '128Mi'
+    requests:
+      cpu: '50m'
+      memory: '64Mi'
+```
+
+Apply the manifest:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/heads/main/examples/operator/mcp-servers/mcpserver_fetch.yaml
+kubectl apply -f toolhive-docs.yaml
 ```
 
 :::info[What's happening?]
@@ -171,8 +194,8 @@ kubectl get mcpservers -n toolhive-system
 You should see:
 
 ```text
-NAME    STATUS   READY   REPLICAS   URL                                                                 AGE
-fetch   Ready    True    1          http://mcp-fetch-proxy.toolhive-system.svc.cluster.local:8080/mcp   30s
+NAME            STATUS   READY   REPLICAS   URL                                                                         AGE
+toolhive-docs   Ready    True    1          http://mcp-toolhive-docs-proxy.toolhive-system.svc.cluster.local:8080/mcp   30s
 ```
 
 If the status is "Pending", wait a few moments and check again. If it remains
@@ -184,13 +207,13 @@ the end of this tutorial.
 Verify that your MCP server is actually working. First, get the service details:
 
 ```bash
-kubectl get service mcp-fetch-proxy -n toolhive-system
+kubectl get service mcp-toolhive-docs-proxy -n toolhive-system
 ```
 
 Port-forward to access the service locally:
 
 ```bash
-kubectl port-forward service/mcp-fetch-proxy -n toolhive-system 8080:8080
+kubectl port-forward service/mcp-toolhive-docs-proxy -n toolhive-system 8080:8080
 ```
 
 In another terminal, test the server:
@@ -220,7 +243,7 @@ Make sure you still have the port-forward running from Step 4. If not, restart
 it in a separate terminal:
 
 ```bash
-kubectl port-forward service/mcp-fetch-proxy -n toolhive-system 8080:8080
+kubectl port-forward service/mcp-toolhive-docs-proxy -n toolhive-system 8080:8080
 ```
 
 Configure Visual Studio Code to connect to your MCP server. Open VS Code and
@@ -245,7 +268,7 @@ access your user settings:
 
 4. Enter the server URL: `http://localhost:8080/mcp` and press Enter
 
-5. Enter a name for the server (e.g., "fetch") and press Enter
+5. Enter a name for the server (e.g., "toolhive-docs") and press Enter
 
 6. Choose "Global" to add the server to your global settings
 
@@ -255,7 +278,7 @@ access your user settings:
    ```json
    {
      "servers": {
-       "fetch": {
+       "toolhive-docs": {
          "url": "http://localhost:8080/mcp",
          "type": "http"
        }
@@ -265,7 +288,7 @@ access your user settings:
    ```
 
 To verify the connection, click **Start**. The indicator should change to
-"Running" and show "1 tools".
+"Running" and show "2 tools".
 
 <ThemedImage
   alt='VS Code MCP settings'
@@ -288,9 +311,9 @@ To verify the connection, click **Start**. The indicator should change to
   className='screenshot'
 />
 
-Now test the connection by asking GitHub Copilot to fetch content from a
-website. Open Copilot Chat in **Agent** mode and ask: "Can you fetch the content
-from https://stacklok.com and summarize it for me?"
+Now test the connection by asking GitHub Copilot a question about ToolHive. Open
+Copilot Chat in **Agent** mode and ask: "What is a Virtual MCP Server and how do
+I use it with ToolHive?"
 
 <ThemedImage
   alt='VS Code Copilot agent mode selection'
@@ -303,8 +326,8 @@ from https://stacklok.com and summarize it for me?"
   className='screenshot'
 />
 
-GitHub Copilot should be able to use your Kubernetes-hosted MCP server to
-retrieve the content and provide a summary.
+GitHub Copilot uses your Kubernetes-hosted MCP server to search the ToolHive
+documentation and compose a grounded answer.
 
 <ThemedImage
   alt='VS Code Copilot tool use confirmation'
@@ -333,7 +356,7 @@ Now that you have a working MCP server, explore some operator features.
 View the detailed status of your MCP server:
 
 ```bash
-kubectl describe mcpserver fetch -n toolhive-system
+kubectl describe mcpserver toolhive-docs -n toolhive-system
 ```
 
 This shows you the current state, any events, and configuration details.
@@ -341,19 +364,19 @@ This shows you the current state, any events, and configuration details.
 Try updating your MCP server's resource limits by editing the resource:
 
 ```bash
-kubectl patch mcpserver fetch -n toolhive-system --type='merge' -p '{"spec":{"resources":{"limits":{"memory":"256Mi"}}}}'
+kubectl patch mcpserver toolhive-docs -n toolhive-system --type='merge' -p '{"spec":{"resources":{"limits":{"memory":"256Mi"}}}}'
 ```
 
 You should see output confirming the patch:
 
 ```text
-mcpserver.toolhive.stacklok.dev/fetch patched
+mcpserver.toolhive.stacklok.dev/toolhive-docs patched
 ```
 
 Check that the pod has been updated with the new resource limits:
 
 ```bash
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch -o jsonpath='{.items[0].spec.containers[0].resources.limits.memory}'
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=toolhive-docs -o jsonpath='{.items[0].spec.containers[0].resources.limits.memory}'
 ```
 
 You should see output showing the updated memory limit:
@@ -372,7 +395,7 @@ When you're done experimenting, you can clean up your resources.
 Delete the MCP server:
 
 ```bash
-kubectl delete mcpserver fetch -n toolhive-system
+kubectl delete mcpserver toolhive-docs -n toolhive-system
 ```
 
 Verify it's been removed:
@@ -390,7 +413,7 @@ No resources found in toolhive-system namespace.
 Check that the pods are also gone:
 
 ```bash
-kubectl get pods -l app.kubernetes.io/name=fetch -n toolhive-system
+kubectl get pods -l app.kubernetes.io/instance=toolhive-docs -n toolhive-system
 ```
 
 You should see:
@@ -422,7 +445,7 @@ can also run:
 task kind-destroy
 ```
 
-This will fully remove the kind cluster and clean up all associated resources.
+This fully removes the kind cluster and cleans up all associated resources.
 
 :::
 
@@ -438,6 +461,10 @@ Here are some next steps to explore:
 - Learn about
   [advanced MCP server configurations](../guides-k8s/run-mcp-k8s.mdx) for
   production deployments
+- Connect to a hosted MCP server with
+  [MCPRemoteProxy](../guides-k8s/remote-mcp-proxy.mdx). For example, point an
+  `MCPRemoteProxy` at `https://toolhive-doc-mcp.stacklok.com/mcp` to use the
+  hosted docs server instead of running the container in your cluster.
 - Learn more about [Helm deployment options](../guides-k8s/deploy-operator.mdx)
   and configuration
 - Integrate MCP servers with your existing Kubernetes applications
@@ -481,7 +508,7 @@ For a deeper walkthrough, see the
 Describe the MCPServer to see status conditions and recent events:
 
 ```bash
-kubectl describe mcpserver fetch -n toolhive-system
+kubectl describe mcpserver toolhive-docs -n toolhive-system
 ```
 
 If the events don't surface a clear reason, follow the operator logs while you
@@ -499,16 +526,16 @@ kubectl logs -n toolhive-system deployment/toolhive-operator -f
 Verify the Service exists and has endpoints:
 
 ```bash
-kubectl describe svc mcp-fetch-proxy -n toolhive-system
-kubectl get endpoints mcp-fetch-proxy -n toolhive-system
+kubectl describe svc mcp-toolhive-docs-proxy -n toolhive-system
+kubectl get endpoints mcp-toolhive-docs-proxy -n toolhive-system
 ```
 
 If endpoints are empty, either the proxy pod isn't Ready or the Service selector
 doesn't match the proxy pod's labels. Compare them:
 
 ```bash
-kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=fetch --show-labels
-kubectl logs -n toolhive-system -l app.kubernetes.io/instance=fetch
+kubectl get pods -n toolhive-system -l app.kubernetes.io/instance=toolhive-docs --show-labels
+kubectl logs -n toolhive-system -l app.kubernetes.io/instance=toolhive-docs
 ```
 
 </details>

--- a/docs/toolhive/guides-ui/quickstart.mdx
+++ b/docs/toolhive/guides-ui/quickstart.mdx
@@ -7,8 +7,8 @@ schema_type: tutorial
 ---
 
 In this tutorial, you'll install the ToolHive desktop application and run your
-first MCP server. By the end, you'll have a working MCP server that can fetch
-content from websites and be used by AI applications like GitHub Copilot or
+first MCP server. By the end, you'll have a working MCP server that can answer
+questions about ToolHive and be used by AI applications like GitHub Copilot or
 Cursor.
 
 ## What you'll learn
@@ -61,23 +61,32 @@ and how to use it.
 
 :::
 
-For this tutorial, you'll use the "fetch" server, which is a simple MCP server
-that lets AI agents get the contents of a website. Click on the "fetch" server
-to start the installation process.
+For this tutorial, you'll use the **ToolHive Docs** server (listed as
+`toolhive-doc-mcp` in the registry), which lets AI agents search the ToolHive
+documentation. Click on the **ToolHive Docs** entry to start the installation
+process.
 
-## Step 3: Install the Fetch MCP server
+## Step 3: Install the ToolHive Docs server
 
-The Fetch MCP server doesn't require any special configuration, so you can
+The ToolHive Docs server doesn't require any special configuration, so you can
 install it with the default settings. Click the **Install server** button to
 start the installation.
 
-Once the server is installed, it will appear on the **MCP Servers** page.
+Once installed, the server appears on the **MCP Servers** page.
 
 :::info[What's happening?]
 
-ToolHive downloads the container image for the fetch server, creates a container
-with the appropriate security settings, and starts the server. It also sets up a
-proxy process that lets your AI agent communicate with the server.
+ToolHive downloads the container image for the server, creates a container with
+the appropriate security settings, and starts it. ToolHive also sets up a proxy
+process that lets your AI agent communicate with the server.
+
+:::
+
+:::tip[Prefer not to run a container?]
+
+The registry also includes **ToolHive Docs (Remote)**, a hosted version of the
+same server at `https://toolhive-doc-mcp.stacklok.com/mcp`. Install that entry
+instead to skip the container pull. The rest of the tutorial works the same way.
 
 :::
 
@@ -100,22 +109,23 @@ the client each time you run an MCP server.
 ## Step 5: Use the MCP server with your client
 
 Now that your MCP server is running and your client is connected to ToolHive,
-you can use the MCP server's tools. Open your client and ask the AI to fetch
-content from a website. Note that you might need to restart your client for the
-changes to take effect.
+you can use the MCP server's tools. Open your client and ask the AI a question
+about ToolHive. Note that you might need to restart your client for the changes
+to take effect.
 
-For example, try asking: "Can you fetch the content from https://toolhive.dev
-and summarize it for me?"
+For example, try asking: "What is a Virtual MCP Server and how do I use it with
+ToolHive?"
 
-The AI should be able to use the Fetch MCP server to retrieve the content and
-provide a summary.
+The AI calls the `query_docs` tool to search the ToolHive documentation and uses
+the results to compose an answer.
 
 :::info[What's happening?]
 
-When you ask the AI agent to fetch content, the large language model (LLM)
-determines that it needs external data. It discovers the fetch tool provided by
-your MCP server, instructs the agent to execute the tool with the URL you
-specified, then receives and processes the webpage content to create a summary.
+When you ask a question about ToolHive, the large language model (LLM)
+determines that it needs reference material. It discovers the `query_docs` and
+`get_chunk` tools provided by your MCP server, calls them to search the official
+ToolHive documentation, then uses the returned passages to construct a grounded
+answer instead of relying on its training data alone.
 
 :::
 


### PR DESCRIPTION
### Description

Updates the CLI, UI, and Kubernetes quickstarts to use the `toolhive-doc-mcp` server as their example MCP server instead of `fetch`. The docs MCP server gives new users a natural on-ramp to discover more about ToolHive through tool calls, and each quickstart links to the hosted `toolhive-doc-mcp-remote` variant as an alternative to running the container locally.

While in the files, also corrected drift that had crept in:

- Refreshed CLI sample output for `thv v0.27.x`: `thv registry list` now has a `TYPE` column and namespaced server names (`io.github.stacklok/<name>`); `thv list` uses `GROUP` / `CREATED` instead of `TOOL TYPE` / `CREATED AT`; `thv run` emits structured JSON logs.
- Replaced the remote `mcpserver_fetch.yaml` reference in the K8s quickstart with an inline `MCPServer` manifest.
- Fixed the K8s cleanup selector: `app.kubernetes.io/name=<instance>` never matched a pod (that label is always `mcpserver`); the correct selector is `app.kubernetes.io/instance=<instance>`.
- Dropped the misleading "verifies image provenance" bullet from the CLI's "What's happening?" block; verification is opt-in via `--image-verification`.
- Tightened future tense and passive voice in the prose we touched.

Validated the K8s manifest and lifecycle commands against a local kind cluster, and the CLI commands against `thv v0.27.0`.

### Type of change

- Documentation update

### Related issues/PRs

_None._

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style