### PR TITLE
Mark Roo Code client integration as deprecated

### DIFF
--- a/docs/toolhive/enterprise.mdx
+++ b/docs/toolhive/enterprise.mdx
@@ -278,9 +278,8 @@ audit logging for teams running MCP at scale across their organization.
 
 Stacklok Enterprise works with any AI coding assistant or agent that supports
 MCP. This includes Claude Code, GitHub Copilot, Cursor, Windsurf, VS Code, Zed,
-Cline, Continue, Roo Code, Goose, LM Studio, OpenAI Codex, and many more. Most
-clients support automatic configuration so developers can connect without manual
-setup.
+Cline, Continue, Goose, LM Studio, OpenAI Codex, and many more. Most clients
+support automatic configuration so developers can connect without manual setup.
 [See the full client compatibility reference](./reference/client-compatibility.mdx)
 for the complete list.
 

--- a/docs/toolhive/guides-cli/client-configuration.mdx
+++ b/docs/toolhive/guides-cli/client-configuration.mdx
@@ -56,9 +56,9 @@ Replace `<CLIENT_NAME>` with the name of your client. Common client names
 include:
 
 - `claude-code` - Claude Code CLI
+- `codex` - OpenAI Codex
 - `cursor` - Cursor IDE
-- `roo-code` - Roo Code extension for Visual Studio Code
-- `cline` - Cline extension for Visual Studio Code
+- `antigravity` - Google Antigravity IDE
 - `vscode` - Visual Studio Code (GitHub Copilot)
 - `vscode-insider` - VS Code Insiders edition
 

--- a/docs/toolhive/reference/client-compatibility.mdx
+++ b/docs/toolhive/reference/client-compatibility.mdx
@@ -31,7 +31,7 @@ We've tested ToolHive with these clients:
 | Mistral Vibe               |    ✅     |         ✅         |       ✅       |                                             |
 | OpenAI Codex               |    ✅     |         ✅         |       ✅       |                                             |
 | OpenCode                   |    ✅     |         ✅         |       ✅       |                                             |
-| Roo Code (VS Code)         |    ✅     |         ✅         |       ✅       | v3.19.2+                                    |
+| Roo Code (VS Code)         |    ✅     |         ✅         |       ✅       | Deprecated ([see note][6])                  |
 | Sourcegraph Amp CLI        |    ✅     |         ✅         |       ✅       |                                             |
 | Sourcegraph Amp (VS Code)  |    ✅     |         ✅         |       ❌       |                                             |
 | Sourcegraph Amp (Cursor)   |    ✅     |         ✅         |       ❌       |                                             |
@@ -49,6 +49,7 @@ We've tested ToolHive with these clients:
 [3]: #vs-code-with-copilot
 [4]: #stdio-only-client-configuration
 [5]: #chatgpt-desktop-configuration
+[6]: #roo-code-and-cline
 
 The minimum versions listed are the earliest versions that support the
 Streamable HTTP transport protocol.
@@ -210,6 +211,19 @@ claude mcp add --scope <user|project> --transport http fetch http://localhost:43
 ```
 
 ### Roo Code and Cline
+
+:::warning[Roo Code is deprecated]
+
+The Roo Code VS Code extension was discontinued on May 15, 2026 and its
+repository archived. ToolHive support for the `roo-code` client is deprecated
+and will be removed in a future release. The Roo Code team recommends migrating
+to [Cline](https://cline.bot/), which ToolHive also supports:
+
+```bash
+thv client register cline
+```
+
+:::
 
 [Roo Code](https://roocode.com/) (previously Roo Cline) and
 [Cline](https://cline.bot/) store their global MCP configuration in their VS


### PR DESCRIPTION
### Description

The Roo Code VS Code extension was discontinued on May 15, 2026 and its repository archived, with the upstream team officially recommending Cline. The docs still presented `roo-code` as a fully supported client, which no longer matches reality. This updates the docs to match the deprecation landing in the CLI.

- Flagged Roo Code as `Deprecated` in the client compatibility table and added a warning admonition to the "Roo Code and Cline" section recommending `thv client register cline`.
- Dropped the `roo-code` and `cline` entries from the CLI registration examples in `client-configuration.mdx` in favor of `codex` and `antigravity` (these are illustrative examples only).
- Removed Roo Code from the enterprise supported-clients list.

The CLI reference pages under `reference/cli/` are intentionally left untouched; they're auto-synced from the toolhive repo and will pick up the `(deprecated)` marker on the next sync.

### Type of change

- Documentation update

### Related issues/PRs

- Companion to stacklok/toolhive#5415 (ships the CLI deprecation warning)
- Part of stacklok/toolhive#5017

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
