### PR TITLE
Remove non-functional permissionProfile from examples

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -163,9 +163,6 @@ spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: streamable-http
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   # highlight-start
   oidcConfigRef:
     name: production-oidc
@@ -238,9 +235,6 @@ spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: sse
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   # Authentication configuration for external IdP
   oidcConfigRef:
     name: external-oidc
@@ -330,9 +324,6 @@ spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: sse
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   # Authentication configuration for Kubernetes service accounts
   oidcConfigRef:
     name: k8s-sa-oidc
@@ -584,9 +575,6 @@ spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: streamable-http
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   # highlight-start
   # Reference the embedded authorization server configuration
   authServerRef:
@@ -1012,9 +1000,6 @@ spec:
   image: ghcr.io/stackloklabs/weather-mcp/server
   transport: sse
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   # Authentication configuration
   oidcConfigRef:
     name: k8s-sa-authz-oidc

--- a/docs/toolhive/guides-mcp/notion-remote.mdx
+++ b/docs/toolhive/guides-mcp/notion-remote.mdx
@@ -111,9 +111,6 @@ spec:
   image: ghcr.io/stacklok/dockyard/npx/notion:2.2.1
   transport: stdio
   proxyPort: 8080
-  permissionProfile:
-    type: builtin
-    name: network
   secrets:
     - name: notion-token
       key: token


### PR DESCRIPTION
### Description

The `permissionProfile` field is not implemented in the operator. Removing from all examples to avoid implying it has an effect.

### Type of change

- Documentation update

### Related issues/PRs

Addresses inaccuracy noted in #655

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy