### PR TITLE
Document sessionAffinity in MCPServer scaling

### DIFF
--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -639,6 +639,34 @@ backends.
 
 :::
 
+### Session affinity for proxy replicas
+
+Clients connect to the proxy runner through its Service. When you run more than
+one proxy replica (`spec.replicas > 1`), the `spec.sessionAffinity` field
+controls how that Service routes repeated connections from the same client:
+
+- `ClientIP` (default) - pins a client to the same proxy pod. Because MCP
+  transports (SSE and streamable HTTP) are stateful, this keeps a client on the
+  replica that holds its in-memory session.
+- `None` - load-balances each connection freely across proxy pods.
+
+```yaml title="MCPServer resource"
+spec:
+  replicas: 2
+  # highlight-next-line
+  sessionAffinity: None # default is ClientIP
+```
+
+Affinity only influences routing; it does not move session state between pods.
+`ClientIP` is also unreliable behind NAT or shared egress IPs, where many
+clients share a source address. For reliable scaling, configure
+[Redis session storage](./redis-session-storage.mdx#horizontal-scaling-session-storage)
+so any proxy pod can serve any client rather than depending on affinity alone.
+
+This client-facing affinity is separate from the backend session routing
+described next, which controls how the proxy reaches backend pods when
+`spec.backendReplicas > 1`.
+
 ### Session routing for backend replicas
 
 MCP connections are stateful: once a client establishes a session with a

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -643,11 +643,12 @@ backends.
 
 Clients connect to the proxy runner through its Service. When you run more than
 one proxy replica (`spec.replicas > 1`), the `spec.sessionAffinity` field
-controls how that Service routes repeated connections from the same client:
+controls whether that Service routes repeated connections from the same source
+IP to the same proxy pod:
 
-- `ClientIP` (default) - pins a client to the same proxy pod. Because MCP
-  transports (SSE and streamable HTTP) are stateful, this keeps a client on the
-  replica that holds its in-memory session.
+- `ClientIP` (default) - routes connections from the same source IP to the same
+  proxy pod. Because MCP transports (SSE and Streamable HTTP) are stateful, this
+  keeps a client's connections on the replica that holds its in-memory session.
 - `None` - load-balances each connection freely across proxy pods.
 
 ```yaml title="MCPServer resource"


### PR DESCRIPTION
### Description

Documents the `spec.sessionAffinity` field in the "Horizontal scaling" section of `run-mcp-k8s.mdx`, where the rest of the MCPServer scaling knobs (`spec.replicas`, `spec.backendReplicas`, session storage) already live. This mirrors how `MCPRemoteProxy` (remote-mcp-proxy.mdx) and `VirtualMCPServer` (vMCP scaling guide) document scaling on their own pages.

The new "Session affinity for proxy replicas" subsection clarifies that `spec.sessionAffinity` controls the **proxy** Service (client-to-proxy connections when `spec.replicas > 1`), which is distinct from the backend session routing already described in the following subsection.

Supersedes #951, which added a parallel section to `redis-session-storage.mdx`. That was the wrong home: the Redis page documents the session store, and its scaling content already overlapped with the affinity/Redis discussion in `run-mcp-k8s.mdx`. This PR puts the field where the scaling guidance lives and leaves the Redis page focused on the backend.

### Type of change

- Documentation update

### Related issues/PRs

Addresses the `sessionAffinity` gap in #655. Supersedes #951.

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)