### PR TITLE
Add Reo.dev analytics script

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -104,6 +104,27 @@ const config: Config = {
         },
       };
     },
+    function reo() {
+      return {
+        name: 'reo-dev',
+        injectHtmlTags() {
+          if (!isProductionDeploy) return {};
+          return {
+            headTags: [
+              {
+                tagName: 'script',
+                // Reo.dev tracking loader.
+                // Source: Generated from the Reo.dev dashboard for Stacklok.
+                // The snippet is intentionally kept minified and should not be edited manually.
+                // To update, re-generate from the Reo.dev dashboard and replace the string verbatim.
+                innerHTML:
+                  '!function(){var e,t,n;e="3a4f9a7c603cbc3",t=function(){Reo.init({clientID:"3a4f9a7c603cbc3", enableThirdPartyTracking: true})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();',
+              },
+            ],
+          };
+        },
+      };
+    },
   ],
 
   // Set the production url of your site here


### PR DESCRIPTION
### Description

Adds the Reo.dev tracking snippet to the site via a Docusaurus plugin. Like the existing GTM and HubSpot integrations, it only loads on production Vercel deployments (`VERCEL_ENV === 'production'`), so it stays disabled during local development and preview builds.

The Reo snippet creates and appends its own `reo.js` script element, so it's injected as a single head `script` tag with no `noscript`/preBody fallback needed. The minified snippet is kept verbatim as generated from the Reo.dev dashboard.

### Type of change

- Other / internal (analytics configuration)

### Related issues/PRs

N/A