### PR TITLE
Clarify auth capabilities on Enterprise page

### DIFF
--- a/docs/toolhive/enterprise.mdx
+++ b/docs/toolhive/enterprise.mdx
@@ -96,13 +96,14 @@ them.
 
 | Capability                                            | Community | Enterprise |
 | :---------------------------------------------------- | :-------: | :--------: |
-| Basic authentication                                  |     ✓     |     ✓      |
-| Policy-as-code engine (CEDAR)                         |     ✓     |     ✓      |
+| OIDC/OAuth authentication                             |     ✓     |     ✓      |
+| Policy-as-code engine (Cedar)                         |     ✓     |     ✓      |
 | Audit logging & compliance reporting                  |     ✓     |     ✓      |
-| Built-in IdP integration (Okta, Entra ID)             |     —     |     ✓      |
+| Token exchange (RFC 8693)                             |     ✓     |     ✓      |
+| Turnkey IdP integration (Okta, Entra ID)              |     —     |     ✓      |
 | IdP group → ToolHive role mapping                     |     —     |     ✓      |
+| Entra ID on-behalf-of flow                            |     —     |     ✓      |
 | Canonical policy packs (read-only, full CRUD, custom) |     —     |     ✓      |
-| Token exchange & credential brokering                 |     —     |     ✓      |
 
 ### Enterprise UI & management
 
@@ -147,7 +148,7 @@ Ready to discuss what the right package looks like for your organization?
 
 ---
 
-## Enterprise Platform Components
+## Enterprise platform components
 
 Stacklok Enterprise Platform secures MCP servers across your organization
 through its registry, runtime, gateway, and portal.
@@ -223,11 +224,11 @@ with forward-deployed engineering support.
 ToolHive Community is an open source distribution optimized for individual
 developers and pre-production use, making it the right tool for evaluating MCP
 and building a proof of concept. Stacklok Enterprise is a separate, hardened
-distribution built for production: semantically versioned, with IdP integration,
-centralized governance, and SLA-backed support. Moving from Community to
-Enterprise is a supported migration where Stacklok provides the enterprise
-binaries and dedicated engineering support to take you from proof of concept to
-production.
+distribution built for production: semantically versioned, with turnkey IdP
+integration, centralized governance, and SLA-backed support. Moving from
+Community to Enterprise is a supported migration where Stacklok provides the
+enterprise binaries and dedicated engineering support to take you from proof of
+concept to production.
 [See the full comparison](#toolhive-community-vs-stacklok-enterprise) or
 [learn about the proof of concept engagement](#validate-stacklok-enterprise-in-your-environment).
 
@@ -239,7 +240,7 @@ production.
 Your data never leaves your environment. Stacklok Enterprise is fully
 self-hosted: you retain complete control over your data and infrastructure,
 regardless of contract status. If you end your subscription, you can downgrade
-to the open-source version at any time. The only things you lose are access to
+to the open source version at any time. The only things you lose are access to
 Enterprise features, forward-deployed engineers, backported security patches,
 and dedicated support. There is zero vendor lock-in.
 [Learn more about the product offerings](#product-offerings).

--- a/docs/toolhive/index.mdx
+++ b/docs/toolhive/index.mdx
@@ -97,9 +97,9 @@ discoverability, governance, publishing, or team-specific access.
 
 :::enterprise
 
-Stacklok Enterprise builds on ToolHive with centralized management, turnkey IdP
-integrations (Okta, Entra ID), hardened images, and platform capabilities for
-teams running MCP in production.
+Stacklok Enterprise builds on ToolHive with centralized management, turnkey
+identity provider integrations (Okta, Entra ID), hardened images, and platform
+capabilities for teams running MCP in production.
 
 [Learn more about Stacklok Enterprise](./enterprise.mdx)
 

--- a/docs/toolhive/index.mdx
+++ b/docs/toolhive/index.mdx
@@ -97,9 +97,9 @@ discoverability, governance, publishing, or team-specific access.
 
 :::enterprise
 
-Stacklok Enterprise builds on ToolHive with centralized management, identity
-provider integrations, hardened images, and platform capabilities for teams
-running MCP in production.
+Stacklok Enterprise builds on ToolHive with centralized management, turnkey IdP
+integrations (Okta, Entra ID), hardened images, and platform capabilities for
+teams running MCP in production.
 
 [Learn more about Stacklok Enterprise](./enterprise.mdx)
 


### PR DESCRIPTION
### Description

The auth & identity comparison table on the Enterprise page had two rows that prospects were reading the wrong way:

- "Basic authentication" was being read as HTTP Basic auth. Renamed to "OIDC/OAuth authentication" since that's what ToolHive actually provides in both Community and Enterprise.
- "Built-in IdP integration (Okta, Entra ID)" implied that OAuth/OIDC isn't available in open source at all. The actual differentiation is that Enterprise ships preset configurations for specific identity providers, so renamed to "Turnkey IdP integration (Okta, Entra ID)".

While in the area:

- Split "Token exchange & credential brokering" into "Token exchange (RFC 8693)" (Community + Enterprise) and "Entra ID on-behalf-of flow" (Enterprise-only, since it's a non-RFC variant).
- Fixed "CEDAR" capitalization (Cedar is a proper noun, not an acronym).
- Aligned the `:::enterprise` admonition on the docs landing page and the FAQ entry on the Enterprise page to use the same "turnkey IdP integration" framing.
- Sentence-cased the "Enterprise platform components" heading to match the rest of the page.
- Fixed "open-source" → "open source" per the style guide.

### Type of change

- Documentation update

### Submitter checklist

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style