### PR TITLE
Document unauthenticated-by-default proxy behavior

### DIFF
--- a/docs/toolhive/guides-k8s/intro.mdx
+++ b/docs/toolhive/guides-k8s/intro.mdx
@@ -66,17 +66,6 @@ The diagram shows how clients connect to MCP servers through a standard Ingress
 or Gateway. To learn how to expose your MCP servers and connect clients, see
 [Connect clients to MCP servers](./connect-clients.mdx).
 
-:::note[Authentication is not enabled by default]
-
-If you deploy a workload without an authentication source (such as
-`oidcConfigRef`), its proxy accepts every request that can reach it, with no
-token or credential check. This suits local development or clusters already
-isolated behind a trusted network boundary, but to enforce identity-based access
-control per request you must configure authentication. See
-[Authentication and authorization](./auth-k8s.mdx).
-
-:::
-
 ## Which resource type should I use?
 
 The operator introduces resource types for MCP workloads. Choose based on where

--- a/docs/toolhive/guides-k8s/intro.mdx
+++ b/docs/toolhive/guides-k8s/intro.mdx
@@ -66,6 +66,17 @@ The diagram shows how clients connect to MCP servers through a standard Ingress
 or Gateway. To learn how to expose your MCP servers and connect clients, see
 [Connect clients to MCP servers](./connect-clients.mdx).
 
+:::note[Authentication is not enabled by default]
+
+If you deploy a workload without an authentication source (such as
+`oidcConfigRef`), its proxy accepts every request that can reach it, with no
+token or credential check. This suits local development or clusters already
+isolated behind a trusted network boundary, but to enforce identity-based access
+control per request you must configure authentication. See
+[Authentication and authorization](./auth-k8s.mdx).
+
+:::
+
 ## Which resource type should I use?
 
 The operator introduces resource types for MCP workloads. Choose based on where

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -210,8 +210,9 @@ proxy accepts every request that can reach it and forwards it to the remote MCP
 server under a synthetic local-user identity, with no token or credential check.
 This is intended for local development or deployments already isolated behind a
 trusted network boundary (such as a NetworkPolicy or service mesh). To enforce
-identity-based access control per request, set `oidcConfigRef` to reference an
-`MCPOIDCConfig`.
+client authentication, configure an authentication source: set `oidcConfigRef`
+to reference an `MCPOIDCConfig`, or configure an embedded authorization server
+with `authServerRef`.
 
 :::
 

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -203,6 +203,18 @@ When you apply an `MCPRemoteProxy` resource, here's what happens:
 The `oidcConfigRef` field references an MCPOIDCConfig resource that validates
 incoming tokens from users. The proxy supports multiple authentication methods:
 
+:::warning[Authentication is not enabled by default]
+
+If you omit `oidcConfigRef` (and configure no other authentication source), the
+proxy accepts every request that can reach it and forwards it to the remote MCP
+server under a synthetic local-user identity, with no token or credential check.
+This is intended for local development or deployments already isolated behind a
+trusted network boundary (such as a NetworkPolicy or service mesh). To enforce
+identity-based access control per request, set `oidcConfigRef` to reference an
+`MCPOIDCConfig`.
+
+:::
+
 <Tabs groupId='auth-method' queryString='auth-method'>
 <TabItem value='inline' label='MCPOIDCConfig (inline)' default>
 

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -184,6 +184,19 @@ For more examples of `MCPServer` resources, see the
 [example MCP server manifests](https://github.com/stacklok/toolhive/tree/main/examples/operator/mcp-servers)
 in the ToolHive repo.
 
+:::warning[Authentication is not enabled by default]
+
+The example above omits `oidcConfigRef`. If you configure no authentication
+source, the proxy accepts every request that can reach it and forwards it to the
+MCP server under a synthetic local-user identity, with no token or credential
+check. This is intended for local development or deployments already isolated
+behind a trusted network boundary (such as a NetworkPolicy or service mesh). To
+enforce identity-based access control per request, set `oidcConfigRef` to
+reference an `MCPOIDCConfig`. See
+[Authentication and authorization](./auth-k8s.mdx).
+
+:::
+
 ## Automatic RBAC management
 
 The ToolHive operator automatically handles RBAC (Role-Based Access Control) for

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -191,8 +191,9 @@ source, the proxy accepts every request that can reach it and forwards it to the
 MCP server under a synthetic local-user identity, with no token or credential
 check. This is intended for local development or deployments already isolated
 behind a trusted network boundary (such as a NetworkPolicy or service mesh). To
-enforce identity-based access control per request, set `oidcConfigRef` to
-reference an `MCPOIDCConfig`. See
+enforce client authentication, configure an authentication source: set
+`oidcConfigRef` to reference an `MCPOIDCConfig`, or configure an embedded
+authorization server with `authServerRef`. See
 [Authentication and authorization](./auth-k8s.mdx).
 
 :::

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -64,9 +64,10 @@ If you configure no incoming authentication source (no `incomingAuth`, or
 `incomingAuth.type: anonymous`), vMCP accepts every request that can reach it,
 with no token or credential check. This is intended for local development or
 deployments already isolated behind a trusted network boundary (such as a
-NetworkPolicy or service mesh). To enforce identity-based access control per
-request, configure [OIDC authentication](#oidc-authentication) with an
-`MCPOIDCConfig`.
+NetworkPolicy or service mesh). To enforce client authentication, configure an
+incoming authentication source: [OIDC authentication](#oidc-authentication) with
+an `MCPOIDCConfig`, or the
+[embedded authorization server](#embedded-authorization-server).
 
 :::
 

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -58,19 +58,6 @@ strategies.
 
 Configure how clients authenticate to vMCP.
 
-:::warning[Authentication is not enabled by default]
-
-If you configure no incoming authentication source (no `incomingAuth`, or
-`incomingAuth.type: anonymous`), vMCP accepts every request that can reach it,
-with no token or credential check. This is intended for local development or
-deployments already isolated behind a trusted network boundary (such as a
-NetworkPolicy or service mesh). To enforce client authentication, configure an
-incoming authentication source: [OIDC authentication](#oidc-authentication) with
-an `MCPOIDCConfig`, or the
-[embedded authorization server](#embedded-authorization-server).
-
-:::
-
 ### Anonymous (development only)
 
 No authentication required:
@@ -81,11 +68,16 @@ spec:
     type: anonymous
 ```
 
-:::warning
+:::warning[Authentication is not enabled by default]
 
-Do not use `anonymous` authentication in production environments. This setting
-disables all access control, allowing anyone to use the vMCP without
-credentials.
+Anonymous authentication disables all access control, allowing anyone who can
+reach the vMCP to use it without credentials. The same applies if you omit
+`incomingAuth` entirely. This is intended for local development or deployments
+already isolated behind a trusted network boundary (such as a NetworkPolicy or
+service mesh); do not use it in production. To enforce client authentication,
+configure an incoming authentication source:
+[OIDC authentication](#oidc-authentication) with an `MCPOIDCConfig`, or the
+[embedded authorization server](#embedded-authorization-server).
 
 :::
 

--- a/docs/toolhive/guides-vmcp/authentication.mdx
+++ b/docs/toolhive/guides-vmcp/authentication.mdx
@@ -58,6 +58,18 @@ strategies.
 
 Configure how clients authenticate to vMCP.
 
+:::warning[Authentication is not enabled by default]
+
+If you configure no incoming authentication source (no `incomingAuth`, or
+`incomingAuth.type: anonymous`), vMCP accepts every request that can reach it,
+with no token or credential check. This is intended for local development or
+deployments already isolated behind a trusted network boundary (such as a
+NetworkPolicy or service mesh). To enforce identity-based access control per
+request, configure [OIDC authentication](#oidc-authentication) with an
+`MCPOIDCConfig`.
+
+:::
+
 ### Anonymous (development only)
 
 No authentication required:


### PR DESCRIPTION
### Description

A security advisory found that when an `MCPServer` or `MCPRemoteProxy` is deployed **without** `spec.oidcConfigRef` (and no other auth source), the proxy runs **unauthenticated**: it accepts every request that can reach its port and forwards it to the MCP server under a synthetic local-user identity (`iss: toolhive-local`, empty token), with no token or credential check.

The ToolHive team decided this default is **intentional and supported** (local dev, and clusters already isolated behind a trusted network boundary). It is not being changed to fail-closed. The upstream fix (merged PR [stacklok/toolhive#5488](https://github.com/stacklok/toolhive/pull/5488)) only made the behavior **visible and documented**.

This PR adds the matching user-facing callout to the hand-written guides. The callout phrases identity enforcement as conditional on configuring an auth source (never claiming ToolHive enforces identity per request unconditionally).

Guides that received the callout:

- `guides-k8s/remote-mcp-proxy.mdx` (MCPRemoteProxy, primary) - warning in the Authentication configuration section
- `guides-k8s/run-mcp-k8s.mdx` (MCPServer) - warning next to the minimal example, which omits auth
- `guides-k8s/intro.mdx` - concise note with a cross-link to the auth guide
- `guides-vmcp/authentication.mdx` (VirtualMCPServer parity) - warning under Incoming authentication

**CRD reference pages are not hand-edited.** `docs/toolhive/reference/crds/*.mdx` and `static/api-specs/crds/*.schema.json` are generated by `scripts/extract-crd-schemas.mjs` from the upstream ToolHive CRD YAMLs. They will pick up the new `SECURITY` note on the `oidcConfigRef` field automatically on the next upstream-release sync. I confirmed the pinned ToolHive version in `.github/upstream-projects.yaml` is currently `v0.29.1`, whose schema does **not** yet include the SECURITY note - so the reference pages will update once Renovate bumps the pin to a release containing PR #5488 (the normal sync flow). I did not force a version bump.

### Type of change

- Documentation update

### Related issues/PRs

- Mirrors upstream PR stacklok/toolhive#5488
- Security advisory GHSA-hfrv-94x5-85p2

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)