### PR TITLE
Remove `group_entity_type` Cedar docs

### DIFF
--- a/docs/toolhive/concepts/cedar-policies.mdx
+++ b/docs/toolhive/concepts/cedar-policies.mdx
@@ -116,11 +116,6 @@ cedar:
     separate from group claims. Use this when your identity provider provides
     roles in a different claim than groups (for example, Entra ID `roles`
     claim). If not set, roles are extracted from the same claims as groups.
-  - `group_entity_type`: Optional Cedar entity type name used for principal
-    parent UIDs synthesized from JWT group and role claims. Defaults to
-    `THVGroup`. Set this when your entity store uses a different type name (for
-    example, `ClaimGroup`) so transitive `in` checks resolve against the
-    entities you provide in `entities_json`.
 
 ## Writing effective policies
 
@@ -570,36 +565,6 @@ With both fields configured, ToolHive extracts group membership from the
 `groups` claim and role membership from the `roles` claim. Both are mapped to
 `THVGroup` parent entities, so you can write policies that reference either
 groups or roles using the same `principal in THVGroup::"..."` syntax.
-
-### Customizing the group entity type
-
-By default, group and role claims are mapped to `THVGroup` parent entities. If
-your authorization model uses a static entity store (provided through
-`entities_json`) with a different entity type, set `group_entity_type` so the
-synthesized principal parents match the entities defined in your store. For
-example, you might want `ClaimGroup` entities synthesized from JWT claims to
-belong to `PlatformRole` parents defined in your entity store:
-
-```json
-{
-  "version": "1.0",
-  "type": "cedarv1",
-  "cedar": {
-    "policies": [
-      "permit(principal in PlatformRole::\"admin\", action, resource);"
-    ],
-    "entities_json": "[{\"uid\": {\"type\": \"ClaimGroup\", \"id\": \"engineering\"}, \"parents\": [{\"type\": \"PlatformRole\", \"id\": \"admin\"}]}]",
-    "group_claim_name": "groups",
-    "group_entity_type": "ClaimGroup"
-  }
-}
-```
-
-Without `group_entity_type`, Cedar synthesizes `THVGroup::"engineering"`
-principal parents, which do not match the `ClaimGroup` entities in
-`entities_json`. Transitive `in` checks against `PlatformRole` silently evaluate
-to false, so every request is denied. Setting `group_entity_type` aligns the
-synthesized parents with your entity store.
 
 ### How it works
 

--- a/docs/toolhive/reference/authz-policy-reference.mdx
+++ b/docs/toolhive/reference/authz-policy-reference.mdx
@@ -319,37 +319,6 @@ cedar:
   entities_json: '[]'
 ```
 
-### Customizing the group entity type
-
-By default, group and role claims become `THVGroup` parent entities. If your
-authorization model defines a static entity store (provided through
-`entities_json`) using a different entity type, set `group_entity_type` so the
-synthesized parents match. This is required for transitive policies that walk a
-hierarchy such as `ClaimGroup in PlatformRole`:
-
-```yaml title="authz-config.yaml"
-version: '1.0'
-type: cedarv1
-cedar:
-  group_claim_name: 'groups'
-  group_entity_type: 'ClaimGroup'
-  policies:
-    - 'permit(principal in PlatformRole::"admin", action, resource);'
-  entities_json: |
-    [
-      {
-        "uid": {"type": "ClaimGroup", "id": "engineering"},
-        "parents": [{"type": "PlatformRole", "id": "admin"}]
-      }
-    ]
-```
-
-Without `group_entity_type`, Cedar synthesizes `THVGroup::"engineering"` for the
-principal's parent. Because the entity store contains `ClaimGroup` entries, the
-transitive `in PlatformRole` check evaluates to false and every request is
-denied. Namespaced names (`Foo::Bar`) are not supported; the type must be a bare
-Cedar identifier.
-
 ### How roles are resolved
 
 In addition to group claims, ToolHive can extract role claims from a separate


### PR DESCRIPTION
### Description
The field is an internal knob we decided not to surface in user-facing docs; it was re-added by the v0.28.3 upstream-release-docs run.

### Type of change
Bug fix (typo, broken link, etc.)

### Related issues/PRs
Closes #916.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
