### PR TITLE
Document full Settings tab layout in UI install guide

### DIFF
--- a/docs/toolhive/guides-ui/install.mdx
+++ b/docs/toolhive/guides-ui/install.mdx
@@ -102,28 +102,32 @@ icon for quick access. The tray menu includes:
 ## Application settings
 
 Open the ToolHive settings screen from the gear icon (⚙️) in the application
-window. The settings screen allows you to configure various options:
+window. The settings screen is organized into tabs:
 
-- **Display theme**: Choose between light and dark themes for the application.
-  ToolHive matches your system theme by default.
-- **Start on login**: Automatically start ToolHive when you log in to your
-  system. MCP servers that were running when you quit ToolHive are restarted
-  automatically.
-- **Error reporting**: Enable or disable error reporting and telemetry data
-  collection.
-- **Skip quit confirmation**: Skip the MCP server shutdown confirmation dialog
-  when quitting ToolHive.
-
-The settings screen also includes a **Version** tab and a **Logs** tab:
-
-- **Version** tab: Displays the Desktop UI version and ToolHive binary version.
-  A green **Latest** badge appears next to each component when you are running
-  the current version. The **Downloads** toggle controls whether ToolHive
+- **General**: Application-wide preferences, including:
+  - **Display theme**: Choose between light and dark themes for the application.
+    ToolHive matches your system theme by default.
+  - **Start on login**: Automatically start ToolHive when you log in to your
+    system. MCP servers that were running when you quit ToolHive are restarted
+    automatically.
+  - **Error reporting**: Enable or disable error reporting and telemetry data
+    collection.
+  - **Skip quit confirmation**: Skip the MCP server shutdown confirmation dialog
+    when quitting ToolHive.
+- **Registry**: Choose the registry that ToolHive uses to discover MCP servers.
+  See [Use the registry](./registry.mdx).
+- **Secrets**: Add and manage the secrets that your MCP servers use. See
+  [Secrets management](./secrets-management.mdx).
+- **CLI**: Install the `thv` command-line tool and check its status. See
+  [Access the CLI](./cli-access.mdx).
+- **Version**: Displays the Desktop UI version and ToolHive binary version. A
+  green **Latest** badge appears next to each component when you are running the
+  current version. The **Downloads** toggle controls whether ToolHive
   automatically downloads and installs updates when a new release is available
   (enabled by default). If you disable auto-updates, an alert appears when a new
   version is available with a **Download** button so you can update manually. A
   blue indicator icon on the **Version** tab signals that an update is ready.
-- **Logs** tab: Download the application log file for troubleshooting.
+- **Logs**: Download the application log file for troubleshooting.
 
 ## Upgrade ToolHive
 


### PR DESCRIPTION
### Description

Reworks the **Application settings** section of the UI install guide to reflect the app's actual six-tab Settings layout (General, Registry, Secrets, CLI, Version, Logs) instead of the old flat option list that only acknowledged the Version and Logs tabs. The General tab's options are now nested under it, and the Registry, Secrets, and CLI tabs cross-link to their dedicated guides.

This closes out the last unaddressed medium-priority item from the UI guides gap analysis. The tab names, order, and General sub-options were verified against the current ToolHive UI source.

### Type of change

- Documentation update

### Related issues/PRs

Resolves #751

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)