### PR TITLE
Remove feature flag CRD install options

### DIFF
--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -65,23 +65,13 @@ helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/to
 
 #### CRD configuration options
 
-The Helm chart provides fine-grained control over which CRDs are installed. By
-default, all CRDs are installed. You can selectively enable or disable CRD
-groups using these values:
+The Helm chart installs all CRDs by default. You can control CRD installation
+and uninstall behavior using these values:
 
-| Value                     | Description                                           | Default |
-| ------------------------- | ----------------------------------------------------- | ------- |
-| `crds.install.server`     | Install server CRDs (MCPServer, MCPRemoteProxy, etc.) | `true`  |
-| `crds.install.registry`   | Install registry CRDs (MCPRegistry, deprecated)       | `true`  |
-| `crds.install.virtualMcp` | Install vMCP CRDs (VirtualMCPServer, etc.)            | `true`  |
-| `crds.keep`               | Preserve CRDs when uninstalling the chart             | `true`  |
-
-For example, to install only server-related CRDs without vMCP support:
-
-```bash
-helm upgrade --install toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds \
-  -n toolhive-system --set crds.install.virtualMcp=false
-```
+| Value          | Description                               | Default |
+| -------------- | ----------------------------------------- | ------- |
+| `crds.install` | Install the ToolHive CRDs                 | `true`  |
+| `crds.keep`    | Preserve CRDs when uninstalling the chart | `true`  |
 
 :::note
 
@@ -95,8 +85,8 @@ CRDs during uninstall, set `crds.keep=false`.
 </TabItem>
 <TabItem value="kubectl" label="kubectl">
 
-To install the CRDs using `kubectl`, run the following, ensuring you only apply
-the CRDs you need for the features you plan to use:
+To install the CRDs using `kubectl`, run the following. The operator registers
+all controllers, so apply the complete set of CRDs:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml

--- a/docs/toolhive/guides-k8s/deploy-operator.mdx
+++ b/docs/toolhive/guides-k8s/deploy-operator.mdx
@@ -357,8 +357,8 @@ helm upgrade -i toolhive-operator-crds oci://ghcr.io/stacklok/toolhive/toolhive-
 </TabItem>
 <TabItem value="kubectl" label="kubectl">
 
-To upgrade the CRDs using `kubectl`, run the following, ensuring you only apply
-the CRDs you need for the features you want:
+To upgrade the CRDs using `kubectl`, run the following. The operator registers
+all controllers, so apply the complete set of CRDs:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/stacklok/toolhive/refs/tags/v0.21.0/deploy/charts/operator-crds/files/crds/toolhive.stacklok.dev_embeddingservers.yaml


### PR DESCRIPTION
### Description

Upstream PR [stacklok/toolhive#5281](https://github.com/stacklok/toolhive/pull/5281) removed the feature-flag mechanism that allowed selectively installing CRD groups. The granular `crds.install.server`, `crds.install.registry`, and `crds.install.virtualMcp` Helm values were collapsed into a single `crds.install: true` boolean, and all operator controllers now register unconditionally.

This updates the Kubernetes operator deployment guide (`guides-k8s/deploy-operator.mdx`) to match:

- Replaced the "fine-grained control" CRD options table (which listed the three removed `crds.install.*` knobs) with a table covering the surviving values: `crds.install` and `crds.keep`.
- Removed the now-invalid `--set crds.install.virtualMcp=false` example.
- Updated the kubectl install guidance to instruct applying the complete CRD set, since the operator now registers all controllers and a partial set would break it.

### Type of change

- Documentation update

### Related issues/PRs

- Upstream: stacklok/toolhive#5281

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)