### PR TITLE
Block eslint v10 majors in Renovate temporarily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,13 @@
       "enabled": false
     },
     {
+      "description": "Temporarily block eslint v10. typescript-eslint, eslint-plugin-mdx, and eslint-plugin-react don't support v10 yet; revisit once plugin majors land.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["eslint", "@eslint/js"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepTypes": ["engines"],
       "rangeStrategy": "replace"


### PR DESCRIPTION
### Description

PR #898 keeps churning because eslint v10 can't merge: `typescript-eslint`, `eslint-plugin-mdx`, and `eslint-plugin-react` don't support eslint v10 yet. Add a Renovate package rule to skip major bumps for `eslint` and `@eslint/js` until the plugin majors land.

### Type of change

- Other / backend (Renovate configuration)

### Related issues/PRs

- #898