### PR TITLE
Fix Slack notify workflow GitHub auth

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -96,6 +96,11 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Skips claude-code-action's OIDC -> GitHub App token exchange
+          # (which needs id-token: write) and uses the job's own minimally
+          # scoped GITHUB_TOKEN instead. Unrelated to anthropic_api_key,
+          # which is the separate Anthropic-auth path.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
           # The triggering PR is authored by Renovate; without this,


### PR DESCRIPTION
### Description

#994 dropped `id-token: write` from `autogen-docs-notify.yml` to stop claude-code-action from trying OIDC for Anthropic auth. That broke a different code path: the action also uses OIDC (independent of `anthropic_api_key`) to mint a GitHub token via app-token exchange, and that started failing once `id-token: write` was removed.

Fix is to set `github_token` explicitly on the action step, which skips the OIDC exchange entirely and falls back to the job's own minimally scoped `GITHUB_TOKEN` (`contents: read`, `pull-requests: read`, `actions: read`). No `id-token: write` needed.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up to #994

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)