### PR TITLE
Document thv registry login and logout

### DIFF
--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -197,6 +197,73 @@ endpoint.
 
 :::
 
+### Authenticate to a protected registry
+
+Some remote registries require authentication before you can list, inspect, or
+run their servers. ToolHive authenticates to these registries using an
+interactive OAuth login backed by an OpenID Connect (OIDC) identity provider. If
+your registry is open to anonymous access, you don't need to log in.
+
+To authenticate, run:
+
+```bash
+thv registry login
+```
+
+This opens your browser to complete the OAuth flow with the registry's identity
+provider. On success, ToolHive caches the resulting tokens and uses them
+automatically for subsequent registry commands.
+
+The login command needs three pieces of configuration: the registry URL, the
+OIDC issuer URL, and an OAuth client ID. If you already configured the registry
+URL with
+[`thv config set-registry`](../reference/cli/thv_config_set-registry.md) and ran
+a previous login, ToolHive reuses the saved values, so you can run
+`thv registry login` with no flags. Otherwise, supply the missing values as
+flags. ToolHive validates them and saves them to your configuration before
+starting the login flow. Passing `--issuer` and `--client-id` again later
+overrides the saved OAuth settings:
+
+```bash
+thv registry login \
+  --registry https://registry.example.com/api \
+  --issuer https://auth.example.com \
+  --client-id my-app
+```
+
+The login command accepts the following flags:
+
+| Flag                     | Description                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `--registry`             | Registry URL. Persisted to your configuration if not already set.               |
+| `--issuer`               | OIDC issuer URL for the identity provider. ToolHive validates it via discovery. |
+| `--client-id`            | OAuth client ID registered with the identity provider.                          |
+| `--audience`             | OAuth audience parameter (optional).                                            |
+| `--scopes`               | Comma-separated OAuth scopes to request. Defaults to `openid,offline_access`.   |
+| `-p, --allow-private-ip` | Allow `--registry` to reference a private IP address. Defaults to `false`.      |
+
+:::note
+
+OAuth login applies only to remote registries (a URL or API endpoint). It isn't
+supported for [local registry files](#set-a-local-registry-file). Supplying a
+new `--registry` URL clears any previously saved credentials so that tokens are
+never sent to the wrong server.
+
+:::
+
+When you're done, clear the cached credentials with:
+
+```bash
+thv registry logout
+```
+
+This removes the cached OAuth tokens for the configured registry. The next
+registry command that requires authentication prompts you to log in again.
+
+For details on configuring authentication on the server side, see
+[Authentication configuration](../guides-registry/authentication.mdx) in the
+Registry Server documentation.
+
 ### Set a local registry file
 
 To configure ToolHive to use a local registry file, set the file path:

--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -197,6 +197,28 @@ endpoint.
 
 :::
 
+If your Registry Server requires authentication, you can configure the OIDC
+settings at the same time by adding the `--issuer` and `--client-id` flags (with
+optional `--audience` and `--scopes`). ToolHive saves these settings so you can
+complete the login with
+[`thv registry login`](#authenticate-to-a-protected-registry):
+
+```bash
+thv config set-registry https://registry.example.com/api \
+  --issuer https://auth.example.com \
+  --client-id <CLIENT_ID>
+```
+
+To point at a Registry Server on a private IP address, such as a local
+deployment during development, add the `-p, --allow-private-ip` flag.
+
+:::note
+
+Running `thv config set-registry` clears any previously configured registry
+authentication, so reconfigure auth after changing the registry.
+
+:::
+
 ### Authenticate to a protected registry
 
 Some remote registries require authentication before you can list, inspect, or

--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -244,13 +244,13 @@ logins (after you log out or your tokens expire) need no flags:
 thv registry login
 ```
 
-Pass `--issuer` or `--client-id` again to override the saved values.
+Pass both `--issuer` and `--client-id` again to override the saved values.
 
 The login command accepts the following flags:
 
 | Flag                     | Description                                                                     |
 | ------------------------ | ------------------------------------------------------------------------------- |
-| `--registry`             | Registry URL. Persisted to your configuration if not already set.               |
+| `--registry`             | Registry URL. Always saved to your configuration, and clears saved credentials. |
 | `--issuer`               | OIDC issuer URL for the identity provider. ToolHive validates it via discovery. |
 | `--client-id`            | OAuth client ID registered with the identity provider.                          |
 | `--audience`             | OAuth audience parameter (optional).                                            |

--- a/docs/toolhive/guides-cli/registry.mdx
+++ b/docs/toolhive/guides-cli/registry.mdx
@@ -204,32 +204,25 @@ run their servers. ToolHive authenticates to these registries using an
 interactive OAuth login backed by an OpenID Connect (OIDC) identity provider. If
 your registry is open to anonymous access, you don't need to log in.
 
-To authenticate, run:
-
-```bash
-thv registry login
-```
-
-This opens your browser to complete the OAuth flow with the registry's identity
-provider. On success, ToolHive caches the resulting tokens and uses them
-automatically for subsequent registry commands.
-
-The login command needs three pieces of configuration: the registry URL, the
-OIDC issuer URL, and an OAuth client ID. If you already configured the registry
-URL with
-[`thv config set-registry`](../reference/cli/thv_config_set-registry.md) and ran
-a previous login, ToolHive reuses the saved values, so you can run
-`thv registry login` with no flags. Otherwise, supply the missing values as
-flags. ToolHive validates them and saves them to your configuration before
-starting the login flow. Passing `--issuer` and `--client-id` again later
-overrides the saved OAuth settings:
+Logging in needs three values: the registry URL, the OIDC issuer URL, and an
+OAuth client ID. Supply them as flags the first time you authenticate. ToolHive
+validates and saves them, then opens your browser to complete the OAuth flow:
 
 ```bash
 thv registry login \
   --registry https://registry.example.com/api \
   --issuer https://auth.example.com \
-  --client-id my-app
+  --client-id <CLIENT_ID>
 ```
+
+ToolHive caches the resulting tokens and reuses the saved settings, so later
+logins (after you log out or your tokens expire) need no flags:
+
+```bash
+thv registry login
+```
+
+Pass `--issuer` or `--client-id` again to override the saved values.
 
 The login command accepts the following flags:
 


### PR DESCRIPTION
### Description

Documents the `thv registry login` and `thv registry logout` commands, which existed in the CLI reference but weren't covered in the registry guide. A new "Authenticate to a protected registry" subsection under "Set a remote registry" explains that ToolHive authenticates to protected remote registries with an interactive browser-based OAuth login backed by an OIDC identity provider, walks through running `thv registry login` (with no flags when config is already saved, or with `--registry`, `--issuer`, and `--client-id` to supply and persist the required values), documents all supported flags including the optional `--audience` and the default `openid,offline_access` scopes, notes that OAuth login applies only to remote registries and that supplying a new `--registry` URL clears previously saved credentials, and covers clearing cached tokens with `thv registry logout`. Every flag, default, and behavior was verified against the ToolHive source (`cmd/thv/app/registry_login.go`, `registry_logout.go`, and `pkg/registry/auth/login.go`) and the auto-generated CLI reference, and the section cross-links to the Registry Server authentication guide.

### Type of change

- Documentation update

### Related issues/PRs

Addresses #654 (high-priority gap # 4: registry login/logout)
