### PR TITLE
Enhance network isolation docs with proxy model and --allow-docker-gateway

### DIFF
--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -153,6 +153,30 @@ architecture-beta
 </TabItem>
 </Tabs>
 
+### Outbound traffic routing
+
+ToolHive routes outbound traffic from MCP servers through an explicit HTTP proxy
+using standard environment variables. When network isolation is active, ToolHive
+automatically injects the following into the MCP server container:
+
+```text
+HTTP_PROXY=http://<SERVER_NAME>-egress:3128
+HTTPS_PROXY=http://<SERVER_NAME>-egress:3128
+http_proxy=http://<SERVER_NAME>-egress:3128
+https_proxy=http://<SERVER_NAME>-egress:3128
+NO_PROXY=localhost,127.0.0.1,::1
+```
+
+Both uppercase and lowercase variants are injected to cover applications that
+use either convention.
+
+For this to work, the MCP server must honor these proxy environment variables.
+If a server bypasses them (for example, by using raw TCP sockets, a custom HTTP
+client that ignores environment variables, or hardcoded connections), its
+outbound traffic fails. ToolHive does not transparently redirect all traffic
+with iptables or nftables rules. The Docker network provides no direct path to
+external networks, so non-compliant outbound connections fail.
+
 :::info[Important]
 
 Network isolation supports HTTP and HTTPS protocols. If your MCP server needs to
@@ -280,18 +304,28 @@ server.
 
 ### Outbound access: MCP server to other workloads
 
-To allow an MCP server to access other workloads on the same network, you need
-to configure outbound network isolation to include the appropriate hostnames and
-ports.
+To allow an MCP server to access other workloads on the same network, configure
+outbound network isolation to include the appropriate hostnames and ports.
 
-For example, in Docker environments, you can add `host.docker.internal` to
-access services on the host. `host.docker.internal` is a special hostname
-provided by Docker that resolves to the host machine's IP address from within
-containers.
+**Reaching the host with `host.docker.internal`**
 
-Create a permission profile that allows this hostname and the required port:
+`host.docker.internal` is a Docker Desktop hostname that resolves to the host
+machine's IP address. Docker gateway addresses are blocked by an explicit deny
+in the egress proxy by default, even when `insecure_allow_all` is set. The
+`--allow-docker-gateway` flag removes that deny for `host.docker.internal`,
+`gateway.docker.internal`, and `172.17.0.1`.
 
-```json title="internal-access-profile.json"
+If you are using the default `network` profile (which allows all outbound
+HTTP/HTTPS), `--allow-docker-gateway` alone is enough:
+
+```bash
+thv run --allow-docker-gateway <SERVER>
+```
+
+If you are using a restrictive permission profile, you need both the flag and
+`host.docker.internal` in your `allow_host` list:
+
+```json title="host-access-profile.json"
 {
   "network": {
     "outbound": {
@@ -303,7 +337,35 @@ Create a permission profile that allows this hostname and the required port:
 }
 ```
 
-Run the MCP server with this profile:
+```bash
+thv run --allow-docker-gateway --permission-profile ./host-access-profile.json \
+  <SERVER>
+```
+
+:::note
+
+`host.docker.internal` is a Docker Desktop feature available on macOS and
+Windows. On Linux hosts running Docker Engine without Docker Desktop, use the
+Docker bridge gateway IP directly (typically `172.17.0.1`) instead.
+
+:::
+
+**Reaching other local services**
+
+For other local services, create a permission profile with the required hostname
+and port:
+
+```json title="internal-access-profile.json"
+{
+  "network": {
+    "outbound": {
+      "insecure_allow_all": false,
+      "allow_host": ["my-local-service.example.com"],
+      "allow_port": [3000]
+    }
+  }
+}
+```
 
 ```bash
 thv run --permission-profile ./internal-access-profile.json <SERVER>
@@ -361,6 +423,39 @@ default behavior of allowing traffic only from the container's own hostname,
 - [File system access](./filesystem-access.mdx)
 
 ## Troubleshooting
+
+<details>
+<summary>MCP server can't reach allowed hosts</summary>
+
+If an MCP server fails to connect to a host that is listed in its permission
+profile, the server may not be respecting the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables that ToolHive injects.
+
+ToolHive uses an explicit proxy model: outbound traffic must flow through the
+egress proxy container. There are no transparent redirect rules, so an HTTP
+client that ignores proxy environment variables has no route to the internet.
+Common causes include:
+
+- The server uses a custom HTTP client that does not read proxy environment
+  variables
+- The server opens raw TCP or UDP sockets directly instead of using standard
+  HTTP libraries
+- The server hardcodes connection targets and bypasses the system proxy
+  configuration
+
+To confirm this is the problem, check the egress proxy logs:
+
+```bash
+docker logs <SERVER_NAME>-egress
+```
+
+If the host you expect is absent from the logs entirely (no denied entry, no
+access entry), the server does not route its traffic through the proxy at all.
+In this case, you need either a different MCP server implementation that
+respects standard proxy environment variables, or opt out of network isolation
+with `--isolate-network=false`.
+
+</details>
 
 <details>
 <summary>Network connectivity issues</summary>

--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -165,6 +165,7 @@ HTTPS_PROXY=http://<SERVER_NAME>-egress:3128
 http_proxy=http://<SERVER_NAME>-egress:3128
 https_proxy=http://<SERVER_NAME>-egress:3128
 NO_PROXY=localhost,127.0.0.1,::1
+no_proxy=localhost,127.0.0.1,::1
 ```
 
 Both uppercase and lowercase variants are injected to cover applications that
@@ -314,7 +315,9 @@ outbound network isolation to include the appropriate hostnames and ports.
 machine's IP address. Docker gateway addresses are blocked by an explicit deny
 in the egress proxy by default, even when `insecure_allow_all` is set. The
 `--allow-docker-gateway` flag removes that deny for `host.docker.internal`,
-`gateway.docker.internal`, and `172.17.0.1`.
+`gateway.docker.internal`, and the Docker bridge gateway IP (resolved
+automatically at runtime; typically `172.17.0.1` on Linux, `192.168.65.1` on
+Docker Desktop).
 
 To allow all outbound HTTP/HTTPS plus gateway access, use the built-in `network`
 profile with the flag:
@@ -346,8 +349,10 @@ thv run --allow-docker-gateway --permission-profile ./host-access-profile.json \
 :::note
 
 `host.docker.internal` is a Docker Desktop feature available on macOS and
-Windows. On Linux hosts running Docker Engine without Docker Desktop, use the
-Docker bridge gateway IP directly (typically `172.17.0.1`) instead.
+Windows. On Linux hosts running Docker Engine without Docker Desktop, the
+hostname does not exist. Use the Docker bridge gateway IP (typically
+`172.17.0.1`) in `allow_host` instead, and still pass `--allow-docker-gateway`
+since the bridge IP is also denied by default.
 
 :::
 
@@ -455,6 +460,12 @@ access entry), the server does not route its traffic through the proxy at all.
 In this case, you need either a different MCP server implementation that
 respects standard proxy environment variables, or opt out of network isolation
 with `--isolate-network=false`.
+
+Note: if you are trying to reach `host.docker.internal` and see DNS errors in
+the server logs, this is expected and harmless. The MCP server container's DNS
+resolver (dnsmasq) cannot resolve `host.docker.internal`, but the Squid egress
+proxy resolves the destination itself. DNS errors in the server's resolver are a
+red herring; the proxy handles resolution for HTTP/HTTPS requests.
 
 </details>
 

--- a/docs/toolhive/guides-cli/network-isolation.mdx
+++ b/docs/toolhive/guides-cli/network-isolation.mdx
@@ -174,8 +174,9 @@ For this to work, the MCP server must honor these proxy environment variables.
 If a server bypasses them (for example, by using raw TCP sockets, a custom HTTP
 client that ignores environment variables, or hardcoded connections), its
 outbound traffic fails. ToolHive does not transparently redirect all traffic
-with iptables or nftables rules. The Docker network provides no direct path to
-external networks, so non-compliant outbound connections fail.
+with iptables or nftables rules. The MCP server container has no direct route to
+external networks; all outbound traffic must go through the egress proxy.
+Non-compliant connections fail.
 
 :::info[Important]
 
@@ -315,11 +316,11 @@ in the egress proxy by default, even when `insecure_allow_all` is set. The
 `--allow-docker-gateway` flag removes that deny for `host.docker.internal`,
 `gateway.docker.internal`, and `172.17.0.1`.
 
-If you are using the default `network` profile (which allows all outbound
-HTTP/HTTPS), `--allow-docker-gateway` alone is enough:
+To allow all outbound HTTP/HTTPS plus gateway access, use the built-in `network`
+profile with the flag:
 
 ```bash
-thv run --allow-docker-gateway <SERVER>
+thv run --allow-docker-gateway --permission-profile network <SERVER>
 ```
 
 If you are using a restrictive permission profile, you need both the flag and

--- a/docs/toolhive/guides-ui/network-isolation.mdx
+++ b/docs/toolhive/guides-ui/network-isolation.mdx
@@ -25,8 +25,8 @@ protocols are not supported.
 :::info[Proxy compatibility]
 
 Network isolation works by routing outbound traffic through an HTTP proxy.
-ToolHive automatically injects `HTTP_PROXY` and `HTTPS_PROXY` environment
-variables into the MCP server container pointing to the egress proxy. The MCP
+ToolHive automatically injects `HTTP_PROXY`, `HTTPS_PROXY`, and their lowercase
+equivalents into the MCP server container pointing to the egress proxy. The MCP
 server must respect these variables for outbound connections to succeed.
 ToolHive blocks outbound traffic from servers that bypass standard proxy
 environment variables (for example, servers that use raw TCP sockets or

--- a/docs/toolhive/guides-ui/network-isolation.mdx
+++ b/docs/toolhive/guides-ui/network-isolation.mdx
@@ -22,6 +22,18 @@ protocols are not supported.
 
 :::
 
+:::info[Proxy compatibility]
+
+Network isolation works by routing outbound traffic through an HTTP proxy.
+ToolHive automatically injects `HTTP_PROXY` and `HTTPS_PROXY` environment
+variables into the MCP server container pointing to the egress proxy. The MCP
+server must respect these variables for outbound connections to succeed.
+ToolHive blocks outbound traffic from servers that bypass standard proxy
+environment variables (for example, servers that use raw TCP sockets or
+hardcoded connections).
+
+:::
+
 ## Enabling network isolation
 
 Network isolation is available for local MCP servers installed from the registry

--- a/docs/toolhive/guides-ui/network-isolation.mdx
+++ b/docs/toolhive/guides-ui/network-isolation.mdx
@@ -118,3 +118,28 @@ containers.
 ## Related information
 
 - [Run MCP servers](./run-mcp-servers.mdx)
+- [Network isolation (CLI guide)](../guides-cli/network-isolation.mdx) for
+  architecture details and advanced configuration
+
+## Troubleshooting
+
+<details>
+<summary>MCP server can't reach an external service</summary>
+
+1. Check your allowed hosts and ports. Open the server's settings and confirm
+   the hostname and port the server needs are listed. Network isolation only
+   supports HTTP and HTTPS, so direct TCP connections (databases, custom
+   protocols) won't work.
+
+2. Check the server logs from the **MCP servers** page. Select the server, open
+   the logs panel, and look for connection errors or denied requests.
+
+3. If the logs show no outbound connection attempts at all, the server may not
+   be respecting the `HTTP_PROXY` and `HTTPS_PROXY` environment variables that
+   ToolHive injects. Servers that bypass standard proxy variables (for example,
+   those using raw TCP sockets or hardcoded connections) will fail regardless of
+   your allowed hosts configuration. See
+   [Network isolation troubleshooting](../guides-cli/network-isolation.mdx#troubleshooting)
+   in the CLI guide for more detail on diagnosing this.
+
+</details>


### PR DESCRIPTION
### Description

Two related documentation gaps addressed:

- **Proxy model** - documents how network isolation works under the hood: ToolHive injects `HTTP_PROXY`/`HTTPS_PROXY` (both uppercase and lowercase variants) into the MCP server container pointing to the Squid egress proxy. MCP servers must honor these variables; servers that bypass them (raw TCP sockets, custom HTTP clients, hardcoded connections) have no direct path out and will fail. Added as a new "Outbound traffic routing" section in the CLI guide, a "Proxy compatibility" admonition in the UI guide, and a new troubleshooting entry for when a server can't reach an allowed host.

- **`--allow-docker-gateway` and `host.docker.internal`** - the flag was missing from the narrative guide (only appeared in the auto-generated CLI reference). Documented the correct behavior: Docker gateway addresses carry an explicit deny in the egress proxy by default, even when `insecure_allow_all` is set. `--allow-docker-gateway` removes that deny. With the default `network` profile the flag alone is sufficient; with a restrictive permission profile you need both the flag and `allow_host: ["host.docker.internal"]` in the profile.

### Type of change

- Documentation update

### Related issues/PRs

Closes #976

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)