### PR TITLE
Remove id-token permission from Slack workflow

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -67,8 +67,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  # Required by anthropics/claude-code-action@v1 for OIDC token exchange.
-  id-token: write
   # Required for Claude to read CI results / Actions context on PRs.
   actions: read
 


### PR DESCRIPTION
The `id-token: write` permission causes the Claude Code action to attempt OIDC exchange, but we already have a token via the repo secrets.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>
