### PR TITLE
Remove alpha note from MCPRemoteProxy page

### DIFF
--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -42,13 +42,6 @@ flowchart LR
   IDP["Identity Provider<br>(Keycloak, Okta, etc.)"] -.->|validates tokens| Proxy
 ```
 
-:::info[Experimental]
-
-The MCPRemoteProxy CRD is still in an alpha state so breaking changes to the
-spec and its capabilities are possible.
-
-:::
-
 ## Prerequisites
 
 - A Kubernetes cluster (current and two previous minor versions are supported)
@@ -217,7 +210,7 @@ with `authServerRef`.
 :::
 
 <Tabs groupId='auth-method' queryString='auth-method'>
-<TabItem value='inline' label='MCPOIDCConfig (inline)' default>
+<TabItem value='inline' label='OIDC provider' default>
 
 Create an MCPOIDCConfig resource with inline OIDC settings and reference it from
 the MCPRemoteProxy. This works with most identity providers:


### PR DESCRIPTION
### Description

Found a lingering "alpha" note on the MCPRemoteProxy guide.

Also updates the MCPOIDCConfig tab label on the same page to read "OIDC provider" for clarity and consistency with the Kubernetes service account tab.

### Type of change

- Documentation update

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
