### PR TITLE
Document bearer token auth for CLI remote servers

### DIFF
--- a/docs/toolhive/guides-cli/run-mcp-servers.mdx
+++ b/docs/toolhive/guides-cli/run-mcp-servers.mdx
@@ -713,6 +713,35 @@ authorization server using one of two mechanisms:
 Either path eliminates the need to pre-configure a client ID and secret for
 authorization servers that support them.
 
+#### Bearer token authentication
+
+Some remote MCP servers accept a static bearer token in the `Authorization`
+header instead of a full OAuth flow. Use `--remote-auth-bearer-token` to provide
+the token directly:
+
+```bash
+thv run https://api.example.com/mcp \
+  --name my-server \
+  --remote-auth-bearer-token <TOKEN>
+```
+
+ToolHive sends the value as an `Authorization: Bearer <TOKEN>` header on every
+request forwarded to the remote server. The token is stored in ToolHive's
+secrets manager; only a reference to it is saved in the run configuration, never
+the token itself.
+
+To keep the token out of your shell history and process list, store it in a file
+and reference it with `--remote-auth-bearer-token-file`:
+
+```bash
+thv run https://api.example.com/mcp \
+  --name my-server \
+  --remote-auth-bearer-token-file ./token.txt
+```
+
+For servers that expect the credential in a different header, such as
+`X-API-Key`, use [forwarded headers](#inject-custom-headers) instead.
+
 #### OIDC authentication
 
 For servers using OpenID Connect (OIDC), provide the issuer URL, client ID, and


### PR DESCRIPTION
### Description

Bearer token support for remote MCP servers shipped in both the UI and CLI, but only the UI guide documented it. This adds a "Bearer token authentication" subsection to the CLI's "Run MCP servers" guide, covering `--remote-auth-bearer-token` and `--remote-auth-bearer-token-file`, with a note that the token is held in ToolHive's secrets manager (only a reference is saved to the run config) and a pointer to forwarded headers for servers that expect a non-`Authorization` header like `X-API-Key`.

### Type of change

- Documentation update

### Related issues/PRs

Closes #456. The UI half was already covered; this completes the CLI side. Feature reference: stacklok/toolhive#3111.