### PR TITLE
Fix allowedTools syntax across Claude workflows

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -122,7 +122,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 30
-            --allowed-tools "Bash(gh:*) Write"
+            --allowedTools "Bash(gh:*),Write"
           prompt: |
             You are running in GitHub Actions with no interactive user.
             Follow these steps exactly and do NOT ask clarifying

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,4 +61,4 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --allowed-tools "Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
+            --allowedTools "Bash(npm run build),Bash(npm run prettier),Bash(npm run prettier:fix),Bash(npm run eslint),Bash(npm run eslint:fix)"

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -530,7 +530,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 1000
-            --allowed-tools "Bash(gh:*) Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
+            --allowedTools "Bash(gh:*),Bash(npm run build),Bash(npm run prettier),Bash(npm run prettier:fix),Bash(npm run eslint),Bash(npm run eslint:fix)"
           prompt: |
             You are running in GitHub Actions with no interactive user.
 
@@ -643,7 +643,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-7
             --max-turns 200
-            --allowed-tools "Bash(gh:*) Bash(npm run build) Bash(npm run prettier) Bash(npm run prettier:fix) Bash(npm run eslint) Bash(npm run eslint:fix)"
+            --allowedTools "Bash(gh:*),Bash(npm run build),Bash(npm run prettier),Bash(npm run prettier:fix),Bash(npm run eslint),Bash(npm run eslint:fix)"
           prompt: |
             You are running in GitHub Actions with no interactive user. Follow
             these steps exactly and do NOT ask clarifying questions -- proceed


### PR DESCRIPTION
### Description

Follow-up to #994, #995, and #996. The Slack notify workflow (`autogen-docs-notify.yml`) was hitting `--max-turns 30` even on a trivial prompt. The actual SDK options for that run showed `"allowedTools": ["Bash(gh:*) Write"]`, a single malformed entry instead of two. claude-code-action's `claude_args` parser splits a quoted `--allowedTools` value on commas, not spaces (confirmed against the action's own docs, which show the comma-separated form). With one bad entry that matches neither tool, every tool call got denied (`permission_denials_count: 21-23`), and the agent burned through all 30 turns retrying.

The same space-separated pattern existed in `claude.yml` and twice in `upstream-release-docs.yml`. Those don't fail outright since they run in modes/turn limits where some baseline tools work regardless, but the npm build/lint/`gh` permissions those flags were meant to grant were likely never actually active.

Also switched `--allowed-tools` to the canonical `--allowedTools` flag rather than relying on the hyphenated alias.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up to #994, #995, #996

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)