### PR TITLE
Clarify the vMCP CLI endpoint

### DIFF
--- a/docs/toolhive/guides-vmcp/local-cli.mdx
+++ b/docs/toolhive/guides-vmcp/local-cli.mdx
@@ -68,9 +68,9 @@ just a group name:
 thv vmcp serve --group my-group
 ```
 
-By default, the server binds to `127.0.0.1:4483`. Point your MCP client at
-`http://127.0.0.1:4483` to access all tools from the group through a single
-endpoint.
+By default, the server binds to `127.0.0.1:4483` using the Streamable HTTP
+transport protocol. Point your MCP client at `http://127.0.0.1:4483/mcp` to
+access all tools from the group through a single endpoint.
 
 :::note[Loopback-only]
 


### PR DESCRIPTION
### Description

The quick mode section of the vMCP local CLI guide pointed readers at `http://127.0.0.1:4483`, which omits the `/mcp` path that the Streamable HTTP server actually serves on. Updated the paragraph to name the transport and include the correct endpoint path.

Verified against the toolhive source: defaults are set in [pkg/vmcp/server/server.go](https://github.com/stacklok/toolhive/blob/main/pkg/vmcp/server/server.go) (`EndpointPath = "/mcp"`, `NewStreamableHTTPServer`) and [cmd/thv/app/vmcp.go](https://github.com/stacklok/toolhive/blob/main/cmd/thv/app/vmcp.go) (host/port).

### Type of change

- Bug fix (typo, broken link, etc.)

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style