### PR TITLE
Stop Slack notify step from loading project config

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -123,6 +123,12 @@ jobs:
             --model claude-opus-4-7
             --max-turns 30
             --allowedTools "Bash(gh:*),Write"
+            # This step's only job is composing a JSON summary from
+            # `gh pr view` output -- it has no use for this repo's own
+            # CLAUDE.md/.claude project config, and loading it just
+            # invites Claude to wander into unrelated workflows that
+            # the tool allowlist above denies.
+            --setting-sources user
           prompt: |
             You are running in GitHub Actions with no interactive user.
             Follow these steps exactly and do NOT ask clarifying


### PR DESCRIPTION
### Description

Follow-up to #997. The allowedTools fix in #997 is confirmed working (`"allowedTools": ["Bash(gh:*)", "Write"]` parses correctly now), but permission denials are still high: 19 denials on a run that succeeded (29/30 turns), 21 and 24 on two that hit the max-turns cap.

I couldn't get a full per-turn transcript to confirm definitively. `gh run rerun --debug` only adds the GitHub Actions runner's own `##[debug]` lines; claude-code-action's "Run Claude Code Action" composite step defines its own explicit `env:` block in `action.yml`, which doesn't forward `ACTIONS_STEP_DEBUG` into the Bun subprocess, so `show_full_output` never actually flips on that way.

The strongest remaining lead: `settingSources` defaults to `["user", "project", "local"]`. The checkout step added in #996 (needed for claude-code-action's `restoreConfigFromBase`) means this repo's `CLAUDE.md` and `.claude/` (agents, commands, skills) are now present in the working directory and get loaded as project context. None of that is relevant to this step, whose only job is to read one PR via `gh pr view` and write a JSON file, and the action's own docs call out `--setting-sources user` as the documented way to avoid pulling in unrelated in-repo config. Scoping this step to user-level settings only should stop Claude from wandering into tool calls the allowlist denies.

This isn't a fully confirmed fix since I couldn't capture the transcript, so worth watching the next real `ready_for_review` trigger to see if denials drop.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up to #994, #995, #996, #997

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)