### PR TITLE
Document ChatGPT Desktop configuration via ngrok tunnel

### DIFF
--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -362,8 +362,29 @@ For more details, see the
 ### ChatGPT Desktop configuration
 
 ChatGPT Desktop only accepts MCP servers over HTTPS, with no equivalent of
-Claude Desktop's command-based configuration. Use `thv proxy tunnel` to expose
+Claude Desktop's command-based configuration. For personal experimentation with
+public, unauthenticated MCP servers, you can use `thv proxy tunnel` to expose
 your local ToolHive workload through an [ngrok](https://ngrok.com) HTTPS tunnel.
+
+:::warning[Scope: personal local use only]
+
+This workaround creates a public ngrok URL pointing at a workload running on
+your machine. Before using it, consider:
+
+- **The tunnel is unauthenticated by default.** Anyone who guesses or learns the
+  ngrok URL can reach your MCP server.
+- **The workload runs with your credentials.** Tunneling an auth-backed server
+  (GitHub, Notion, Slack, and similar) means anyone who reaches the URL acts
+  with your access.
+- **Workspace connectors share one tunnel.** On Business, Enterprise, or Edu
+  workspaces, every member who uses the connector hits your tunnel and acts as
+  you, not as themselves.
+
+For shared, multi-user, or credentialed setups, use a
+[Virtual MCP Server (vMCP)](../guides-vmcp/intro.mdx), which fronts MCP servers
+with proper authentication, per-user OAuth, and policy enforcement.
+
+:::
 
 You'll need:
 

--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -40,13 +40,14 @@ We've tested ToolHive with these clients:
 | Windsurf IDE               |    ✅     |         ✅         |       ✅       |                                             |
 | Windsurf (JetBrains)       |    ✅     |         ✅         |       ❌       |                                             |
 | Zed                        |    ✅     |         ✅         |       ❌       | v0.214.5+                                   |
-| ChatGPT Desktop            |    ✅     |         ❌         |       ❌       | See [STDIO-only client configuration][4]    |
+| ChatGPT Desktop            |    ✅     |         ❌         |       ❌       | See [ChatGPT Desktop configuration][5]      |
 | Claude Desktop             |    ✅     |         ❌         |       ❌       | See [STDIO-only client configuration][4]    |
 | GitHub Copilot (JetBrains) |    ✅     |         ❌         |       ❌       | v1.5.47+                                    |
 | PydanticAI                 |    ✅     |         ❌         |       ❌       | v0.2.18+                                    |
 
 [3]: #vs-code-with-copilot
 [4]: #stdio-only-client-configuration
+[5]: #chatgpt-desktop-configuration
 
 The minimum versions listed are the earliest versions that support the
 Streamable HTTP transport protocol.
@@ -322,31 +323,17 @@ Copilot for JetBrains supports SSE (`"type": "sse"`) and Streamable HTTP
 ### STDIO-only client configuration
 
 Some MCP clients, like Claude Desktop, only support MCP servers that communicate
-via STDIO transport. However, many popular MCP servers use Server-Sent Events
-(SSE) or Streamable HTTP transport protocols.
+via STDIO transport. ToolHive's `thv proxy stdio` command wraps any running
+ToolHive workload as a STDIO process so these clients can connect to it.
 
-ToolHive's `thv proxy stdio` command transforms servers using SSE or Streamable
-HTTP into STDIO-compatible processes, enabling these clients to work with any
-MCP server.
-
-**How it works:**
-
-1. ToolHive runs the MCP server in its container with its default transport
-   (SSE, HTTP, or other)
-2. The `thv proxy stdio` command sets up a STDIO-level wrapper pointing to that
-   existing server
-3. Your client interacts with this wrapper just like any other STDIO MCP server
-
-**Example:**
-
-First, run an MCP server with SSE transport:
+Run an MCP server with ToolHive as usual, for example:
 
 ```bash
-thv run osv --transport sse --name osv
+thv run osv
 ```
 
-Then configure your client to use the proxy stdio command. For Claude Desktop,
-update your configuration file (typically located at
+Then configure your client to launch `thv proxy stdio <WORKLOAD_NAME>`. For
+Claude Desktop, edit your configuration file (typically located at
 `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
@@ -367,11 +354,63 @@ the name you used when running the server with `thv run`.
 
 :::
 
-After restarting your client, the MCP server's tools will be available for use,
-even though it uses SSE transport.
+After restarting your client, the MCP server's tools are available for use.
 
 For more details, see the
 [`thv proxy stdio` CLI reference](../reference/cli/thv_proxy_stdio.md).
+
+### ChatGPT Desktop configuration
+
+ChatGPT Desktop only accepts MCP servers over HTTPS, with no equivalent of
+Claude Desktop's command-based configuration. Use `thv proxy tunnel` to expose
+your local ToolHive workload through an [ngrok](https://ngrok.com) HTTPS tunnel.
+
+You'll need:
+
+- An ngrok account and auth token
+- A static ngrok domain (recommended, so the connector URL stays stable across
+  restarts)
+
+Run an MCP server with ToolHive as usual, for example:
+
+```bash
+thv run osv
+```
+
+Then start the ngrok tunnel, using the workload name as the target:
+
+```bash
+thv proxy tunnel osv osv-tunnel \
+  --tunnel-provider ngrok \
+  --provider-args '{"auth-token": "<YOUR_NGROK_TOKEN>", "url": "https://<YOUR_NGROK_DOMAIN>", "pooling": true}'
+```
+
+Then create a custom connector in ChatGPT. The setup happens on the web; the
+connector then works in both ChatGPT on the web and ChatGPT Desktop.
+
+1. Open [ChatGPT](https://chatgpt.com/) on the web and navigate to **Settings →
+   Apps**.
+2. Turn on **Developer mode** (this may require an admin to enable on Business,
+   Enterprise, or Edu workspaces).
+3. Click **Create** and fill in the app details, including the **URL**: your
+   ngrok domain plus the MCP endpoint path, typically `/mcp` for Streamable HTTP
+   servers (for example, `https://<YOUR_NGROK_DOMAIN>/mcp`).
+4. Check the **I trust this application** box and click **Save**.
+
+After saving, ChatGPT lists the tools your MCP server exposes. You can add them
+to a conversation by clicking **+** near the message composer and selecting your
+app.
+
+:::tip
+
+The `url` field in `--provider-args` sets a static ngrok domain. If you omit it,
+ngrok assigns a temporary random URL each time, which means updating the
+connector in ChatGPT on every restart.
+
+:::
+
+For more details, see the
+[`thv proxy tunnel` CLI reference](../reference/cli/thv_proxy_tunnel.md).
 
 ## Related information
 


### PR DESCRIPTION
### Description

Adds a ChatGPT Desktop section to the client compatibility guide. ChatGPT Desktop only accepts MCP servers over HTTPS (no command-based config like Claude Desktop), so the new section documents exposing a local ToolHive workload via `thv proxy tunnel` with ngrok, including a worked example and the connector setup steps.

The existing ChatGPT Desktop row in the compatibility table now links to this dedicated section instead of the generic STDIO-only configuration.

While here, also simplifies the existing STDIO-only workaround (for Claude Desktop):

- Drops `--transport sse` from both example commands. SSE is deprecated, and the workarounds work with whatever transport the server runs by default.
- Removes the stepwise "How it works" preambles in favor of "run an MCP server with ToolHive as usual, then apply the workaround."
- Renames the second positional arg in the `thv proxy tunnel` example from `osv` to `osv-tunnel` so the two arguments are visibly distinct.

### Type of change

- Documentation update

### Submitter checklist

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style