### PR TITLE
Document ingress routing fields for MCPServer

### DIFF
--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -591,6 +591,54 @@ Verify the route is configured:
 kubectl get httproute -n toolhive-system
 ```
 
+### MCPServer fields for ingress routing
+
+Three fields on the MCPServer spec control how the proxy presents its endpoint
+when it runs behind an ingress or load balancer. Set them so that the URLs the
+proxy generates match what external clients use.
+
+| Field                                                                   | What it does                                                                                                            | When to set it                                                                             |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `proxyMode`<br/>(`sse` \| `streamable-http`, default `streamable-http`) | Endpoint style for stdio servers: `/mcp` vs `/sse`                                                                      | Only when `transport` is `stdio`, to match your ingress paths and client transport setting |
+| `endpointPrefix`<br/>(string, no default)                               | Prepends a path prefix to the proxy's advertised endpoint URLs                                                          | When the ingress forwards a prefix without stripping it (for example, `/fetch/mcp`)        |
+| `trustProxyHeaders`<br/>(boolean, default `false`)                      | Builds endpoint URLs from `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Prefix` headers | When an ingress or load balancer terminates TLS or rewrites the host                       |
+
+These fields matter most for OAuth discovery and any flow where the proxy
+returns a URL to the client. If clients receive `http://` links or internal
+hostnames, `trustProxyHeaders` is usually the fix. If a stripped or added path
+prefix breaks discovery, reconcile `endpointPrefix` with your ingress rewrite
+behavior.
+
+This example uses a stdio-transport server behind path-based routing where the
+ingress preserves the `/fetch` prefix:
+
+```yaml title="fetch-server-ingress.yaml"
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: fetch
+  namespace: toolhive-system
+spec:
+  image: ghcr.io/stackloklabs/gofetch/server:latest
+  transport: stdio
+  proxyMode: streamable-http
+  endpointPrefix: /fetch
+  trustProxyHeaders: true
+  proxyPort: 8080
+```
+
+With this configuration, the proxy advertises its endpoint as
+`https://mcp.example.com/fetch/mcp`, matching the external URL clients connect
+to.
+
+:::note
+
+If your ingress strips the path prefix before forwarding to the backend (the
+approach used in the path-based routing examples above), omit `endpointPrefix`.
+Setting it in that case would double the prefix in generated URLs.
+
+:::
+
 ### TLS certificates
 
 For production deployments, use valid TLS certificates from a trusted

--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -597,11 +597,11 @@ Three fields on the MCPServer spec control how the proxy presents its endpoint
 when it runs behind an ingress or load balancer. Set them so that the URLs the
 proxy generates match what external clients use.
 
-| Field                                                                   | What it does                                                                                                            | When to set it                                                                             |
-| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `proxyMode`<br/>(`sse` \| `streamable-http`, default `streamable-http`) | Endpoint style for stdio servers: `/mcp` vs `/sse`                                                                      | Only when `transport` is `stdio`, to match your ingress paths and client transport setting |
-| `endpointPrefix`<br/>(string, no default)                               | Prepends a path prefix to the proxy's advertised endpoint URLs                                                          | When the ingress forwards a prefix without stripping it (for example, `/fetch/mcp`)        |
-| `trustProxyHeaders`<br/>(boolean, default `false`)                      | Builds endpoint URLs from `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Prefix` headers | When an ingress or load balancer terminates TLS or rewrites the host                       |
+| Field                                                                   | What it does                                                                                                            | When to set it                                                                                                           |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `proxyMode`<br/>(`sse` \| `streamable-http`, default `streamable-http`) | Endpoint style for stdio servers: `/mcp` vs `/sse`                                                                      | Only when `transport` is `stdio`, to match your ingress paths and client transport setting                               |
+| `endpointPrefix`<br/>(string, no default)                               | Prepends a path prefix to the proxy's advertised endpoint URLs                                                          | When the ingress strips a path prefix before forwarding, so advertised URLs still include it (for example, `/fetch/mcp`) |
+| `trustProxyHeaders`<br/>(boolean, default `false`)                      | Builds endpoint URLs from `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port`, and `X-Forwarded-Prefix` headers | When an ingress or load balancer terminates TLS or rewrites the host                                                     |
 
 These fields matter most for OAuth discovery and any flow where the proxy
 returns a URL to the client. If clients receive `http://` links or internal
@@ -610,7 +610,9 @@ prefix breaks discovery, reconcile `endpointPrefix` with your ingress rewrite
 behavior.
 
 This example uses a stdio-transport server behind path-based routing where the
-ingress preserves the `/fetch` prefix:
+ingress strips the `/fetch` prefix before forwarding (as in the path-based
+routing examples above), and `endpointPrefix` puts it back into the URLs the
+proxy advertises:
 
 ```yaml title="fetch-server-ingress.yaml"
 apiVersion: toolhive.stacklok.dev/v1beta1
@@ -633,9 +635,9 @@ to.
 
 :::note
 
-If your ingress strips the path prefix before forwarding to the backend (the
-approach used in the path-based routing examples above), omit `endpointPrefix`.
-Setting it in that case would double the prefix in generated URLs.
+If your ingress forwards the path prefix to the backend without stripping it,
+omit `endpointPrefix`. The proxy already sees the prefixed path, so setting it
+would double the prefix in generated URLs.
 
 :::
 


### PR DESCRIPTION
### Description

Adds a section to `connect-clients.mdx` covering the MCPServer fields that matter when running behind an ingress or load balancer: `proxyMode`, `endpointPrefix`, and `trustProxyHeaders`. Presented as a compact reference table plus practical guidance (which field fixes common symptoms) and a YAML example. Field types, allowed values, and defaults were verified against the MCPServer CRD schema.

### Type of change

- Documentation update

### Related issues/PRs

Addresses gaps in #655.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)