### PR TITLE
Fix K8s and vMCP logging guide inaccuracies

### DIFF
--- a/docs/toolhive/guides-k8s/logging.mdx
+++ b/docs/toolhive/guides-k8s/logging.mdx
@@ -7,8 +7,10 @@ description:
 
 ToolHive provides structured JSON logging for MCP servers in Kubernetes, giving
 you detailed operational insights and compliance audit trails. You can configure
-log levels, enable audit logging for tracking MCP operations, and integrate with
-common log collection systems like Fluentd, Filebeat, and Splunk.
+log levels, enable audit logging for tracking MCP operations, and ship the logs
+with collectors like Fluent Bit, Grafana Alloy, or the OpenTelemetry Collector
+to the analysis system you already use, such as the Elastic Stack (ELK), Splunk,
+or Datadog.
 
 ## Overview
 
@@ -36,7 +38,7 @@ flowchart TB
     ELK["ELK stack"]
     Splunk["Splunk"]
     Datadog["Datadog"]
-    Etc["...other collectors"]
+    Etc["...other systems"]
   end
 
   Op --> Stdout
@@ -154,7 +156,7 @@ request from an MCPServer resource:
 ```json
 {
   "time": "2024-01-01T12:00:00.123456789Z",
-  "level": "INFO+2",
+  "level": "AUDIT",
   "msg": "audit_event",
   "audit_id": "550e8400-e29b-41d4-a716-446655440000",
   "type": "mcp_tool_call",
@@ -226,7 +228,7 @@ configured, the `user_id` field is set to `local`.
 | Field                        | Type   | Description                                                             |
 | ---------------------------- | ------ | ----------------------------------------------------------------------- |
 | `time`                       | string | Timestamp when the log was generated                                    |
-| `level`                      | string | Log level (INFO+2 for audit events)                                     |
+| `level`                      | string | Log level (`AUDIT` for audit events)                                    |
 | `msg`                        | string | Always "audit_event" for audit logs                                     |
 | `audit_id`                   | string | Unique identifier for the audit event                                   |
 | `type`                       | string | Type of MCP operation (see event types below)                           |
@@ -271,111 +273,245 @@ configured, the `user_id` field is set to `local`.
 ## Set up log collection
 
 ToolHive outputs structured JSON logs that work with your existing log
-collection infrastructure. The examples below show basic host-based
-configurations for common log collectors. Adapt these patterns to match your
-organization's logging setup.
+collection infrastructure. Before configuring a collector, identify which pods
+and containers to target, then route their logs to your observability backend.
 
-:::note[Prerequisites]
+### Identify the namespace and containers
 
-These examples assume:
+By default, the operator and its workloads run in the `toolhive-system`
+namespace, but this varies by installation. Confirm the namespace and list the
+pods running in it:
 
-- Container logs are available at `/var/log/pods/`
-- You have a standard Kubernetes logging setup
-- Deployment manifests are handled separately
-- You're using host-based log collection
+```bash
+kubectl get pods -n toolhive-system
+```
+
+ToolHive pods use different container names depending on the component, and not
+every container emits JSON:
+
+| Component                                        | Container  | Output                                   |
+| ------------------------------------------------ | ---------- | ---------------------------------------- |
+| MCP server proxy (`MCPServer`, `MCPRemoteProxy`) | `toolhive` | Structured JSON, including audit events  |
+| Virtual MCP server (`VirtualMCPServer`)          | `vmcp`     | Structured JSON, including audit events  |
+| MCP server process                               | `mcp`      | Raw MCP server stdout (often plain text) |
+
+Target the `toolhive` and `vmcp` containers for JSON log collection. The `mcp`
+container passes through whatever the MCP server writes to stdout, so pointing a
+JSON parser at it produces parse failures whenever that output is plain text.
+
+On a standard Kubernetes node, container logs are symlinked under
+`/var/log/containers/` using the pattern
+`<POD>_<NAMESPACE>_<CONTAINER>-<ID>.log`. To match only the JSON-emitting
+containers in the `toolhive-system` namespace, target:
+
+```text
+/var/log/containers/*_toolhive-system_toolhive-*.log
+/var/log/containers/*_toolhive-system_vmcp-*.log
+```
+
+:::note[Audit events use a custom log level]
+
+Audit events are logged at a custom `AUDIT` level (`"level": "AUDIT"` in the
+JSON output), which sits between `INFO` and `WARN` so audit events stay distinct
+from regular application logs.
+
+Because `AUDIT` is not one of the standard level names that log aggregators
+detect automatically (`debug`, `info`, `warn`, `error`, and so on), audit events
+appear with an undetected or `unknown` level in views like Grafana's Explore
+Logs. Filter on an explicit `level = "AUDIT"` label or on the
+`msg = "audit_event"` field rather than relying on automatic level detection.
 
 :::
 
 :::tip[Use your existing collection methods]
 
-If your organization uses sidecar-based or operator-based log collection (such
-as Fluent Bit sidecars or the Fluentd Operator), adapt these configuration
-patterns to work with your existing infrastructure.
+The examples below run each collector as a `DaemonSet` that tails container logs
+from each node. If your organization uses sidecar-based or operator-based log
+collection, adapt these patterns to match your existing infrastructure.
 
 :::
 
-### Configure Fluentd
+### Fluent Bit
 
-```text
-# fluentd.conf
-<source>
-  @type tail
-  path /var/log/pods/*toolhive*.log
-  tag toolhive
-  read_from_head true
-  <parse>
-    @type json
-    time_key time
-    time_format %Y-%m-%dT%H:%M:%S.%NZ
-  </parse>
-</source>
+[Fluent Bit](https://fluentbit.io/) is a lightweight, widely deployed log
+processor with first-class support for the container (CRI) log format and JSON
+parsing. The following [Helm chart](https://github.com/fluent/helm-charts)
+values define a complete pipeline that tails the ToolHive containers, enriches
+records with Kubernetes metadata, promotes the JSON log fields to the top level,
+and ships everything to Grafana Loki:
 
-# Route standard logs
-<match toolhive>
-  @type elasticsearch
-  host elasticsearch.logging.svc.cluster.local
-  port 9200
-  index_name toolhive
-</match>
+```yaml title="fluent-bit-values.yaml"
+luaScripts:
+  add_service.lua: |
+    function add_service(tag, timestamp, record)
+      if record["kubernetes"] ~= nil then
+        record["service"] = record["kubernetes"]["container_name"]
+      end
+      return 1, timestamp, record
+    end
 
-# Route audit logs (entries that contain audit_id) to a separate index
-<filter toolhive>
-  @type grep
-  <regexp>
-    key audit_id
-    pattern .+
-  </regexp>
-  @label @AUDIT
-</filter>
+config:
+  inputs: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        # Target the toolhive (MCP proxy) and vmcp (Virtual MCP) containers.
+        # Both emit structured JSON covering audit and application logs.
+        Path              /var/log/containers/*_toolhive-system_toolhive-*.log,/var/log/containers/*_toolhive-system_vmcp-*.log
+        Parser            cri
+        DB                /var/log/flb-toolhive.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
 
-<label @AUDIT>
-  <match **>
-    @type elasticsearch
-    host elasticsearch.logging.svc.cluster.local
-    port 9200
-    index_name toolhive-audit
-  </match>
-</label>
+  filters: |
+    [FILTER]
+        Name              kubernetes
+        Match             kube.*
+        Kube_Tag_Prefix   kube.var.log.containers.
+        Labels            Off
+        Annotations       Off
+
+    [FILTER]
+        # Add a `service` label (= container name) for Grafana drilldown grouping
+        Name    lua
+        Match   kube.*
+        script  /fluent-bit/scripts/add_service.lua
+        call    add_service
+
+    [FILTER]
+        # Parse the JSON content from the `message` field set by the CRI parser
+        # and promote its fields (level, msg, audit_id, ...) to the top level.
+        # Reserve_Data keeps non-JSON lines (such as plain-text output) intact.
+        Name              parser
+        Match             kube.*
+        Key_Name          message
+        Parser            toolhive_json
+        Reserve_Data      True
+        Preserve_Key      False
+
+  customParsers: |
+    [PARSER]
+        # No Time_Key: the CRI parser already set the timestamp from the log prefix.
+        Name        toolhive_json
+        Format      json
+
+  outputs: |
+    [OUTPUT]
+        Name              loki
+        Match             kube.*
+        Host              loki.observability.svc
+        Port              3100
+        Labels            job=toolhive
+        Label_Keys        $kubernetes['namespace_name'],$kubernetes['pod_name'],$kubernetes['container_name'],$service
+        Auto_Kubernetes_Labels Off
+        # Drop internal CRI and Fluent Bit fields that add noise to the log body
+        Remove_Keys       logtag,stream,kubernetes
 ```
 
-### Configure Filebeat
+The second JSON `parser` filter is the critical stage. Without it, the
+structured fields (including `level`) stay nested inside the raw log string and
+aren't available as top-level fields for filtering in Loki.
 
-```yaml
-filebeat.inputs:
-  - type: container
-    paths:
-      - /var/log/pods/*toolhive*.log
-    json.keys_under_root: true
-    json.add_error_key: true
+### Grafana Alloy
 
-output.elasticsearch:
-  hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
-  indices:
-    - index: 'toolhive-audit-%{+yyyy.MM.dd}'
-      when.has_fields: ['audit_id']
-    - index: 'toolhive-%{+yyyy.MM.dd}'
+[Grafana Alloy](https://grafana.com/docs/alloy/latest/) is Grafana's current
+recommended collector (it supersedes Promtail) and a natural companion to Loki.
+This configuration discovers the ToolHive containers, parses their JSON, and
+promotes `level` to a label:
+
+```alloy title="config.alloy"
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+// Keep only the JSON-emitting toolhive and vmcp containers
+discovery.relabel "toolhive" {
+  targets = discovery.kubernetes.pods.targets
+
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    regex         = "toolhive-system"
+    action        = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    regex         = "toolhive|vmcp"
+    action        = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "service"
+  }
+}
+
+loki.source.kubernetes "toolhive" {
+  targets    = discovery.relabel.toolhive.output
+  forward_to = [loki.process.toolhive.receiver]
+}
+
+loki.process "toolhive" {
+  forward_to = [loki.write.default.receiver]
+
+  // Promote the JSON `level` field to a label
+  stage.json {
+    expressions = { level = "level" }
+  }
+  stage.labels {
+    values = { level = "" }
+  }
+}
+
+loki.write "default" {
+  endpoint {
+    url = "http://loki.observability.svc:3100/loki/api/v1/push"
+  }
+}
 ```
 
-### Configure Splunk
+### OpenTelemetry Collector
 
-```ini
-# inputs.conf
-[monitor:///var/log/pods/*toolhive*]
-sourcetype = _json
-index = toolhive
+If you already run the
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) as an
+observability hub, its `filelog` receiver can scrape the ToolHive container
+logs. This receiver is also the basis for the
+[Splunk Distribution of the OpenTelemetry Collector](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector),
+Splunk's current recommended approach for Kubernetes log collection:
 
-# props.conf
-[_json]
-KV_MODE = json
-SHOULD_LINEMERGE = false
-TRANSFORMS-route_audit = route_audit
+```yaml title="otel-collector-config.yaml"
+receivers:
+  filelog:
+    include:
+      - /var/log/pods/toolhive-system_toolhive-*/toolhive/*.log
+      - /var/log/pods/toolhive-system_vmcp-*/vmcp/*.log
+    include_file_path: true
+    operators:
+      # Parse the container (CRI/containerd) log envelope
+      - type: container
+      # Promote the structured JSON fields (level, msg, audit_id, ...) to attributes
+      - type: json_parser
+        if: 'body matches "^{"'
 
-# transforms.conf
-[route_audit]
-REGEX = "audit_id":\s*".+"
-DEST_KEY = _MetaData:Index
-FORMAT = toolhive_audit
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      processors: [batch]
+      exporters: [otlp]
 ```
+
+Unlike the `/var/log/containers/` symlinks used in the examples above, the
+`filelog` receiver reads the `/var/log/pods/` directory layout directly. The
+receiver fits best when the Collector is already part of your stack; teams that
+need a dedicated, high-throughput log scraper often pair it with Fluent Bit or
+Grafana Alloy.
 
 ## Security considerations
 

--- a/docs/toolhive/guides-k8s/logging.mdx
+++ b/docs/toolhive/guides-k8s/logging.mdx
@@ -318,8 +318,9 @@ from regular application logs.
 Because `AUDIT` is not one of the standard level names that log aggregators
 detect automatically (`debug`, `info`, `warn`, `error`, and so on), audit events
 appear with an undetected or `unknown` level in views like Grafana's Explore
-Logs. Filter on an explicit `level = "AUDIT"` label or on the
-`msg = "audit_event"` field rather than relying on automatic level detection.
+Logs. To filter for them, match the `level` field value `AUDIT` or the `msg`
+value `audit_event` directly. Matching `level` as a label or indexed field works
+only if your collector promotes that field from the JSON log line first.
 
 :::
 
@@ -498,6 +499,14 @@ receivers:
       # Promote the structured JSON fields (level, msg, audit_id, ...) to attributes
       - type: json_parser
         if: 'body matches "^{"'
+
+processors:
+  batch: {}
+
+exporters:
+  # Replace with the exporter for your backend (otlphttp, loki, splunk_hec, datadog, ...)
+  otlp:
+    endpoint: otel-backend.observability.svc:4317
 
 service:
   pipelines:

--- a/docs/toolhive/guides-vmcp/audit-logging.mdx
+++ b/docs/toolhive/guides-vmcp/audit-logging.mdx
@@ -242,8 +242,9 @@ from regular application logs.
 Because `AUDIT` is not one of the standard level names that log aggregators
 detect automatically (`debug`, `info`, `warn`, `error`, and so on), audit events
 appear with an undetected or `unknown` level in views like Grafana's Explore
-Logs. Filter on an explicit `level = "AUDIT"` label or on the
-`msg = "audit_event"` field rather than relying on automatic level detection.
+Logs. To filter for them, match the `level` field value `AUDIT` or the `msg`
+value `audit_event` directly. Matching `level` as a label or indexed field works
+only if your collector promotes that field from the JSON log line first.
 
 :::
 

--- a/docs/toolhive/guides-vmcp/audit-logging.mdx
+++ b/docs/toolhive/guides-vmcp/audit-logging.mdx
@@ -173,7 +173,7 @@ Each audit event is a structured JSON object with these fields:
 ```json
 {
   "time": "2025-02-02T15:45:30.123456789Z",
-  "level": "INFO+2",
+  "level": "AUDIT",
   "msg": "audit_event",
   "audit_id": "a3f2b8d1-4c5e-6789-abcd-ef0123456789",
   "type": "mcp_tool_call",
@@ -220,7 +220,7 @@ Each audit event is a structured JSON object with these fields:
 | Field       | Description                                               |
 | ----------- | --------------------------------------------------------- |
 | `time`      | Timestamp when the log was generated                      |
-| `level`     | Log level (INFO+2 for audit events)                       |
+| `level`     | Log level (`AUDIT` for audit events)                      |
 | `msg`       | Always "audit_event" for audit logs                       |
 | `audit_id`  | Unique identifier for this audit event                    |
 | `type`      | Event classification (what happened)                      |
@@ -232,6 +232,20 @@ Each audit event is a structured JSON object with these fields:
 | `target`    | Resource or operation targeted                            |
 | `metadata`  | Additional context (duration_ms, transport, backend_name) |
 | `data`      | Optional request and response payloads                    |
+
+:::note[Audit events use a custom log level]
+
+Audit events are logged at a custom `AUDIT` level (`"level": "AUDIT"` in the
+JSON output), which sits between `INFO` and `WARN` so audit events stay distinct
+from regular application logs.
+
+Because `AUDIT` is not one of the standard level names that log aggregators
+detect automatically (`debug`, `info`, `warn`, `error`, and so on), audit events
+appear with an undetected or `unknown` level in views like Grafana's Explore
+Logs. Filter on an explicit `level = "AUDIT"` label or on the
+`msg = "audit_event"` field rather than relying on automatic level detection.
+
+:::
 
 ## User identity in audit logs
 
@@ -270,8 +284,8 @@ spec:
       # logFile not specified = stdout
 ```
 
-This approach works well with log aggregation systems like Fluentd, Fluent Bit,
-or cloud provider log collectors (CloudWatch, Google Cloud Logging, Azure
+This approach works well with log aggregation systems like Fluent Bit, Grafana
+Alloy, or cloud provider log collectors (CloudWatch, Google Cloud Logging, Azure
 Monitor).
 
 ### Log to a file
@@ -392,11 +406,17 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/instance=my-vmcp \
 
 When audit logs are written to stdout (the default), they integrate with
 standard Kubernetes log collection infrastructure. Your existing log collectors
-(Fluentd, Fluent Bit, Filebeat, Splunk forwarders) can parse the JSON audit
-events and route them to your observability backend.
+(Fluent Bit, Grafana Alloy, the OpenTelemetry Collector, and others) can parse
+the JSON audit events and route them to your observability backend.
 
-For detailed configuration examples and best practices for setting up log
-collection with Fluentd, Filebeat, Splunk, and other systems, see the
+vMCP pods run a single container named `vmcp`, which emits the structured JSON
+application and audit logs. Target this container in your collector
+configuration, for example with a log path glob like
+`/var/log/containers/*_<NAMESPACE>_vmcp-*.log`.
+
+For complete, working configuration examples for Fluent Bit, Grafana Alloy, and
+the OpenTelemetry Collector, including how to identify the right namespace and
+containers, see the
 [Kubernetes logging guide](../guides-k8s/logging.mdx#set-up-log-collection).
 
 ## Next steps


### PR DESCRIPTION
### Description

Fixes the inaccuracies in the Kubernetes and vMCP logging guides reported in #625.

- **Namespace and container targeting:** adds guidance on verifying the namespace and targeting the right containers (`toolhive` and `vmcp` emit structured JSON including audit events; `mcp` is the raw MCP server, often plain text). Prevents pipelines that silently collect nothing or fail JSON parsing.
- **Modern log shipper examples:** replaces the dated Fluentd/Filebeat/Splunk snippets with a complete, tested Fluent Bit pipeline (adapted from `StacklokLabs/toolhive-demo-sandbox`), a Grafana Alloy config, and an OpenTelemetry Collector `filelog` example. The Splunk Distribution of the OpenTelemetry Collector is noted as Splunk's current approach.
- **Audit log level:** the issue reported audit events at `INFO+2`. That was fixed upstream in stacklok/toolhive#5256 (shipped in v0.29.3): the level now renders as `AUDIT`. Updated all references accordingly and added a note that `AUDIT` is a custom level that log aggregators don't auto-detect, so filters should be explicit (`level = "AUDIT"` or `msg = "audit_event"`).

### Type of change

- Documentation update

### Related issues/PRs

Closes #625

Upstream fix that changed the audit level: stacklok/toolhive#5256

### Screenshots

N/A

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

<!-- No pages were added, deleted, renamed, or reordered, so the Navigation section is omitted. -->

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

---

**Notes for reviewers:** the Fluent Bit config is field-tested. The Grafana Alloy and OpenTelemetry Collector examples are best-effort (syntax-checked and editorially reviewed, but not run against a live cluster) and would benefit from validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
