### PR TITLE
chore: add needs-triage caller workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,13 @@
+name: Needs Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  triage:
+    uses: stacklok/.github/.github/workflows/needs-triage.yml@b43e3f174f9bbf2ca4efe6e421a1d007e7fa1b8f  # v1
+

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,5 +9,5 @@ permissions:
 
 jobs:
   triage:
-    uses: stacklok/.github/.github/workflows/needs-triage.yml@b43e3f174f9bbf2ca4efe6e421a1d007e7fa1b8f  # v1
+    uses: stacklok/.github/.github/workflows/needs-triage.yml@b43e3f174f9bbf2ca4efe6e421a1d007e7fa1b8f # v1
 


### PR DESCRIPTION
Wires up the org-wide `needs-triage` reusable workflow. Any new or reopened issue is auto-labeled `needs-triage`; removing the label signals a maintainer has triaged it. Bot-authored issues are skipped.

Caller declares minimal `permissions: issues: write` and pins the reusable workflow to a commit SHA (`v1`). Verified end-to-end in the sandbox.