### PR TITLE
Add MCPRegistry to Helm migration guide

### DIFF
--- a/docs/toolhive/guides-registry/deploy-helm.mdx
+++ b/docs/toolhive/guides-registry/deploy-helm.mdx
@@ -7,9 +7,11 @@ description:
 
 :::info
 
-For alternative deployment approaches, see
-[Deploy with the ToolHive Operator](./deploy-operator.mdx) or
-[Deploy manually](./deploy-manual.mdx).
+Helm is the recommended way to deploy the Registry Server. For an alternative
+approach, see [Deploy manually](./deploy-manual.mdx). The
+[ToolHive Operator method](./deploy-operator.mdx) is deprecated; if you're
+currently using it, see
+[Migrate from the operator to Helm](./migrate-to-helm.mdx).
 
 :::
 

--- a/docs/toolhive/guides-registry/deploy-helm.mdx
+++ b/docs/toolhive/guides-registry/deploy-helm.mdx
@@ -84,8 +84,11 @@ where to find it.
 
 The chart's main container runs with `readOnlyRootFilesystem: true` as the
 non-root UID `65535`, so the init container copies the Secret into an `emptyDir`
-volume and applies `0600` permissions (libpq rejects pgpass files with wider
-permissions):
+volume and applies `0600` permissions there (libpq rejects pgpass files with
+wider permissions). Leave the `pgpass-secret` volume at its default mode:
+Kubernetes mounts Secret files owned by root, so a restrictive `defaultMode`
+such as `0600` would make the file unreadable by UID `65535` and the init
+container would fail to copy it.
 
 ```yaml title="values.yaml (excerpt)"
 extraEnv:
@@ -96,7 +99,6 @@ extraVolumes:
   - name: pgpass-secret
     secret:
       secretName: registry-pgpass
-      defaultMode: 0600
   - name: pgpass-prepared
     emptyDir: {}
 

--- a/docs/toolhive/guides-registry/deploy-operator.mdx
+++ b/docs/toolhive/guides-registry/deploy-operator.mdx
@@ -14,8 +14,10 @@ functional for now, but it will be removed in a future release. When you create
 or update an `MCPRegistry` resource, `kubectl` prints a deprecation warning and
 the operator emits a warning event recommending the Helm chart.
 
-For new deployments, use [Deploy with Helm](./deploy-helm.mdx) instead. Existing
-deployments continue to work without changes.
+For new deployments, use [Deploy with Helm](./deploy-helm.mdx) instead. To move
+an existing operator-managed registry to the Helm chart, see
+[Migrate from the operator to Helm](./migrate-to-helm.mdx). Existing deployments
+continue to work without changes.
 
 :::
 

--- a/docs/toolhive/guides-registry/deployment.mdx
+++ b/docs/toolhive/guides-registry/deployment.mdx
@@ -37,7 +37,9 @@ The `MCPRegistry` CRD used by the ToolHive Operator method is deprecated and
 superseded by the
 [toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
 Helm chart. The CRD remains fully functional for now, but it will be removed in
-a future release. For new deployments, use the [Helm](#helm) method instead.
+a future release. For new deployments, use the [Helm](#helm) method instead. To
+move an existing operator-managed registry, see
+[Migrate from the operator to Helm](./migrate-to-helm.mdx).
 
 :::
 

--- a/docs/toolhive/guides-registry/migrate-to-helm.mdx
+++ b/docs/toolhive/guides-registry/migrate-to-helm.mdx
@@ -1,0 +1,196 @@
+---
+title: Migrate from the operator to Helm
+description:
+  Migrate an operator-managed MCPRegistry deployment to the standalone Registry
+  Server Helm chart
+---
+
+The `MCPRegistry` CRD and the operator-managed deployment method are deprecated
+in favor of the
+[toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server)
+Helm chart, which installs the Registry Server directly. This guide walks you
+through moving an existing operator-managed registry to the Helm chart.
+
+The CRD remains fully functional for now, so you can migrate at your own pace.
+This guide uses a parallel cutover: you deploy the Helm release alongside your
+existing `MCPRegistry`, verify it, repoint clients, and only then remove the
+CRD-managed deployment.
+
+:::info[Why migrate?]
+
+The Helm chart manages the Registry Server like any other Helm release, without
+requiring the ToolHive Operator. The `MCPRegistry` CRD will be removed in a
+future release. Migrating now avoids a forced cutover later.
+
+:::
+
+## Before you begin
+
+- A Kubernetes cluster with an existing operator-managed `MCPRegistry` resource
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
+  with your cluster
+- [Helm](https://helm.sh/docs/intro/install/) v3.10 or later (v3.14+ is
+  recommended)
+- Access to the same PostgreSQL database your `MCPRegistry` currently uses
+
+Both deployment methods read the same
+[Registry Server configuration](./configuration.mdx) and connect to the same
+PostgreSQL schema, so the Helm release can reuse your existing database without
+a data migration.
+
+## How configuration maps
+
+The operator wraps the Registry Server's configuration in the `MCPRegistry`
+spec. The Helm chart exposes the same configuration directly in its values file.
+The table below maps each `MCPRegistry` field to its Helm equivalent.
+
+| `MCPRegistry` spec field          | Helm values field                           |
+| --------------------------------- | ------------------------------------------- |
+| `spec.configYAML`                 | `config` (as structured YAML, not a string) |
+| `spec.pgpassSecretRef`            | pgpass Secret + init container (see below)  |
+| `spec.podTemplateSpec.…resources` | `resources`                                 |
+| `spec.volumes`                    | `extraVolumes`                              |
+| `spec.volumeMounts`               | `extraVolumeMounts`                         |
+| `spec.displayName`                | No equivalent (metadata only; omit)         |
+
+The most important change is `configYAML`: in the CRD it's a YAML string, while
+in the Helm chart the same content goes under `config` as a structured block.
+The schema under both is identical.
+
+## Step 1: Capture your existing configuration
+
+Export your current `MCPRegistry` resource so you can copy its configuration:
+
+```bash
+kubectl -n <NAMESPACE> get mcpregistry <NAME> -o yaml > mcpregistry-backup.yaml
+```
+
+Note the value of `spec.configYAML`. This is the configuration you'll move into
+the Helm values file. Also note the namespace and any database settings so the
+Helm release connects to the same PostgreSQL instance.
+
+## Step 2: Build the Helm values file
+
+Create a `values.yaml` file and copy the contents of `spec.configYAML` under the
+`config` key. For example, an `MCPRegistry` with this spec:
+
+```yaml title="mcpregistry-backup.yaml (excerpt)"
+spec:
+  displayName: My MCP Registry
+  configYAML: |
+    sources:
+      - name: toolhive
+        git:
+          repository: https://github.com/stacklok/toolhive-catalog.git
+          branch: main
+          path: pkg/catalog/toolhive/data/registry-upstream.json
+        syncPolicy:
+          interval: '30m'
+    registries:
+      - name: default
+        sources: ['toolhive']
+    auth:
+      mode: anonymous
+```
+
+becomes this Helm values file:
+
+```yaml title="values.yaml"
+config:
+  sources:
+    - name: toolhive
+      git:
+        repository: https://github.com/stacklok/toolhive-catalog.git
+        branch: main
+        path: pkg/catalog/toolhive/data/registry-upstream.json
+      syncPolicy:
+        interval: '30m'
+  registries:
+    - name: default
+      sources: ['toolhive']
+  auth:
+    mode: anonymous
+```
+
+If your `MCPRegistry` used `pgpassSecretRef` for database credentials, the Helm
+chart provides the same credentials through a pgpass Secret and an init
+container that prepares the file. See
+[Provide database credentials](./deploy-helm.mdx#provide-database-credentials)
+for the complete pattern, then add the `extraEnv`, `extraVolumes`,
+`extraVolumeMounts`, and `initContainers` blocks to your values file.
+
+## Step 3: Deploy the Helm release
+
+Install the chart into the same namespace as your existing registry. Use a
+release name that doesn't collide with the operator-managed resources:
+
+```bash
+helm upgrade --install registry-server \
+  oci://ghcr.io/stacklok/toolhive-registry-server \
+  -n <NAMESPACE> --create-namespace \
+  -f values.yaml
+```
+
+Because both deployments point at the same database, the Helm-managed pod runs
+against your existing data. See [Deploy with Helm](./deploy-helm.mdx) for the
+full set of chart values and their defaults.
+
+## Step 4: Verify the new deployment
+
+Confirm the Helm-managed Registry Server pod is running and healthy:
+
+```bash
+kubectl -n <NAMESPACE> get pods -l app.kubernetes.io/instance=registry-server
+```
+
+Port-forward to the new service and check that it serves registry data:
+
+```bash
+kubectl -n <NAMESPACE> port-forward svc/registry-server 8080:80
+curl http://localhost:8080/v0/servers
+```
+
+The Helm release creates a service named after the release (for example,
+`registry-server`), which differs from the service the operator created for your
+`MCPRegistry`. Note the new service name and endpoint for the next step.
+
+## Step 5: Repoint clients
+
+Update any clients, ingress rules, or `VirtualMCPServer` backends that reference
+the old operator-managed service so they point at the new Helm-managed service
+endpoint. Roll out and verify these changes while the old deployment is still
+running, so you can fall back if needed.
+
+## Step 6: Remove the MCPRegistry resource
+
+Once clients are using the Helm-managed Registry Server and you've confirmed
+it's healthy, delete the `MCPRegistry` resource. The operator removes the
+deployment, service, and RBAC resources it created:
+
+```bash
+kubectl -n <NAMESPACE> delete mcpregistry <NAME>
+```
+
+Deleting the `MCPRegistry` does not affect the database, so your registry data
+remains intact for the Helm-managed server.
+
+If the operator is no longer managing any other resources, you can optionally
+uninstall it. See [Deploy the operator](../guides-k8s/deploy-operator.mdx) for
+details on what the operator manages before removing it.
+
+## Next steps
+
+- [Configure sources and registries](./configuration.mdx) to adjust your data
+  sources and sync policies
+- [Set up authentication](./authentication.mdx) to secure access to your
+  registry
+- [Configure telemetry](./telemetry-metrics.mdx) to monitor your deployment
+
+## Related information
+
+- [Deploy with Helm](./deploy-helm.mdx) - Full reference for the Registry Server
+  Helm chart
+- [Deploy the Registry Server](./deployment.mdx) - Overview of all deployment
+  methods
+- [Database configuration](./database.mdx) - PostgreSQL setup and the pgpass
+  format

--- a/docs/toolhive/guides-registry/migrate-to-helm.mdx
+++ b/docs/toolhive/guides-registry/migrate-to-helm.mdx
@@ -44,14 +44,14 @@ The operator wraps the Registry Server's configuration in the `MCPRegistry`
 spec. The Helm chart exposes the same configuration directly in its values file.
 The table below maps each `MCPRegistry` field to its Helm equivalent.
 
-| `MCPRegistry` spec field          | Helm values field                           |
-| --------------------------------- | ------------------------------------------- |
-| `spec.configYAML`                 | `config` (as structured YAML, not a string) |
-| `spec.pgpassSecretRef`            | pgpass Secret + init container (see below)  |
-| `spec.podTemplateSpec.…resources` | `resources`                                 |
-| `spec.volumes`                    | `extraVolumes`                              |
-| `spec.volumeMounts`               | `extraVolumeMounts`                         |
-| `spec.displayName`                | No equivalent (metadata only; omit)         |
+| `MCPRegistry` spec field                           | Helm values field                           |
+| -------------------------------------------------- | ------------------------------------------- |
+| `spec.configYAML`                                  | `config` (as structured YAML, not a string) |
+| `spec.pgpassSecretRef`                             | pgpass Secret + init container (see below)  |
+| `spec.podTemplateSpec.spec.containers[].resources` | `resources`                                 |
+| `spec.volumes`                                     | `extraVolumes`                              |
+| `spec.volumeMounts`                                | `extraVolumeMounts`                         |
+| `spec.displayName`                                 | No equivalent (metadata only; omit)         |
 
 The most important change is `configYAML`: in the CRD it's a YAML string, while
 in the Helm chart the same content goes under `config` as a structured block.
@@ -143,16 +143,26 @@ Confirm the Helm-managed Registry Server pod is running and healthy:
 kubectl -n <NAMESPACE> get pods -l app.kubernetes.io/instance=registry-server
 ```
 
-Port-forward to the new service and check that it serves registry data:
+By default, the chart names the service after the release and chart, in the form
+`<RELEASE_NAME>-toolhive-registry-server`. For the `registry-server` release
+used above, that's `registry-server-toolhive-registry-server`. Confirm the exact
+name:
 
 ```bash
-kubectl -n <NAMESPACE> port-forward svc/registry-server 8080:80
-curl http://localhost:8080/v0/servers
+kubectl -n <NAMESPACE> get svc -l app.kubernetes.io/instance=registry-server
 ```
 
-The Helm release creates a service named after the release (for example,
-`registry-server`), which differs from the service the operator created for your
-`MCPRegistry`. Note the new service name and endpoint for the next step.
+Port-forward to the service (its port defaults to `8080`) and check that it
+serves registry data. Replace `default` with one of the registry names from your
+`config`:
+
+```bash
+kubectl -n <NAMESPACE> port-forward svc/registry-server-toolhive-registry-server 8080:8080
+curl -s http://localhost:8080/registry/default/v0.1/servers | jq .
+```
+
+This service name differs from the one the operator created for your
+`MCPRegistry`. Note it for the next step.
 
 ## Step 5: Repoint clients
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -244,9 +244,10 @@ const sidebars: SidebarsConfig = {
           },
           collapsible: false,
           items: [
-            'toolhive/guides-registry/deploy-operator',
             'toolhive/guides-registry/deploy-helm',
             'toolhive/guides-registry/deploy-manual',
+            'toolhive/guides-registry/deploy-operator',
+            'toolhive/guides-registry/migrate-to-helm',
           ],
         },
         'toolhive/guides-registry/configuration',


### PR DESCRIPTION
### Description

Follow-up to #926. Adds a dedicated guide for migrating an operator-managed `MCPRegistry` deployment to the standalone [toolhive-registry-server](https://github.com/stacklok/toolhive-registry-server) Helm chart, and wires it into the existing deprecation notices.

Changes:

- **New page** `guides-registry/migrate-to-helm.mdx`: a parallel-cutover how-to guide (capture config → map `configYAML` to the chart's `config` block → deploy the release → verify → repoint clients → remove the `MCPRegistry`). Includes a field-mapping table and reuses the existing PostgreSQL database, so no data migration is required.
- **Sidebar**: reordered the "Deploy the Registry Server" children to lead with Helm (recommended), followed by manual, the deprecated operator method, and the new migration guide.
- **Deprecation notices**: linked the migration guide from the warnings in `deployment.mdx` and `deploy-operator.mdx`.
- **Helm page**: reapplied the deprecation note in the intro callout (recommending Helm, flagging the operator method as deprecated, linking the migration guide). This edit was part of #926's branch but did not land in the squash merge, so it's reintroduced here.

### Type of change

- New documentation

### Related issues/PRs

- Follows up #926 and documents the deprecation from stacklok/toolhive#5470.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

#### Navigation

- [x] New pages include a frontmatter section with title and description at a minimum
- [x] Sidebar navigation (`sidebars.ts`) updated for added, deleted, reordered, or renamed files
- [x] Redirects added to `vercel.json` for moved, renamed, or deleted pages (n/a - no URLs changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)