### PR TITLE
Specify format of kubernetes.namespaces

### DIFF
--- a/docs/toolhive/guides-registry/configuration.mdx
+++ b/docs/toolhive/guides-registry/configuration.mdx
@@ -395,9 +395,10 @@ registries:
 **Configuration options:**
 
 - `kubernetes` (required): Empty object or namespace configuration (see below)
-- `kubernetes.namespaces` (optional): List of Kubernetes namespaces to watch. If
-  empty, falls back to the `THV_REGISTRY_WATCH_NAMESPACE` environment variable,
-  or all namespaces if neither is set
+- `kubernetes.namespaces` (optional): A comma-separated list of Kubernetes
+  namespaces to watch. If empty, falls back to the
+  `THV_REGISTRY_WATCH_NAMESPACE` environment variable, or all namespaces if
+  neither is set
 - No sync policy required (Kubernetes sources query live deployments on-demand)
 
 #### Per-entry claims via annotation


### PR DESCRIPTION

### Description

Registry configuration guide: specify that the `kubernetes.namespaces` configuration option is comma-separated.

Previously, a reader would have to go down to the environment variables table at the bottom of the page to learn this.

### Type of change

- Documentation update

### Related issues/PRs

Closes #893

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>