### PR TITLE
Add MCPRegistry CRD deprecation notices

### DIFF
--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -5,6 +5,20 @@ description:
   Operator
 ---
 
+:::warning[MCPRegistry CRD is deprecated]
+
+The `MCPRegistry` CRD is deprecated and superseded by the
+[toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
+Helm chart, which installs the Registry Server directly. The CRD remains fully
+functional for now, but it will be removed in a future release. When you create
+or update an `MCPRegistry` resource, `kubectl` prints a deprecation warning and
+the operator emits a warning event recommending the Helm chart.
+
+For new deployments, use [Deploy with Helm](./deploy-helm.mdx) instead. Existing
+deployments continue to work without changes.
+
+:::
+
 ## Prerequisites
 
 - A Kubernetes cluster (current and two previous minor versions are supported)

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -25,20 +25,21 @@ description:
 The Registry Server can be deployed in Kubernetes using three methods. Choose
 the one that fits your environment:
 
-| Method                                  | Description                                                        |
-| --------------------------------------- | ------------------------------------------------------------------ |
-| [ToolHive Operator](#toolhive-operator) | Manage the Registry Server lifecycle through `MCPRegistry` CRDs    |
-| [Helm](#helm)                           | Deploy a standalone Registry Server using its dedicated Helm chart |
-| [Manual manifests](#manual-manifests)   | Deploy directly using raw Kubernetes manifests                     |
+| Method                                  | Description                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------- |
+| [Helm](#helm)                           | Deploy a standalone Registry Server using its dedicated Helm chart           |
+| [ToolHive Operator](#toolhive-operator) | Manage the Registry Server lifecycle through `MCPRegistry` CRDs (deprecated) |
+| [Manual manifests](#manual-manifests)   | Deploy directly using raw Kubernetes manifests                               |
 
-## ToolHive Operator
+:::warning[MCPRegistry CRD is deprecated]
 
-Deploy and manage the Registry Server using `MCPRegistry` custom resources. The
-ToolHive Operator watches for these resources and creates the necessary
-infrastructure automatically.
+The `MCPRegistry` CRD used by the ToolHive Operator method is deprecated and
+superseded by the
+[toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
+Helm chart. The CRD remains fully functional for now, but it will be removed in
+a future release. For new deployments, use the [Helm](#helm) method instead.
 
-See [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a complete
-guide.
+:::
 
 ## Helm
 
@@ -48,6 +49,23 @@ repository. Use this method when you want to manage the Registry Server like any
 other Helm release without installing the ToolHive Operator.
 
 See [Deploy with Helm](./deploy-helm.mdx) for a complete guide.
+
+## ToolHive Operator
+
+:::warning[Deprecated]
+
+This method relies on the `MCPRegistry` CRD, which is deprecated in favor of the
+[Helm](#helm) deployment method. It remains functional but will be removed in a
+future release.
+
+:::
+
+Deploy and manage the Registry Server using `MCPRegistry` custom resources. The
+ToolHive Operator watches for these resources and creates the necessary
+infrastructure automatically.
+
+See [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a complete
+guide.
 
 ## Manual manifests
 
@@ -60,10 +78,11 @@ See [Deploy manually](./deploy-manual.mdx) for instructions.
 
 Pick the deployment method that fits your environment and follow its guide:
 
-- [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a CRD-driven
-  workflow
 - [Deploy with Helm](./deploy-helm.mdx) for a standalone chart-based install
+  (recommended)
 - [Deploy manually](./deploy-manual.mdx) for raw Kubernetes manifests
+- [Deploy with the ToolHive Operator](./deploy-operator.mdx) for a CRD-driven
+  workflow (deprecated)
 
 Then configure the rest of the stack:
 


### PR DESCRIPTION
### Description

The `MCPRegistry` CRD is deprecated and superseded by the [toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server) Helm chart, which installs the Registry Server directly. The CRD remains fully functional for now but will be removed in a future release.

This adds user-facing deprecation notices in the registry section, in the two spots recommended by the maintainer:

- **`guides-registry/deployment.mdx`** (deployment landing page): reordered the methods table to lead with Helm and tagged the ToolHive Operator row as `(deprecated)`; added a top-level warning callout; added a per-section warning under **ToolHive Operator**; reordered **Next steps** so Helm is recommended first and the Operator (deprecated) last.
- **`guides-registry/deploy-operator.mdx`** (CRD-specific page): added a prominent warning admonition after the front matter noting the CRD is deprecated, that `kubectl` and the operator now emit deprecation warnings, and that new deployments should use Helm while existing deployments keep working.

### Type of change

- Documentation update

### Related issues/PRs

- Documents the deprecation introduced in stacklok/toolhive#5470 (PR 1 of 2). A follow-up upstream PR plans a dedicated migration guide; when that lands, it would be worth adding a migration page here and linking these warnings to it.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)