### PR TITLE
Improve upstream-release-docs skill: gap-hardening and workflow cleanup

### DIFF
--- a/.claude/skills/upstream-release-docs/SKILL.md
+++ b/.claude/skills/upstream-release-docs/SKILL.md
@@ -46,7 +46,7 @@ This skill runs in one of two modes. **The caller signals the mode; absent an ex
 
 ### Unattended decision-point behavior
 
-When a step would normally ask the user (Phase 2 step 4, Phase 2 step 5), instead:
+When Phase 2 step 4 would normally ask the user for a major feature's "why", instead:
 
 1. Fetch the PR body and author with `gh pr view <NUMBER> --repo <OWNER>/<REPO> --json title,body,author`. The PR body usually carries the "why" the author wrote at open time: motivation, intended consumers, design decisions.
 2. If the PR body references linked issues ("Closes #N", "Fixes #N", "Refs #N"), fetch the likely-context-bearing ones with `gh issue view <N> --repo <OWNER>/<REPO>`.
@@ -57,7 +57,7 @@ When a step would normally ask the user (Phase 2 step 4, Phase 2 step 5), instea
 
 These files are read by the automated caller and spliced into the PR body. The filenames and the repo-root location are a contract with the caller; do not rename or relocate them.
 
-**`GAPS.md`** — only if you genuinely need to defer (see above). An empty `GAPS.md` is worse than none; do not create it if every feature's "why" was resolvable from available sources.
+**`GAPS.md`** - only if you genuinely need to defer (see above). An empty `GAPS.md` is worse than none; do not create it if every feature's "why" was resolvable from available sources.
 
 - Include only content gaps a human reviewer must fill. Exclude environment or sandbox limitations (for example, "couldn't run `npm build`"); the PR's CI handles those. Exclude "documented for clarity, not a gap" commentary.
 - Each entry must @-mention the PR author, skipping bot authors (`renovate[bot]`, `github-actions[bot]`, `stacklokbot`).
@@ -77,14 +77,14 @@ These files are read by the automated caller and spliced into the PR body. The f
   > <Self-contained, paste-ready prompt referencing the file(s), PR number, and the narrow piece of info needed.>
   ```
 
-**`NO_CHANGES.md`** — if the Phase 3 impact map is empty (no doc-relevant changes for this release), write this at repo root with a one-line explanation and stop. Do not hand-edit any file.
+**`NO_CHANGES.md`** - if the Phase 3 impact map is empty (no doc-relevant changes for this release), write this at repo root with a one-line explanation and stop. Do not hand-edit any file.
 
-**`SUMMARY.md`** — before the final commit, write a concise list of the hand-written doc changes you made. The caller surfaces it as the PR's "Summary of changes" so reviewers see what shipped without reading the diff. Skip it only when you wrote `NO_CHANGES.md` or made zero hand-edits. Keep it to 3-8 bullets, each formatted as one of:
+**`SUMMARY.md`** - before the final commit, write a concise list of the hand-written doc changes you made. The caller surfaces it as the PR's "Summary of changes" so reviewers see what shipped without reading the diff. Skip it only when you wrote `NO_CHANGES.md` or made zero hand-edits. Keep it to 3-8 bullets, each formatted as one of:
 
-- `Added <what> at <path>` — new pages/sections
-- `Updated <what> in <path>` — meaningful prose edits
-- `Swept <what> across N files in <area>` — repo-wide renames, apiVersion bumps, etc.
-- `Removed <what> from <path>` — deletions
+- `Added <what> at <path>` - new pages/sections
+- `Updated <what> in <path>` - meaningful prose edits
+- `Swept <what> across N files in <area>` - repo-wide renames, apiVersion bumps, etc.
+- `Removed <what> from <path>` - deletions
 
 Describe one logical change as one bullet (don't enumerate each file in a sweep), and exclude auto-generated reference files the caller's refresh step updates: describe only your hand-written edits.
 
@@ -326,13 +326,13 @@ When receiving review comments (from humans or automated reviewers):
 ## Key Principles
 
 - **Triple verification**: verify during deep dive (Phase 2), before finalizing (Phase 5), and when handling reviews (Phase 6)
-- **Document what the release falsifies, not just what it adds**: a new capability that extends or replaces an existing one almost always makes prior "only / default / automatic / planned" statements wrong. Audit the _displaced_ concept's vocabulary (the old mechanism's terms) across the whole docs set, not just the new feature's name. A purely additive (`+N / -0`) edit to a prose page is a smell that a contradiction was left unreconciled. The reviewer cannot catch a sin of omission in a zero-deletion diff; the skill must.
+- **Document what the release falsifies, not just what it adds**: a new capability usually makes prior "only / default / automatic / planned" statements wrong. Audit the _displaced_ concept's vocabulary across the whole docs set, and treat a purely additive (`+N / -0`) prose edit as a smell. The reviewer cannot catch a sin of omission in a zero-deletion diff; the skill must (Phase 3 displacement audit).
 - **Transparency**: log the categorized summary (after Phase 1) and impact map (after Phase 3) for auditability, but do not stop; run all phases to completion
 - **Respect auto-generated content**: don't manually edit auto-generated files, but always create the surrounding conceptual/guide content that auto-generated reference docs don't provide
-- **Separate by Diataxis type, at the right granularity**: keep concept and how-to content distinguishable. For standalone capabilities that means separate pages per type; for features that extend existing docs, a new section of the right type within the existing page is preferable to a new standalone page. Prefer extending an existing page over creating a new one when the feature extends a documented capability, and reserve new pages for genuinely standalone capabilities. This is a default, not a mandate: split a section out to its own page (with a summary and cross-link left behind) when it is a distinct subject, has its own full how-to lifecycle, or would overload an already-long host page. The test is shared subject and a focused page, not extend-versus-new in the abstract.
-- **Verify completeness, not just accuracy**: accuracy checks confirm what you wrote is true; they never catch what you left out. Inventory the release's new public surface (fields, flags, enum values, config keys, routes) in Phase 2 and confirm in Phase 5 that each symbol is documented or consciously deferred. An accurate section that covers only part of a feature's surface is the most common silent failure of this workflow.
+- **Separate by Diataxis type, at the right granularity**: keep concept and how-to content distinguishable, but prefer extending an existing page over a new one when the feature extends a documented capability. Reserve new pages for standalone capabilities, and split a section out only when it would overload its host (Phase 4).
+- **Verify completeness, not just accuracy**: accuracy checks never catch what you left out. Inventory the release's new public surface in Phase 2 and confirm in Phase 5 that each symbol is documented or consciously deferred. An accurate section that covers only part of a feature's surface is this workflow's most common silent failure.
 - **Document the full lifecycle**: if a feature has producer and consumer sides, document both. Always answer "then what?" Readers who follow the docs to completion must not hit a dead end. If consumption tooling isn't built yet, say so explicitly.
-- **Ask for context on major features**: for entirely new capabilities, don't fabricate the "why" from code alone. In interactive mode, ask the user for user stories, PRDs, or RFCs. In unattended mode, derive the "why" from PR bodies and linked issues best-effort and defer to `GAPS.md` only when it is genuinely underivable (see [Execution modes](#execution-modes)). Incremental changes can proceed autonomously in either mode.
+- **Ask for context on major features**: don't fabricate the "why" from code alone. Interactive mode asks the user for user stories, PRDs, or RFCs; unattended mode derives it from PR bodies and linked issues, deferring to `GAPS.md` only when genuinely underivable (see [Execution modes](#execution-modes)). Incremental changes proceed autonomously in either mode.
 - **Lead with scenarios, not abstractions**: open concept pages with concrete "who is this for and why should they care" scenarios, not abstract definitions
 - **Flag gaps honestly**: if consumption tooling, client support, or integration isn't ready yet, say so explicitly rather than omitting the topic
 - **Use realistic examples**: guide pages need end-to-end examples with plausible data, exact commands, and expected output, not placeholder values

--- a/.claude/skills/upstream-release-docs/SKILL.md
+++ b/.claude/skills/upstream-release-docs/SKILL.md
@@ -36,6 +36,58 @@ Any output that may be rendered as a GitHub comment, PR body, or Markdown file i
 - When the release notes body contains bare `#NNN`, expand them to `<OWNER>/<REPO>#NNN` before echoing them back.
 - Full PR/issue URLs are also fine.
 
+## Execution modes
+
+This skill runs in one of two modes. **The caller signals the mode; absent an explicit unattended signal, assume interactive.** Never infer unattended mode from surrounding context.
+
+**Interactive (default):** a human is present. At decision points that need product context you cannot derive from source (Phase 2 step 4), ask the user. **Never write the `GAPS.md`, `SUMMARY.md`, or `NO_CHANGES.md` artifacts described below in interactive mode**; surface that information conversationally instead. Those files are machine-readable handoff artifacts for an automated caller, and writing them during a local run just litters the repo root.
+
+**Unattended:** no interactive user, for example a CI workflow that invokes `/upstream-release-docs ... in unattended mode`. Never ask clarifying questions; proceed best-effort at every decision point, and route anything genuinely unresolvable into the artifacts below.
+
+### Unattended decision-point behavior
+
+When a step would normally ask the user (Phase 2 step 4, Phase 2 step 5), instead:
+
+1. Fetch the PR body and author with `gh pr view <NUMBER> --repo <OWNER>/<REPO> --json title,body,author`. The PR body usually carries the "why" the author wrote at open time: motivation, intended consumers, design decisions.
+2. If the PR body references linked issues ("Closes #N", "Fixes #N", "Refs #N"), fetch the likely-context-bearing ones with `gh issue view <N> --repo <OWNER>/<REPO>`.
+3. Write the "why"/consumer narrative directly into the relevant page using what you learned. This is best-effort; reviewers refine it later.
+4. Defer to `GAPS.md` only when the rationale demonstrably cannot be derived from available sources: the PR points to an internal design doc you cannot access, multiple plausible consumer narratives exist and choosing one would mislead readers, or a release timeline or commitment needs product-team confirmation.
+
+### Artifacts (unattended mode only, written at repo root)
+
+These files are read by the automated caller and spliced into the PR body. The filenames and the repo-root location are a contract with the caller; do not rename or relocate them.
+
+**`GAPS.md`** — only if you genuinely need to defer (see above). An empty `GAPS.md` is worse than none; do not create it if every feature's "why" was resolvable from available sources.
+
+- Include only content gaps a human reviewer must fill. Exclude environment or sandbox limitations (for example, "couldn't run `npm build`"); the PR's CI handles those. Exclude "documented for clarity, not a gap" commentary.
+- Each entry must @-mention the PR author, skipping bot authors (`renovate[bot]`, `github-actions[bot]`, `stacklokbot`).
+- Each entry must include a paste-ready "Helper prompt for local Claude" referencing the specific file(s), the PR number for context, and the narrow piece of information the human must supply or confirm.
+
+  Entry format:
+
+  ```markdown
+  ### <Feature name> (PR <OWNER>/<REPO>#123 by @alice)
+
+  <One paragraph: what's missing and why it couldn't be resolved from available sources.>
+
+  **File(s):** path/to/file.mdx
+
+  **Helper prompt for local Claude:**
+
+  > <Self-contained, paste-ready prompt referencing the file(s), PR number, and the narrow piece of info needed.>
+  ```
+
+**`NO_CHANGES.md`** — if the Phase 3 impact map is empty (no doc-relevant changes for this release), write this at repo root with a one-line explanation and stop. Do not hand-edit any file.
+
+**`SUMMARY.md`** — before the final commit, write a concise list of the hand-written doc changes you made. The caller surfaces it as the PR's "Summary of changes" so reviewers see what shipped without reading the diff. Skip it only when you wrote `NO_CHANGES.md` or made zero hand-edits. Keep it to 3-8 bullets, each formatted as one of:
+
+- `Added <what> at <path>` — new pages/sections
+- `Updated <what> in <path>` — meaningful prose edits
+- `Swept <what> across N files in <area>` — repo-wide renames, apiVersion bumps, etc.
+- `Removed <what> from <path>` — deletions
+
+Describe one logical change as one bullet (don't enumerate each file in a sweep), and exclude auto-generated reference files the caller's refresh step updates: describe only your hand-written edits.
+
 ## Phase 1: Discovery
 
 1. Fetch the release:
@@ -92,8 +144,9 @@ For each PR identified in Phase 1 (skip internal/infra unless user requests):
    - Ask how consumers are expected to discover and use the feature (CLI, IDE extension, API, etc.)
    - Do not attempt to fabricate the "why" or consumer story from code structure alone. This produces documentation that covers the "what" and "how" but misses the perspective and voice that only comes from understanding the product intent
    - Incremental changes (new config options, default changes, annotation additions) can proceed without this step
+   - **In unattended mode, do not ask.** Follow the unattended decision-point behavior in [Execution modes](#execution-modes): derive the "why" from the PR body and linked issues, write it best-effort, and defer to `GAPS.md` only when it is genuinely underivable.
 
-5. **Check related repositories**: components often span multiple repos. For example, a server's CRD/operator may live in a different repo than the server itself. When a release changes config structures, API surfaces, or deployment models, check whether related repos (operators, CLIs, client libraries) have also released changes that affect the documentation. Ask the user which repos are related if unclear.
+5. **Check related repositories**: components often span multiple repos. For example, a server's CRD/operator may live in a different repo than the server itself. When a release changes config structures, API surfaces, or deployment models, check whether related repos (operators, CLIs, client libraries) have also released changes that affect the documentation. Ask the user which repos are related if unclear (in unattended mode, infer related repos from the release notes and proceed best-effort).
 
 6. **Read the actual source code at the release tag** to verify every claim made in the PR description:
 
@@ -118,6 +171,8 @@ For each PR identified in Phase 1 (skip internal/infra unless user requests):
    - **Auto-generated content**: files generated from upstream (OpenAPI specs, CLI reference docs, JSON schemas). Do not manually edit these; flag them for automated update instead. However, auto-generated reference docs (e.g., API endpoints from a swagger spec) do **not** replace the need for conceptual explanations, guide content, or cross-references in existing pages. A new feature with auto-generated API docs still needs: (1) a conceptual explanation of what it is and why it exists, (2) mentions and cross-references in related existing pages (intro pages, feature lists, related guides), and (3) guide content if the feature has non-trivial workflows. Only skip creating a **duplicate API reference page**: never skip the surrounding documentation.
    - **Hidden/experimental features**: look for indicators like `Hidden: true` in CLI command definitions, feature flags, or internal-only annotations. Do not document these unless the user explicitly asks.
 
+10. **Inventory the new public surface.** As you read the source and the regenerated reference assets, list every new or changed user-facing symbol the release introduces: CRD/struct fields, enum values, CLI flags and subcommands, env vars, config keys, and API routes. Most are already enumerated in the auto-synced reference assets (CLI `.md`, CRD `*.schema.json`, Swagger YAML) and the diff, so this is mostly transcription, not discovery. This list is the checklist the completeness pass in Phase 5 verifies against. It is the difference between documentation that is _accurate_ and documentation that is _complete_: a release can ship five new config fields, and a section that explains one of them correctly passes every accuracy check while silently omitting the other four.
+
 ## Phase 3: Audit Existing Docs
 
 1. Search the documentation codebase for references to affected areas:
@@ -125,23 +180,45 @@ For each PR identified in Phase 1 (skip internal/infra unless user requests):
    - Feature names, API paths, version numbers
    - Any terminology that changed
 
-2. Check the project style guide (CLAUDE.md, STYLE-GUIDE.md, or similar) for conventions.
+2. **Displacement audit (find what the release makes false, not just what it adds).** This is the step most often skipped, and the skipped result is documentation that adds a correct new section while leaving stale claims that now contradict it. A release PR is a delta: it tells you what was _added_, never which existing sentences that addition _falsifies_. Closing that gap is your job here, not the reviewer's.
 
-3. Build an **impact map**, a table with these columns:
+   For each new or changed feature, ask: **does it add an alternative, a replacement, a default change, or an additional option for a capability the docs already describe?** If yes, the feature has a _displaced concept_. Audit the displaced concept's vocabulary, not the new feature's:
+   - The new feature's terms (the new flag, config key, or feature name) only find where to _add_ content. Search them to place the new section.
+   - The displaced concept's terms find where existing prose is now _wrong_. A feature named CIMD that adds a second client-registration mechanism falsifies sentences about the _old_ mechanism (DCR, "Dynamic Client Registration", "register automatically"). Grep for those, not for the new feature name.
 
-   | File | Current text/value | Verified replacement | Change type       |
-   | ---- | ------------------ | -------------------- | ----------------- |
-   | path | what exists now    | what it should be    | update/new/remove |
+   Then sweep the displaced concept's surrounding prose for **exclusivity and temporal language**, the phrasing that silently goes stale when a feature lands:
+   - Exclusivity: "only", "the only", "must", "always", "automatically", "the way to", "requires".
+   - Temporal/roadmap: "currently implements", "is planned", "not yet", "coming soon", "future release", "for now".
+   - Each hit is a candidate contradiction. Read it against the verified new behavior and decide whether it must be revised.
 
-4. **Log the impact map** for transparency, then proceed to Phase 4.
+3. **Heed the additive-only smell.** If your planned edit to an existing page only _appends_ a new section and revises no existing sentence (a `+N / -0` diff on a prose page), treat that as a signal, not a success. A newly added capability almost always falsifies an existing "only / default / planned" statement nearby. Reconcile the page you are editing with the section you just added to it, then check sibling pages that cover the same concept.
+
+4. Check the project style guide (CLAUDE.md, STYLE-GUIDE.md, or similar) for conventions.
+
+5. Build an **impact map**, a table with these columns:
+
+   | File | Current text/value | Verified replacement | Change type |
+   | --- | --- | --- | --- |
+   | path | what exists now | what it should be | update/new/remove/contradiction |
+
+   Use the `contradiction` change type for existing statements the release falsifies (stale exclusivity or roadmap claims). Every contradiction found in the displacement audit must appear as a row. A feature that adds a new section to one page typically produces several `contradiction` rows across sibling pages, not just an `new` row on the page you extended.
+
+6. **Log the impact map** for transparency, then proceed to Phase 4.
 
 ## Phase 4: Implementation
 
 Apply the approved changes:
 
-1. **Update existing pages**: edit files using the impact map. Preserve the existing writing style and conventions.
+1. **Update existing pages, and prefer extending them over creating new ones.** Edit files using the impact map, preserving the existing writing style and conventions. When a feature _extends_ a capability the docs already cover (a new auth mechanism alongside an existing one, a new flag on a documented command, an additional option on a documented resource), the right move is almost always to add a section to the existing page and reconcile the surrounding prose (see the displacement audit in Phase 3), not to spin up a standalone page. A standalone page for an extension fragments the concept across two locations, duplicates context, and is a common over-documentation failure mode. Reserve new pages for genuinely standalone capabilities (see the next step).
 
-2. **Create new pages** for new features that lack existing documentation. Default to documenting new features rather than skipping them:
+   **But split instead of extending when the section would overload the host page.** "Prefer extending" is a default, not a mandate to cram everything onto one page; the opposite failure is a page that accretes a section every release until it is too dense to scan and breaks progressive disclosure. Graduate the content to its own page, leaving a brief summary and a cross-link behind, when any of these hold:
+   - The content is a distinct subject readers would look for by its own name, not a facet of the host page's subject.
+   - It has its own full how-to lifecycle (setup, configure, verify, troubleshoot). In this case the _concept_ can stay as a section on the host page while the _guide_ becomes its own page; both can be correct at once.
+   - The host page is already long or already covers multiple capabilities, so adding more would bury existing content.
+
+   The test is whether the new content shares the host page's subject and keeps it focused, not extend-versus-new in the abstract.
+
+2. **Create new pages** for genuinely standalone new features that lack existing documentation. Default to documenting new features rather than skipping them, but first confirm the feature is standalone rather than an extension of something already documented (if it extends an existing capability, prefer step 1):
 
    **Page placement**: the docs are organized by product area under `docs/toolhive/`. Place new content in the correct section:
    - **Product-specific guides** go in the relevant product section (`docs/toolhive/guides-ui/`, `guides-cli/`, `guides-k8s/`, `guides-vmcp/`, `guides-registry/`).
@@ -151,7 +228,7 @@ Apply the approved changes:
    - **Reference material** goes in `docs/toolhive/reference/`.
    - Check the project's CLAUDE.md "Information architecture" section for the full placement rules.
 
-   **Diataxis separation**: create separate pages per document type, not one combined page:
+   **Diataxis separation**: keep document types distinct, but apply this at the right granularity. The rule is that concept and how-to content stay distinguishable, not that every feature gets its own page set. For a genuinely standalone capability, create separate pages per document type rather than one combined page. For a feature that extends existing documentation, a new section of the appropriate type _within_ an existing page is usually correct and preferable to a new page; don't fragment a concept across a new standalone page just to satisfy the separation rule. The page types below describe the content each type should contain, whether it lives on its own page or as a section:
    - **Concept page** (explanation): What is this feature, why does it exist, when would you use it? Lead with concrete scenarios and user personas ("If you maintain a shared MCP registry and want to let teams publish reusable tool bundles..."). Explain relationships to existing features.
    - **Guide page** (how-to): Task-oriented, organized by user goals, not by API endpoint order. Include practical examples: realistic `curl` commands, sample payloads with plausible values, expected responses, and error cases. If a feature has both producer and consumer sides, document both workflows.
    - **Reference page**: Only create if not already auto-generated. If auto-generated API reference exists, link to it instead of duplicating endpoint listings.
@@ -214,17 +291,25 @@ Apply the approved changes:
 
 1. **Re-verify every factual claim** against source code at the tag. This is the third verification pass (after Phase 2 and Phase 4). For large doc sets, spawn parallel verification agents (one per file or topic area) to check all claims concurrently. Each agent should read the doc file and verify every factual claim (struct fields, API routes, defaults, behavioral logic) against the actual source code at the release tag. Collect and resolve any discrepancies before proceeding.
 
-2. **Build the site**: run the project's build command to check for broken links, missing references, or build errors.
+   This pass **must extend beyond the files you changed.** Stale claims live in pages the release did not touch, which is exactly why they get missed: per-changed-file verification can never surface a contradiction in a file that has no diff. For every concept introduced or changed this release, re-grep the displaced concept's vocabulary and the exclusivity/temporal phrases from Phase 3 across the entire docs set, and verify each surviving statement against the new source-of-truth behavior. If any page still asserts the old mechanism is the only, default, automatic, or planned-future option, it is a defect even though it is not in your diff. Spawn a verification agent dedicated to this displacement check, separate from the per-file agents.
 
-3. **Run linting**: execute the project's lint/format commands.
+2. **Verify completeness, not just accuracy.** The pass above confirms that what you wrote is _true_; this pass confirms that what the release _shipped_ is covered. Accurate-but-partial documentation (a correct new section that explains half a feature's surface) passes every accuracy check and is the most common silent failure of this workflow, because nothing in an accuracy review flags an omission. Take the new-public-surface inventory from Phase 2 and confirm each symbol is either:
+   - documented in prose (a guide, concept, or reference page mentions and explains it), or
+   - consciously deferred, with the reason recorded (auto-generated reference only, hidden/experimental, or a deferral entry).
 
-4. **Run `/docs-review`**: invoke the docs-review skill on all changed and new files to catch style, structure, and clarity issues. When the review returns, **do not stop or present the findings to the user**. Instead, immediately apply every actionable fix yourself:
+   Any inventoried symbol that is neither documented nor deferred is a coverage gap: document it, or record why not. Do not let a symbol fall through silently. A section that documents a feature's happy path but omits its flags, enum values, or config knobs is incomplete even when every sentence in it is accurate. For large surfaces, spawn a coverage agent that takes the inventory and the changed/related doc files and returns, per symbol, "documented at `file:line`" or "not found."
+
+3. **Build the site**: run the project's build command to check for broken links, missing references, or build errors.
+
+4. **Run linting**: execute the project's lint/format commands.
+
+5. **Run `/docs-review`**: invoke the docs-review skill on all changed and new files to catch style, structure, and clarity issues. When the review returns, **do not stop or present the findings to the user**. Instead, immediately apply every actionable fix yourself:
    - For primary issues: edit the files to resolve them.
    - For secondary issues and inline suggestions: apply the fixes directly.
    - For items you disagree with (e.g., they conflict with verified source code): do not apply the suggestion, but briefly log each skipped item with a source-verified reason for auditability.
    - After applying fixes, re-run formatting/linting to ensure the fixes are clean.
 
-5. Fix any remaining issues found in the build or lint steps. Re-run validation until clean.
+6. Fix any remaining issues found in the build or lint steps. Re-run validation until clean.
 
 ## Phase 6: Handle Review Feedback
 
@@ -241,11 +326,13 @@ When receiving review comments (from humans or automated reviewers):
 ## Key Principles
 
 - **Triple verification**: verify during deep dive (Phase 2), before finalizing (Phase 5), and when handling reviews (Phase 6)
+- **Document what the release falsifies, not just what it adds**: a new capability that extends or replaces an existing one almost always makes prior "only / default / automatic / planned" statements wrong. Audit the _displaced_ concept's vocabulary (the old mechanism's terms) across the whole docs set, not just the new feature's name. A purely additive (`+N / -0`) edit to a prose page is a smell that a contradiction was left unreconciled. The reviewer cannot catch a sin of omission in a zero-deletion diff; the skill must.
 - **Transparency**: log the categorized summary (after Phase 1) and impact map (after Phase 3) for auditability, but do not stop; run all phases to completion
 - **Respect auto-generated content**: don't manually edit auto-generated files, but always create the surrounding conceptual/guide content that auto-generated reference docs don't provide
-- **Separate by Diataxis type**: never combine concepts and how-to guides in a single page. Create separate pages for each document type.
+- **Separate by Diataxis type, at the right granularity**: keep concept and how-to content distinguishable. For standalone capabilities that means separate pages per type; for features that extend existing docs, a new section of the right type within the existing page is preferable to a new standalone page. Prefer extending an existing page over creating a new one when the feature extends a documented capability, and reserve new pages for genuinely standalone capabilities. This is a default, not a mandate: split a section out to its own page (with a summary and cross-link left behind) when it is a distinct subject, has its own full how-to lifecycle, or would overload an already-long host page. The test is shared subject and a focused page, not extend-versus-new in the abstract.
+- **Verify completeness, not just accuracy**: accuracy checks confirm what you wrote is true; they never catch what you left out. Inventory the release's new public surface (fields, flags, enum values, config keys, routes) in Phase 2 and confirm in Phase 5 that each symbol is documented or consciously deferred. An accurate section that covers only part of a feature's surface is the most common silent failure of this workflow.
 - **Document the full lifecycle**: if a feature has producer and consumer sides, document both. Always answer "then what?" Readers who follow the docs to completion must not hit a dead end. If consumption tooling isn't built yet, say so explicitly.
-- **Ask for context on major features**: for entirely new capabilities, don't fabricate the "why" from code alone. Ask the user for user stories, PRDs, or RFCs. Incremental changes can proceed autonomously, but big feature introductions need human input to capture product intent and voice.
+- **Ask for context on major features**: for entirely new capabilities, don't fabricate the "why" from code alone. In interactive mode, ask the user for user stories, PRDs, or RFCs. In unattended mode, derive the "why" from PR bodies and linked issues best-effort and defer to `GAPS.md` only when it is genuinely underivable (see [Execution modes](#execution-modes)). Incremental changes can proceed autonomously in either mode.
 - **Lead with scenarios, not abstractions**: open concept pages with concrete "who is this for and why should they care" scenarios, not abstract definitions
 - **Flag gaps honestly**: if consumption tooling, client support, or integration isn't ready yet, say so explicitly rather than omitting the topic
 - **Use realistic examples**: guide pages need end-to-end examples with plausible data, exact commands, and expected output, not placeholder values

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -514,9 +514,7 @@ jobs:
             --max-turns 1000
             --allowed-tools "Bash(gh:*) Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
           prompt: |
-            You are running in GitHub Actions with no interactive user. Follow
-            these steps exactly and do NOT ask clarifying questions -- proceed
-            best-effort at every decision point.
+            You are running in GitHub Actions with no interactive user.
 
             PROJECT:    ${{ steps.detect.outputs.id }}
             REPO:       ${{ steps.detect.outputs.repo }}
@@ -525,112 +523,33 @@ jobs:
             CLONE:      ${{ steps.clone.outputs.scratch_dir }}
             DOCS_HINTS: ${{ steps.hints.outputs.docs_paths }}
 
-            Run /upstream-release-docs ${{ steps.detect.outputs.repo }} ${{ steps.detect.outputs.new_tag }}
-            Execute all 6 phases. Prefer reading source code from the
-            local clone at ${{ steps.clone.outputs.scratch_dir }}
-            instead of `gh api contents?ref=<tag>` -- it's already at
-            the tag and doesn't consume API quota.
+            Run /upstream-release-docs ${{ steps.detect.outputs.repo }} ${{ steps.detect.outputs.new_tag }} in unattended mode.
+            Execute all 6 phases. Do NOT ask clarifying questions;
+            proceed best-effort at every decision point. The skill's
+            "Execution modes" section is the single source of truth for
+            unattended behavior and the GAPS.md / SUMMARY.md /
+            NO_CHANGES.md artifact contracts (their format, when to
+            write each, and what to exclude). Follow it; this prompt
+            deliberately no longer duplicates those contracts.
 
-            For Phase 2 step 4 (context on major new features), do the
-            following INSTEAD of the skill's default "ask the user"
-            behavior (there is no interactive user here):
-              1. Use `gh pr view <NUMBER> --repo ${{ steps.detect.outputs.repo }}
-                 --json title,body,author` to fetch the PR description
-                 for each major new feature. The PR body typically
-                 contains the "why" framing the author wrote when
-                 opening the PR -- motivation, intended consumers,
-                 design decisions.
-              2. If the PR body references linked issues (look for
-                 "Closes #N", "Fixes #N", "Refs #N"), fetch those
-                 with `gh issue view <N> --repo ${{ steps.detect.outputs.repo }}`
-                 when they are likely to contain product context.
-              3. Write the "why"/consumer narrative directly in the
-                 relevant docs page using what you learned. This is a
-                 best-effort pass -- reviewers will refine it during
-                 normal review.
-              4. Only defer to GAPS.md when the rationale demonstrably
-                 cannot be derived from available sources. Genuine
-                 examples: the PR body points to an internal design
-                 doc or product spec you cannot access; multiple
-                 plausible consumer narratives exist and picking one
-                 would mislead readers; a release timeline or
-                 commitment needs product-team confirmation.
+            Prefer reading source code from the local clone at
+            ${{ steps.clone.outputs.scratch_dir }} instead of
+            `gh api contents?ref=<tag>` -- it's already at the tag and
+            doesn't consume API quota. Do not hand-edit auto-generated
+            reference under docs/toolhive/reference/cli/,
+            docs/toolhive/reference/crds/, or static/api-specs/ --
+            earlier workflow steps sync those from release assets.
 
-            GAPS.md contract (only if you genuinely need to defer):
-              - ONLY include content gaps a human reviewer must fill
-                in. Do NOT include environment/sandbox limitations
-                (e.g. "couldn't run npm build") -- those are
-                infrastructure concerns; the PR's CI handles them.
-                Do NOT include "not a gap, documented for clarity"
-                commentary.
-              - Each entry MUST include a "Helper prompt for local
-                Claude" block a reviewer can paste verbatim into
-                their local Claude Code to resolve the gap. The
-                prompt must reference the specific file(s) to edit,
-                the PR number that provides context, and the narrow
-                piece of information the human needs to supply or
-                confirm.
-              - Each entry MUST @-mention the PR author (skip this
-                for bot authors: renovate[bot], github-actions[bot],
-                stacklokbot).
-
-            GAPS.md entry format:
-              ```
-              ### <Feature name> (PR #123 by @alice)
-
-              <One paragraph: what's missing, why you couldn't
-              resolve it from available sources.>
-
-              **File(s):** path/to/file.mdx
-
-              **Helper prompt for local Claude:**
-              > <Paste-ready prompt. Self-contained. References the
-              > specific file(s), the PR number, and the narrow
-              > piece of info needed. A human should be able to
-              > paste this into `claude` locally and get a usable
-              > response without additional context.>
-              ```
-
-            Do NOT create GAPS.md if every feature's "why" was
-            resolvable from PR descriptions. An empty GAPS.md is
-            worse than no file.
-
-            Follow the skill's own guidance on auto-generated reference
-            files (Phase 4 step 5, Phase 4 step 6) -- do not hand-edit
-            docs/toolhive/reference/cli/, static/api-specs/, or
-            docs/toolhive/reference/crds/. Those are synced or
-            regenerated from release assets by earlier steps in this
-            workflow; if a release genuinely needs hand-written
-            reference updates, note that in GAPS.md.
-
-            If you conclude there are no doc-relevant changes for this
-            release (Phase 3 impact map is empty), stop and write
-            NO_CHANGES.md at repo root with a one-line explanation.
-            Still do not hand-edit any file.
-
-            BEFORE the final commit in Phase 6, write SUMMARY.md at
-            repo root with a concise bullet list of changes you made
-            on the docs side. This surfaces directly in the PR body
-            as a "Summary of changes" section so reviewers see what
-            actually shipped without clicking the diff.
-
-            Format each bullet as one of:
-              - `Added <what> at <path>` -- new pages/sections
-              - `Updated <what> in <path>` -- meaningful prose edits
-              - `Swept <what> across N files in <area>` -- repo-wide
-                renames, apiVersion bumps, etc.
-              - `Removed <what> from <path>` -- deletions
-
-            Keep the list to 3-8 bullets. Focus on what a reviewer
-            needs to know, not how you did it. If many files are
-            touched as one logical change (e.g. a v1alpha1 ->
-            v1beta1 apiVersion sweep), describe it as one bullet --
-            do not enumerate each file. Do NOT include bullets for
-            auto-generated reference files the refresh step
-            updated; only describe your hand-written edits.
-
-            Skip SUMMARY.md only when you wrote NO_CHANGES.md or
-            made zero hand-edits.
+            Project dependencies are already installed by an earlier
+            workflow step; node_modules is present in the working tree.
+            Run `npm run prettier:fix` and `npm run eslint:fix`
+            directly to format and lint your edits. Do NOT run
+            `npm ci` or `npm install` -- they are unnecessary here and
+            not in the allow-list; if a lint command appears to require
+            a fresh install, it does not. Do not defer formatting to
+            CI: the lint and format CI checks do not run on commits
+            pushed by this bot account. Format your edits in this
+            session.
 
       # Capture skill_gen's execution stats BEFORE skill_review runs
       # and overwrites the shared execution-output JSON at the
@@ -721,6 +640,17 @@ jobs:
             changed (use `git show --name-only HEAD` or `git diff
             --name-only HEAD~1 HEAD` to find them). Apply every
             actionable fix per the skill's standard guidance.
+
+            Project dependencies are already installed by an earlier
+            workflow step; node_modules is present in the working tree.
+            Run `npm run prettier:fix` and `npm run eslint:fix`
+            directly to format and lint your edits. Do NOT run
+            `npm ci` or `npm install` -- they are unnecessary here and
+            not in the allow-list; if a lint command appears to require
+            a fresh install, it does not. Do not defer formatting to
+            CI: the lint and format CI checks do not run on commits
+            pushed by this bot account. Format your edits in this
+            session.
 
             If you spot a factual concern, re-verify against the
             local clone at ${{ steps.clone.outputs.scratch_dir }}
@@ -847,6 +777,10 @@ jobs:
         env:
           BASELINE_SHA: ${{ steps.pre_skill.outputs.sha }}
         run: |
+          # GAPS.md / NO_CHANGES.md / SUMMARY.md filenames and their
+          # repo-root location are a contract with the skill. The skill's
+          # "Execution modes" section owns the format and write conditions;
+          # keep these names in sync with that section if either changes.
           GAPS_BODY=""
           NO_CHANGES_BODY=""
           SUMMARY_BODY=""


### PR DESCRIPTION
### Description

Improvements to the `upstream-release-docs` skill and its CI workflow, prompted by reviewing how #915 documented the CIMD feature: it added an accurate new section but left several existing pages asserting DCR as the only client-registration method, which the release made false.

The skill was good at turning a release delta into new sections but blind to two things: what a release makes _false_ in existing prose, and whether a new section actually covers the feature's full surface. Three reinforcing guards address that:

- **Displacement audit (Phase 3).** When a feature extends or replaces a documented capability, grep the _displaced_ concept's vocabulary and exclusivity/temporal phrasing ("only", "currently implements", "is planned") to find statements the release now contradicts. Purely additive (`+N / -0`) prose edits are flagged as a smell, and the Phase 5 re-verify pass now extends beyond changed files.
- **Completeness pass (Phase 2 + Phase 5).** Inventory the new public surface (fields, flags, enum values, config keys, routes) and verify each symbol is documented or consciously deferred. Accuracy checks never catch omissions.
- **Extend-existing bias (Phase 4).** Prefer adding a section to an existing page over a standalone page when a feature extends a documented capability, with a density guard for when to split a section out instead.

Also consolidates the unattended-mode contract into a new "Execution modes" section so the skill owns the `GAPS.md` / `SUMMARY.md` / `NO_CHANGES.md` formats instead of duplicating them in the workflow YAML, with explicit interactive-mode gating so a local run never writes those handoff artifacts.

On the workflow side: the generation prompt drops ~100 duplicated lines in favor of a pointer to the skill, and both prompts now tell the model that dependencies are pre-installed, to run the linters directly (not `npm ci`), and not to defer to CI lint, which doesn't run on bot-pushed commits.

### Type of change

- Tooling / automation change (skill + CI workflow; no documentation content changes)

### Related issues/PRs

- Context: #915 (CIMD docs), #911 (feature author's CIMD docs)

### Notes for reviewers

- No site content changed, so no sidebar/redirect/frontmatter impact.
- `SKILL.md` and the workflow prompt edits don't run in CI here; they take effect on the next automated release-docs run.