### PR TITLE
Fix stale vMCP-to-MCPRemoteProxy auth claims

### DIFF
--- a/docs/toolhive/concepts/vmcp.mdx
+++ b/docs/toolhive/concepts/vmcp.mdx
@@ -44,22 +44,18 @@ Managing 10-20+ MCP server connections is overwhelming. Each server needs its
 own configuration, authentication, and maintenance. vMCP aggregates all backend
 MCP servers into one endpoint with automatic conflict resolution.
 
-vMCP supports two types of backends:
+vMCP supports three types of backends:
 
 - **MCPServer**: Container-based MCP servers running in your Kubernetes cluster
 - **MCPRemoteProxy**: Proxies to external remote MCP servers (SaaS platforms,
   third-party services, or MCP servers hosted outside your cluster)
+- **MCPServerEntry**: Zero-infrastructure catalog entries that point vMCP at a
+  remote MCP server without deploying a proxy pod
 
-:::note[MCPRemoteProxy support]
-
-MCPRemoteProxy support in vMCP is currently in development. vMCP can discover
-MCPRemoteProxy backends, but authentication between vMCP and MCPRemoteProxy is
-not yet fully implemented. MCPServer backends work fully with vMCP.
-
-:::
-
-This architecture enables combining internal tools with external SaaS MCP
-endpoints in a single unified interface.
+vMCP discovers these backend types through a shared MCPGroup and authenticates
+to each one using its configured outgoing authentication strategy. This
+architecture enables combining internal tools with external SaaS MCP endpoints
+in a single unified interface.
 
 **Example scenario**: An engineering team needs access to 8 backend servers
 (GitHub, Jira, Slack, Confluence, PagerDuty, Datadog, AWS, and internal company

--- a/docs/toolhive/concepts/vmcp.mdx
+++ b/docs/toolhive/concepts/vmcp.mdx
@@ -52,18 +52,17 @@ vMCP supports three types of backends:
 - **MCPServerEntry**: Zero-infrastructure catalog entries that point vMCP at a
   remote MCP server without deploying a proxy pod
 
-vMCP discovers these backend types through a shared MCPGroup and authenticates
-to each one using its configured outgoing authentication strategy. This
-architecture enables combining internal tools with external SaaS MCP endpoints
-in a single unified interface.
+vMCP aggregates these backend types and authenticates to each one using its
+configured outgoing authentication strategy. This architecture enables combining
+internal tools with external SaaS MCP endpoints in a single unified interface.
 
 **Example scenario**: An engineering team needs access to 8 backend servers
 (GitHub, Jira, Slack, Confluence, PagerDuty, Datadog, AWS, and internal company
 docs). Some are container-based MCPServer resources running in the cluster,
-while others are remote SaaS MCP endpoints accessed via MCPRemoteProxy. Instead
-of configuring 8 separate connections, they configure one vMCP connection with
-SSO. This significantly reduces configuration complexity and makes onboarding
-new team members much easier.
+while others are remote SaaS MCP endpoints reached through an MCPRemoteProxy or
+MCPServerEntry. Instead of configuring 8 separate connections, they configure
+one vMCP connection with SSO. This significantly reduces configuration
+complexity and makes onboarding new team members much easier.
 
 When multiple backend MCP servers have tools with the same name (for example,
 both GitHub and Jira have `create_issue`), vMCP automatically prefixes them:

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -816,18 +816,21 @@ See [Telemetry and metrics](./telemetry-and-metrics.mdx) for more information.
 
 ## Use with Virtual MCP Server
 
-MCPRemoteProxy resources can be added to an MCPGroup and discovered by a
+MCPRemoteProxy resources can be added to an MCPGroup and aggregated by a
 VirtualMCPServer, letting you combine remote MCP servers with local
 container-based MCPServer resources into a single unified endpoint.
 
-When a VirtualMCPServer runs in
-[discovered mode](../guides-vmcp/backend-discovery.mdx), it finds MCPRemoteProxy
-backends through their shared MCPGroup and connects to them like any other
-backend. Because the proxy validates incoming requests with its `oidcConfigRef`,
+In [discovered mode](../guides-vmcp/backend-discovery.mdx), the vMCP finds
+MCPRemoteProxy backends through their shared MCPGroup and connects to them like
+any other backend. (In inline mode, you list the backends in the
+VirtualMCPServer spec instead.) If the proxy is configured to validate incoming
+requests, whether through `oidcConfigRef` or an embedded authorization server,
 configure an
 [outgoing authentication strategy](../guides-vmcp/authentication.mdx#outgoing-authentication)
 on the vMCP so it presents a token the proxy accepts, such as `upstreamInject`
-to forward a user's upstream token or `headerInjection` for a static credential.
+to forward a user's upstream token or `tokenExchange` to obtain a token with the
+proxy's expected audience. A proxy left without an authentication source accepts
+the vMCP's requests without extra configuration.
 
 :::tip[Lighter-weight alternative]
 

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -817,26 +817,31 @@ See [Telemetry and metrics](./telemetry-and-metrics.mdx) for more information.
 ## Use with Virtual MCP Server
 
 MCPRemoteProxy resources can be added to an MCPGroup and discovered by a
-VirtualMCPServer, enabling you to combine remote MCP servers with local
+VirtualMCPServer, letting you combine remote MCP servers with local
 container-based MCPServer resources into a single unified endpoint.
 
-:::caution[Current limitation]
+When a VirtualMCPServer runs in
+[discovered mode](../guides-vmcp/backend-discovery.mdx), it finds MCPRemoteProxy
+backends through their shared MCPGroup and connects to them like any other
+backend. Because the proxy validates incoming requests with its `oidcConfigRef`,
+configure an
+[outgoing authentication strategy](../guides-vmcp/authentication.mdx#outgoing-authentication)
+on the vMCP so it presents a token the proxy accepts, such as `upstreamInject`
+to forward a user's upstream token or `headerInjection` for a static credential.
 
-vMCP can discover MCPRemoteProxy backends in a group, but authentication between
-vMCP and MCPRemoteProxy is not yet fully implemented. Since MCPRemoteProxy
-requires `oidcConfigRef` to validate incoming requests, and vMCP does not
-currently forward authentication tokens to backends, vMCP cannot communicate
-with MCPRemoteProxy backends that require authentication.
+:::tip[Lighter-weight alternative]
 
-This limitation will be addressed in a future release. For now, MCPRemoteProxy
-works best when accessed directly by clients rather than through vMCP
-aggregation.
+If you only need to route a remote MCP server through vMCP and don't need the
+proxy's per-request authorization, audit logging, or tool filtering, use an
+[MCPServerEntry](./mcp-server-entry.mdx) instead. It registers the remote
+endpoint as a catalog entry with no proxy pod, and vMCP handles outgoing
+authentication to the remote server directly.
 
 :::
 
-### Add remote proxy to a group
+### Add a remote proxy to a group
 
-To include a remote proxy in an MCPGroup for future vMCP aggregation, add the
+To include a remote proxy in an MCPGroup for vMCP aggregation, add the
 `groupRef` field to your MCPRemoteProxy spec:
 
 ```yaml
@@ -866,10 +871,9 @@ spec:
     audience: context7-proxy
 ```
 
-### Planned benefits of vMCP aggregation
+### Benefits of vMCP aggregation
 
-When vMCP authentication to MCPRemoteProxy is implemented, the following
-benefits will be available:
+Aggregating MCPRemoteProxy backends behind a vMCP provides:
 
 - **Unified endpoint**: Clients connect to one vMCP URL instead of multiple
   proxy endpoints

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -78,8 +78,9 @@ spec:
 
 :::note
 
-When vMCP discovers an MCPRemoteProxy that validates incoming requests with
-`oidcConfigRef`, configure an
+When vMCP connects to an MCPRemoteProxy that validates incoming requests,
+whether through `oidcConfigRef` or an embedded authorization server, configure
+an
 [outgoing authentication strategy](./authentication.mdx#outgoing-authentication)
 so vMCP can authenticate to the proxy. See
 [Proxy remote MCP servers](../guides-k8s/remote-mcp-proxy.mdx#use-with-virtual-mcp-server)

--- a/docs/toolhive/guides-vmcp/configuration.mdx
+++ b/docs/toolhive/guides-vmcp/configuration.mdx
@@ -76,11 +76,12 @@ spec:
     audience: context7-proxy
 ```
 
-:::caution[Current limitation]
+:::note
 
-vMCP can discover MCPRemoteProxy backends in a group, but authentication between
-vMCP and MCPRemoteProxy is not yet fully implemented. This limitation will be
-addressed in a future release. See
+When vMCP discovers an MCPRemoteProxy that validates incoming requests with
+`oidcConfigRef`, configure an
+[outgoing authentication strategy](./authentication.mdx#outgoing-authentication)
+so vMCP can authenticate to the proxy. See
 [Proxy remote MCP servers](../guides-k8s/remote-mcp-proxy.mdx#use-with-virtual-mcp-server)
 for details.
 

--- a/docs/toolhive/guides-vmcp/intro.mdx
+++ b/docs/toolhive/guides-vmcp/intro.mdx
@@ -27,21 +27,18 @@ same in both modes. The rest of this page focuses on the Kubernetes deployment
 model. For individual development or local testing without a cluster, see
 [Run vMCP locally with the CLI](./local-cli.mdx).
 
-vMCP supports two types of backends:
+vMCP supports three types of backends:
 
 - **MCPServer**: Container-based MCP servers running in your cluster
 - **MCPRemoteProxy**: Proxies to external remote MCP servers (such as Notion,
   analytics platforms, or other SaaS MCP endpoints)
+- **MCPServerEntry**: Zero-infrastructure catalog entries that point vMCP at a
+  remote MCP server without deploying a proxy pod
 
-:::note[MCPRemoteProxy support]
-
-vMCP can discover MCPRemoteProxy backends in a group, but authentication between
-vMCP and MCPRemoteProxy is not yet fully implemented. MCPServer backends work
-fully with vMCP. See
+vMCP discovers these backend types through a shared MCPGroup and authenticates
+to each one using its configured outgoing authentication strategy. See
 [Proxy remote MCP servers](../guides-k8s/remote-mcp-proxy.mdx#use-with-virtual-mcp-server)
-for details on the current limitations.
-
-:::
+for details on aggregating remote proxies behind a vMCP.
 
 ## Core capabilities
 

--- a/docs/toolhive/guides-vmcp/intro.mdx
+++ b/docs/toolhive/guides-vmcp/intro.mdx
@@ -35,8 +35,8 @@ vMCP supports three types of backends:
 - **MCPServerEntry**: Zero-infrastructure catalog entries that point vMCP at a
   remote MCP server without deploying a proxy pod
 
-vMCP discovers these backend types through a shared MCPGroup and authenticates
-to each one using its configured outgoing authentication strategy. See
+vMCP aggregates these backend types and authenticates to each one using its
+configured outgoing authentication strategy. See
 [Proxy remote MCP servers](../guides-k8s/remote-mcp-proxy.mdx#use-with-virtual-mcp-server)
 for details on aggregating remote proxies behind a vMCP.
 
@@ -103,9 +103,11 @@ flowchart TB
 2. Backend resources reference the group using `groupRef`:
    - **MCPServer** resources for container-based MCP servers
    - **MCPRemoteProxy** resources for external remote MCP servers
+   - **MCPServerEntry** resources for remote MCP servers registered without a
+     proxy pod
 3. You create a VirtualMCPServer that references the group
-4. The operator discovers all MCPServer and MCPRemoteProxy backends in the group
-   and aggregates their capabilities
+4. The operator discovers all MCPServer, MCPRemoteProxy, and MCPServerEntry
+   backends in the group and aggregates their capabilities
 5. Clients connect to the VirtualMCPServer endpoint and see a unified view of
    all tools from both local and remote backends
 


### PR DESCRIPTION
### Description

The Kubernetes and vMCP guides claimed that authentication between vMCP and MCPRemoteProxy was "not yet fully implemented" and that vMCP "does not currently forward authentication tokens to backends." That functionality gap was closed upstream in stacklok/toolhive#2970 (merged 2025-12-12), which made VirtualMCPServer discover MCPRemoteProxy backends and resolve their external auth configs. Token-forwarding strategies were rounded out later (e.g. stacklok/toolhive#4390 `upstream_inject`). The claim had been stale for roughly six months.

This removes the limitation from all four places it appeared and documents the working behavior:

- **`guides-k8s/remote-mcp-proxy.mdx`** - replaced the `Current limitation` caution with how a discovered-mode vMCP authenticates to the proxy via an outgoing authentication strategy; added an MCPServerEntry "lighter-weight alternative" tip; renamed "Planned benefits of vMCP aggregation" to "Benefits" (present tense).
- **`guides-vmcp/configuration.mdx`** - swapped the caution for a note pointing at outgoing-auth configuration.
- **`guides-vmcp/intro.mdx`** and **`concepts/vmcp.mdx`** - removed the stale notes and now list all three backend types (MCPServer, MCPRemoteProxy, MCPServerEntry).

### Type of change

- Documentation update

### Related issues/PRs

- Upstream feature: stacklok/toolhive#2970

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)
