### PR TITLE
Add weekly update for 2026-05-18

### DIFF
--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -1,25 +1,26 @@
 ---
-title: Agents go GA in the Playground, plus no more port conflicts with Studio
-sidebar_label: 'May 18: Agents GA in the Playground'
+title: Agents arrive in the Playground, plus no more port conflicts with Studio
+sidebar_label: 'May 18: Agents in the Playground'
 description:
-  Agents in the ToolHive Playground are GA, with built-in ToolHive Assistant and
-  Skill Engineer agents, plus the option to author your own.
+  Agents are available to everyone in the ToolHive Playground, with built-in
+  ToolHive Assistant and Skill Engineer agents, plus the option to author your
+  own.
 ---
 
-This week, ToolHive Studio v0.35.0 takes Agents in the Playground out of
-feature-flag and ships them to everyone, with two built-in agents and the option
-to author your own. Studio also retires the localhost TCP port it used to talk
-to ToolHive in favor of a per-user socket, and the Playground picks up message
-editing, queueing, and per-message cost.
+This week, ToolHive Studio v0.35.0 makes Agents in the Playground available to
+everyone, with two built-in agents and the option to author your own. Studio
+also retires the localhost TCP port it used to talk to ToolHive in favor of a
+per-user socket, and the Playground picks up message editing, queueing, and
+per-message cost.
 
 {/* truncate */}
 
-## Agents are GA in the Playground
+## Agents in the Playground, available to everyone
 
 Agents in the [Playground](/toolhive/guides-ui/playground) are now available to
-everyone, no feature flag required. Each chat thread runs against an agent that
-sets the system prompt and a default toolset, so you can shape Studio around the
-task in front of you instead of starting from a blank model every time.
+every user of Studio. Each chat thread runs against an agent that sets the
+system prompt and a default toolset, so you can shape Studio around the task in
+front of you instead of starting from a blank model every time.
 
 Studio ships with two built-in agents:
 

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -1,56 +1,66 @@
 ---
-title: Agents go GA in ToolHive Studio, plus a tighter transport layer
-sidebar_label: 'May 18: Studio Agents GA and UNIX socket transport'
+title: Build skills end-to-end inside the Playground, no more port conflicts
+sidebar_label: 'May 18: Skill Engineer in the Playground'
 description:
-  ToolHive Studio v0.35.0 ships Agents GA in the Playground with a built-in
-  skill engineering agent, and moves Studio-thv communication onto UNIX sockets.
+  Build and test your own skills end-to-end inside the ToolHive Playground, and
+  run Studio on a per-user socket instead of a localhost TCP port.
 ---
 
-This week, ToolHive Studio v0.35.0 takes Agents in the Playground out of
-feature-flag and drops Studio's localhost TCP port for a UNIX socket on macOS
-and Linux, or a named pipe on Windows. The Playground also gains per-thread
-context, message editing, and a handful of quality-of-life improvements.
+This week, ToolHive Studio v0.35.0 lets you build and test your own skills
+end-to-end inside the Playground (Agents are out of feature-flag for everyone),
+retires the localhost TCP port Studio used to talk to ToolHive in favor of a
+per-user socket, and adds per-thread context, message editing, and a few more
+quality-of-life improvements to the Playground.
 
 {/* truncate */}
 
-## Agents are GA in the Playground
+## Build and test your own skills inside the Playground
 
-Agent mode is enabled for everyone in the
-[Playground](/toolhive/guides-ui/playground), no feature flag required. The
-headline addition is a built-in **Skill Engineer** agent that can scaffold and
-test skills directly inside the Playground, so you can go from idea to working
-skill without leaving Studio. Generate a `SKILL.md`, iterate on the agent's
-output, and try it against your MCP servers in the same window. See
-[Build a skill from a local folder](/toolhive/guides-ui/skills-build) for the
-end-to-end flow.
+Agents in the [Playground](/toolhive/guides-ui/playground) are now available to
+everyone, no feature flag required. The headline is a built-in **Skill
+Engineer** agent that takes you from "I want a skill that does X" to a working,
+tested skill without leaving Studio:
 
-## Studio talks to `thv` over a UNIX socket
+1. Open a new Playground thread and pick the **Skill Engineer** agent.
+2. Describe the workflow you want the skill to capture.
+3. Skill Engineer scaffolds a `SKILL.md`, iterates with you on the contents, and
+   tests it against your MCP servers in the same window.
+4. Install the result into your AI client, or
+   [push it to a registry](/toolhive/guides-ui/skills-build) when it's ready to
+   share.
 
-Studio no longer binds a localhost TCP port to communicate with the `thv` API.
-Instead, it uses:
+See [Build a skill from a local folder](/toolhive/guides-ui/skills-build) for
+the end-to-end flow, including how to publish a finished skill.
 
-- A **UNIX socket** on macOS and Linux.
-- A **named pipe** on Windows.
+## No more localhost port conflicts with Studio
 
-That drops a localhost port from your dev surface, so no more port conflicts
-with other tools. The socket is scoped to the current user, so other accounts on
-the machine can't reach it.
+Studio no longer binds a localhost TCP port to talk to ToolHive on your machine.
+Instead, it uses a UNIX socket on macOS and Linux, or a named pipe on Windows.
+What that means for you day to day:
+
+- **No more port conflicts** when another dev tool wants the same localhost port
+  you were using for Studio.
+- **Tighter local security**: the socket is scoped to your user account, so
+  other accounts on the same machine can't reach it.
+
+It's a behind-the-scenes change, but it removes a class of "why is my port
+already in use" headaches.
 
 ## More Playground improvements
 
 A handful of smaller Playground improvements ship alongside the headline
 changes:
 
-- **Per-thread agent, model, MCP, and skills selection.** Each chat thread
-  remembers its own context. Switch threads, switch stack.
-- **Edit and resend.** Edit a previous user message and resend it; the
-  conversation regenerates from that point.
-- **Per-message cost.** Each assistant message shows its estimated cost using
+- **Each thread keeps its own stack.** Pick the agent, model, MCP servers, and
+  skills per thread, and Studio remembers them. Switch threads, switch stack.
+- **Edit and resend a previous message.** Tweak a prompt that didn't quite land
+  and rerun from there, instead of starting a new thread.
+- **See the estimated cost** of every assistant message, using
   [models.dev](https://models.dev) pricing data.
-- **Message queuing.** Send follow-up messages while a response is still
-  streaming, and they queue and run in order.
-- **One-click copy and an agent-aware empty state.** Copy any message from its
-  menu, and the suggested prompts on a new thread adapt to the selected agent.
+- **Queue follow-up messages while a response is still streaming**, so you don't
+  have to wait between turns.
+- **One-click copy and agent-aware suggestions** on the empty state, so new
+  threads start with prompts tailored to the agent you picked.
 
 ## Getting started
 

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -1,0 +1,63 @@
+---
+title: Agents go GA in ToolHive Studio, plus a tighter transport layer
+sidebar_label: 'May 18: Studio Agents GA and UNIX socket transport'
+description:
+  ToolHive Studio v0.35.0 ships Agents GA in the Playground with a built-in
+  skill engineering agent, and moves Studio-thv communication onto UNIX sockets.
+---
+
+This week, ToolHive Studio v0.35.0 takes Agents in the Playground out of
+feature-flag and drops Studio's localhost TCP port for a UNIX socket on macOS
+and Linux, or a named pipe on Windows. The Playground also gains per-thread
+context, message editing, and a handful of quality-of-life improvements.
+
+{/* truncate */}
+
+## Agents are GA in the Playground
+
+Agent mode is enabled for everyone, no feature flag required. The headline
+addition is a built-in **skill engineering agent** that can scaffold and test
+skills directly inside the Playground, so you can go from idea to working skill
+without leaving Studio. Generate a `SKILL.md`, iterate on the agent's output,
+and try it against your MCP servers in the same window.
+
+## Studio talks to `thv` over a UNIX socket
+
+Studio no longer binds a localhost TCP port to communicate with the `thv` API.
+Instead, it uses:
+
+- A **UNIX socket** on macOS and Linux.
+- A **Windows named pipe** on Windows.
+
+That drops a localhost port from your dev surface, so no more port conflicts
+with other tools. The socket is scoped to the current user, so other accounts on
+the machine can't reach it.
+
+## Playground quality-of-life
+
+A handful of smaller Playground improvements ship alongside the headline
+changes:
+
+- **Per-thread model, MCP, and skills selection.** Each chat thread remembers
+  its own context. Switch threads, switch stack.
+- **Edit and resend.** Edit a previous user message and resend it; the
+  conversation regenerates from that point.
+- **Per-message cost.** Each assistant message shows its estimated cost using
+  [models.dev](https://models.dev) pricing data.
+- **Message queuing.** Send follow-up messages while a response is still
+  streaming, and they queue and run in order.
+- **One-click copy and an agent-aware empty state.** Copy any message in a
+  click, and the empty-state suggestions adapt to the agent you've selected.
+
+## Getting started
+
+For detailed release notes, check the project repositories:
+
+- [ToolHive Runtimes](https://github.com/stacklok/toolhive/releases) (CLI and
+  Kubernetes Operator)
+- [ToolHive Desktop UI](https://github.com/stacklok/toolhive-studio/releases)
+- [ToolHive Cloud UI](https://github.com/stacklok/toolhive-cloud-ui/releases)
+- [ToolHive Registry Server](https://github.com/stacklok/toolhive-registry-server/releases)
+
+You can find all ToolHive documentation on the
+[Stacklok documentation site](/toolhive).

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -1,36 +1,42 @@
 ---
-title: Build skills end-to-end inside the Playground, no more port conflicts
-sidebar_label: 'May 18: Skill Engineer in the Playground'
+title: Agents go GA in the Playground, plus no more port conflicts with Studio
+sidebar_label: 'May 18: Agents GA in the Playground'
 description:
-  Build and test your own skills end-to-end inside the ToolHive Playground, and
-  run Studio on a per-user socket instead of a localhost TCP port.
+  Agents in the ToolHive Playground are GA, with built-in ToolHive Assistant and
+  Skill Engineer agents, plus the option to author your own.
 ---
 
-This week, ToolHive Studio v0.35.0 lets you build and test your own skills
-end-to-end inside the Playground (Agents are out of feature-flag for everyone),
-retires the localhost TCP port Studio used to talk to ToolHive in favor of a
-per-user socket, and adds per-thread context, message editing, and a few more
-quality-of-life improvements to the Playground.
+This week, ToolHive Studio v0.35.0 takes Agents in the Playground out of
+feature-flag and ships them to everyone, with two built-in agents and the option
+to author your own. Studio also retires the localhost TCP port it used to talk
+to ToolHive in favor of a per-user socket, and the Playground picks up message
+editing, queueing, and per-message cost.
 
 {/* truncate */}
 
-## Build and test your own skills inside the Playground
+## Agents are GA in the Playground
 
 Agents in the [Playground](/toolhive/guides-ui/playground) are now available to
-everyone, no feature flag required. The headline is a built-in **Skill
-Engineer** agent that takes you from "I want a skill that does X" to a working,
-tested skill without leaving Studio:
+everyone, no feature flag required. Each chat thread runs against an agent that
+sets the system prompt and a default toolset, so you can shape Studio around the
+task in front of you instead of starting from a blank model every time.
 
-1. Open a new Playground thread and pick the **Skill Engineer** agent.
-2. Describe the workflow you want the skill to capture.
-3. Skill Engineer scaffolds a `SKILL.md`, iterates with you on the contents, and
-   tests it against your MCP servers in the same window.
-4. Install the result into your AI client, or
-   [push it to a registry](/toolhive/guides-ui/skills-build) when it's ready to
-   share.
+Studio ships with two built-in agents:
 
-See [Build a skill from a local folder](/toolhive/guides-ui/skills-build) for
-the end-to-end flow, including how to publish a finished skill.
+- **ToolHive Assistant** for general questions and workflows across your
+  installed MCP servers and skills.
+- **Skill Engineer** for going from "I want a skill that does X" to a working,
+  tested skill without leaving Studio. It scaffolds a `SKILL.md`, iterates with
+  you on the contents, and tests it against your MCP servers in the same window.
+  When you're done,
+  [install or publish the skill](/toolhive/guides-ui/skills-build) from the same
+  place.
+
+You can also author your own agents with their own system prompts and default
+toolsets, and pick one per thread. Each thread keeps its own agent, model, MCP
+servers, and skills selection, so a Skill Engineer thread can sit next to a
+ToolHive Assistant thread or a custom agent thread without configuration leaking
+between them.
 
 ## No more localhost port conflicts with Studio
 
@@ -48,11 +54,8 @@ already in use" headaches.
 
 ## More Playground improvements
 
-A handful of smaller Playground improvements ship alongside the headline
-changes:
+A handful of smaller Playground improvements ship alongside:
 
-- **Each thread keeps its own stack.** Pick the agent, model, MCP servers, and
-  skills per thread, and Studio remembers them. Switch threads, switch stack.
 - **Edit and resend a previous message.** Tweak a prompt that didn't quite land
   and rerun from there, instead of starting a new thread.
 - **See the estimated cost** of every assistant message, using

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agents arrive in the Playground, plus no more port conflicts with Studio
+title: Agents arrive in the Playground
 sidebar_label: 'May 18: Agents in the Playground'
 description:
   Agents are available to everyone in the ToolHive Playground, with built-in
@@ -7,29 +7,29 @@ description:
   own.
 ---
 
-This week, ToolHive Studio v0.35.0 makes Agents in the Playground available to
-everyone, with two built-in agents and the option to author your own. Studio
-also retires the localhost TCP port it used to talk to ToolHive in favor of a
-per-user socket, and the Playground picks up message editing, queueing, and
-per-message cost.
+This week, ToolHive Desktop UI v0.35.0 makes Agents in the Playground available
+to everyone, with two built-in agents and the option to author your own. The
+Desktop UI also retires the localhost TCP port it used to talk to ToolHive in
+favor of a per-user socket, and the Playground picks up message editing,
+queueing, and per-message cost.
 
 {/* truncate */}
 
 ## Agents in the Playground, available to everyone
 
 Agents in the [Playground](/toolhive/guides-ui/playground) are now available to
-every user of Studio. Each chat thread runs against an agent that sets the
-system prompt and a default toolset, so you can shape Studio around the task in
-front of you instead of starting from a blank model every time.
+every user of the Desktop UI. Each chat thread runs against an agent that sets
+the system prompt and a default toolset, so you can shape the Desktop UI around
+the task in front of you instead of starting from a blank model every time.
 
-Studio ships with two built-in agents:
+The Desktop UI ships with two built-in agents:
 
 - **ToolHive Assistant** for general questions and workflows across your
   installed MCP servers and skills.
 - **Skill Engineer** for going from "I want a skill that does X" to a working,
-  tested skill without leaving Studio. It scaffolds a `SKILL.md`, iterates with
-  you on the contents, and tests it against your MCP servers in the same window.
-  When you're done,
+  tested skill without leaving the Desktop UI. It scaffolds a `SKILL.md`,
+  iterates with you on the contents, and tests it against your MCP servers in
+  the same window. When you're done,
   [install or publish the skill](/toolhive/guides-ui/skills-build) from the same
   place.
 
@@ -39,14 +39,14 @@ servers, and skills selection, so a Skill Engineer thread can sit next to a
 ToolHive Assistant thread or a custom agent thread without configuration leaking
 between them.
 
-## No more localhost port conflicts with Studio
+## No more localhost port conflicts with the Desktop UI
 
-Studio no longer binds a localhost TCP port to talk to ToolHive on your machine.
-Instead, it uses a UNIX socket on macOS and Linux, or a named pipe on Windows.
-What that means for you day to day:
+The Desktop UI no longer binds a localhost TCP port to talk to ToolHive on your
+machine. Instead, it uses a UNIX socket on macOS and Linux, or a named pipe on
+Windows. What that means for you day to day:
 
 - **No more port conflicts** when another dev tool wants the same localhost port
-  you were using for Studio.
+  you were using for the Desktop UI.
 - **Tighter local security**: the socket is scoped to your user account, so
   other accounts on the same machine can't reach it.
 

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -15,7 +15,7 @@ queueing, and per-message cost.
 
 {/* truncate */}
 
-## Agents in the Playground, available to everyone
+## Agents in the Desktop UI Playground
 
 Agents in the [Playground](/toolhive/guides-ui/playground) are now available to
 every user of the Desktop UI. Each chat thread runs against an agent that sets

--- a/blog/toolhive-updates/2026-05-18-updates.mdx
+++ b/blog/toolhive-updates/2026-05-18-updates.mdx
@@ -15,11 +15,14 @@ context, message editing, and a handful of quality-of-life improvements.
 
 ## Agents are GA in the Playground
 
-Agent mode is enabled for everyone, no feature flag required. The headline
-addition is a built-in **skill engineering agent** that can scaffold and test
-skills directly inside the Playground, so you can go from idea to working skill
-without leaving Studio. Generate a `SKILL.md`, iterate on the agent's output,
-and try it against your MCP servers in the same window.
+Agent mode is enabled for everyone in the
+[Playground](/toolhive/guides-ui/playground), no feature flag required. The
+headline addition is a built-in **Skill Engineer** agent that can scaffold and
+test skills directly inside the Playground, so you can go from idea to working
+skill without leaving Studio. Generate a `SKILL.md`, iterate on the agent's
+output, and try it against your MCP servers in the same window. See
+[Build a skill from a local folder](/toolhive/guides-ui/skills-build) for the
+end-to-end flow.
 
 ## Studio talks to `thv` over a UNIX socket
 
@@ -27,27 +30,27 @@ Studio no longer binds a localhost TCP port to communicate with the `thv` API.
 Instead, it uses:
 
 - A **UNIX socket** on macOS and Linux.
-- A **Windows named pipe** on Windows.
+- A **named pipe** on Windows.
 
 That drops a localhost port from your dev surface, so no more port conflicts
 with other tools. The socket is scoped to the current user, so other accounts on
 the machine can't reach it.
 
-## Playground quality-of-life
+## More Playground improvements
 
 A handful of smaller Playground improvements ship alongside the headline
 changes:
 
-- **Per-thread model, MCP, and skills selection.** Each chat thread remembers
-  its own context. Switch threads, switch stack.
+- **Per-thread agent, model, MCP, and skills selection.** Each chat thread
+  remembers its own context. Switch threads, switch stack.
 - **Edit and resend.** Edit a previous user message and resend it; the
   conversation regenerates from that point.
 - **Per-message cost.** Each assistant message shows its estimated cost using
   [models.dev](https://models.dev) pricing data.
 - **Message queuing.** Send follow-up messages while a response is still
   streaming, and they queue and run in order.
-- **One-click copy and an agent-aware empty state.** Copy any message in a
-  click, and the empty-state suggestions adapt to the agent you've selected.
+- **One-click copy and an agent-aware empty state.** Copy any message from its
+  menu, and the suggested prompts on a new thread adapt to the selected agent.
 
 ## Getting started
 


### PR DESCRIPTION
### Description

Adds the 2026-05-18 weekly update post for ToolHive Studio v0.35.0:

- **Agents are GA in the Playground.** Agent mode is enabled for everyone; a built-in skill engineering agent can scaffold and test skills directly inside the Playground.
- **Studio talks to `thv` over a UNIX socket / Windows named pipe.** No more localhost TCP port binding, no port conflicts, and the socket is scoped to the current user.
- **Playground quality-of-life.** Per-thread model/MCP/skills context, edit-and-resend, per-message cost (via models.dev), message queuing while a response is streaming, one-click copy, and an agent-aware empty state.

Skips fixes, security overrides, and under-the-hood items per the editorial pattern of the past few weekly posts. Happy to fold them in if you'd like.

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)