### PR TITLE
Fix elicitation template paths in composite tools guide

### DIFF
--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -219,7 +219,7 @@ spec:
             arguments:
               ref: '{{.steps.get_pr_details.output.head_sha}}'
               environment: '{{.params.environment}}'
-            condition: '{{.steps.approval.content.approved}}'
+            condition: '{{.steps.approval.output.content.approved}}'
             dependsOn: [approval]
 ```
 
@@ -597,8 +597,8 @@ Access workflow context in arguments:
 | `{{.params.name}}`               | Input parameter                            |
 | `{{.steps.id.output}}`           | Step output (map)                          |
 | `{{.steps.id.output.text}}`      | Text content from step output              |
-| `{{.steps.id.content}}`          | Elicitation response content               |
-| `{{.steps.id.action}}`           | Elicitation action (accept/decline/cancel) |
+| `{{.steps.id.output.content}}`   | Elicitation response content               |
+| `{{.steps.id.output.action}}`    | Elicitation action (accept/decline/cancel) |
 | `{{.forEach.<itemVar>}}`         | Current forEach item                       |
 | `{{.forEach.<itemVar>.<field>}}` | Field on current forEach item              |
 | `{{.forEach.index}}`             | Zero-based iteration index                 |


### PR DESCRIPTION
### Description

Fixes incorrect template paths for elicitation step results in the composite tools guide. The `action` and `content` fields are stored inside a step's `output` map, so the correct template paths are `{{.steps.id.output.action}}` and `{{.steps.id.output.content}}`. The previous paths (`{{.steps.id.action}}` and `{{.steps.id.content}}`) resolve to empty strings at runtime, causing conditions like `{{eq .steps.approval.action "accept"}}` to silently evaluate to `false` and conditional steps to always be skipped.

Three locations updated:
- Reference table (two rows)
- Code example using `.steps.approval.content.approved` in a condition

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Closes #629

Related: stacklok/toolhive#4312

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)