### PR TITLE
Document caBundleRef for custom OIDC CA certificates

### DIFF
--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -190,6 +190,60 @@ kubectl get mcpoidc -n toolhive-system
 The `REFERENCES` column shows which workloads use this config. The `VALID`
 column confirms validation passed.
 
+### Use a custom CA certificate for the OIDC issuer
+
+If your OIDC provider presents a certificate signed by a non-public CA, such as
+a corporate Keycloak instance with a self-signed certificate, ToolHive can't
+validate tokens until it trusts that CA. Use `caBundleRef` to point the
+`MCPOIDCConfig` at a ConfigMap containing the CA bundle. ToolHive auto-mounts
+the ConfigMap and configures token validation to trust the custom CA.
+
+First, create a ConfigMap with the CA certificate. The ConfigMap must live in
+the same namespace as the MCPServer that references the config:
+
+```bash
+kubectl create configmap corporate-ca-bundle \
+  --from-file=ca.crt=/path/to/corporate-ca.crt \
+  -n toolhive-system
+```
+
+Then reference it from the `MCPOIDCConfig` with `caBundleRef`:
+
+```yaml title="corporate-oidc-config.yaml"
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPOIDCConfig
+metadata:
+  name: corporate-oidc
+  namespace: toolhive-system
+spec:
+  type: inline
+  inline:
+    issuer: 'https://keycloak.corp.example.com/realms/myrealm'
+    clientId: 'your-client-id'
+    clientSecretRef:
+      name: oidc-secret
+      key: client-secret
+    # highlight-start
+    caBundleRef:
+      configMapRef:
+        name: corporate-ca-bundle
+        key: ca.crt
+    # highlight-end
+```
+
+Set `key` to the ConfigMap key that holds the bundle, commonly `ca.crt`. Once
+you apply the config and a referencing MCPServer, check the
+`CABundleRefValidated` condition on that MCPServer to confirm the CA bundle
+resolved:
+
+```bash
+kubectl get mcpserver <YOUR_SERVER_NAME> -n toolhive-system \
+  -o jsonpath='{.status.conditions[?(@.type=="CABundleRefValidated")]}'
+```
+
+If the ConfigMap is missing or the key isn't found, the condition reports a
+`False` status with a reason of `CABundleRefNotFound` or `CABundleRefInvalid`.
+
 ### Benefits of MCPOIDCConfig
 
 - **Centralized management**: update provider settings in one place for all

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -192,11 +192,12 @@ column confirms validation passed.
 
 ### Use a custom CA certificate for the OIDC issuer
 
-If your OIDC provider presents a certificate signed by a non-public CA, such as
-a corporate Keycloak instance with a self-signed certificate, ToolHive can't
-validate tokens until it trusts that CA. Use `caBundleRef` to point the
-`MCPOIDCConfig` at a ConfigMap containing the CA bundle. ToolHive auto-mounts
-the ConfigMap and configures token validation to trust the custom CA.
+If your OIDC provider serves its endpoints with a certificate signed by a
+non-public CA, such as a corporate Keycloak instance with an internal CA,
+ToolHive can't reach the issuer's discovery and JWKS endpoints over TLS until it
+trusts that CA. Use `caBundleRef` to point the `MCPOIDCConfig` at a ConfigMap
+containing the CA bundle. ToolHive auto-mounts the ConfigMap and uses it when
+connecting to the issuer.
 
 First, create a ConfigMap with the CA certificate. The ConfigMap must live in
 the same namespace as the MCPServer that references the config:
@@ -231,10 +232,10 @@ spec:
     # highlight-end
 ```
 
-Set `key` to the ConfigMap key that holds the bundle, commonly `ca.crt`. Once
-you apply the config and a referencing MCPServer, check the
-`CABundleRefValidated` condition on that MCPServer to confirm the CA bundle
-resolved:
+Set `key` to the ConfigMap key that holds the bundle, commonly `ca.crt`. After
+you apply the config and point an MCPServer's `oidcConfigRef` at
+`corporate-oidc`, check the `CABundleRefValidated` condition on that MCPServer
+to confirm the CA bundle resolved:
 
 ```bash
 kubectl get mcpserver <YOUR_SERVER_NAME> -n toolhive-system \


### PR DESCRIPTION
### Description

Adds a "Use a custom CA certificate for the OIDC issuer" subsection to the K8s auth guide, under the MCPOIDCConfig section. It covers the corporate-Keycloak / non-public-CA scenario: creating the CA bundle ConfigMap, referencing it via `caBundleRef` on an `MCPOIDCConfig`, and checking the `CABundleRefValidated` condition.

The original issue was written against the pre-v1beta1 shape (inline `oidcConfig`, deprecating `thvCABundlePath`), which is now stale: `thvCABundlePath` was removed in v0.15.0, the migration is already covered in `migrate-to-v1beta1.mdx`, and OIDC config now lives on the dedicated `MCPOIDCConfig` CRD. This PR is the rescoped remainder, the one missing piece in `auth-k8s.mdx`.

Two details were verified against the operator source rather than the issue text:

- The `CABundleRefValidated` condition is set on the **MCPServer** status, not the MCPOIDCConfig (`mcpserver_controller.go`).
- The CA ConfigMap is resolved in the **MCPServer's** namespace.

### Type of change

- Documentation update

### Related issues/PRs

Closes #466
Documents stacklok/toolhive#3391

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)