### PR TITLE
Fix Slack notify prompt to use literal values, not $VAR

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -102,10 +102,6 @@ jobs:
       # nor make arbitrary network calls (no curl/Bash beyond gh).
       - name: Compose reviewer summary
         uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1.0.152
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_REPO: ${{ github.repository }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Skips claude-code-action's OIDC -> GitHub App token exchange
@@ -140,16 +136,11 @@ jobs:
             the `gh` CLI. A later, separate, deterministic step does the
             actual Slack posting.
 
-            Context (available to you as environment variables):
-              PR_NUMBER    - the PR number
-              GH_REPO      - owner/repo of this repository
-              PR_URL       - the PR's html_url
-              MESSAGE_FILE - the path to write the JSON output file to
-              GH_TOKEN     - auth for the `gh` CLI
-
             STEP 1 — Read the PR.
-            Run:
-              gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json title,body,reviewRequests,files,url
+            Run this exact command (the values below are already
+            filled in -- do not substitute shell variables, and do
+            not quote the numbers or the repo name):
+              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,reviewRequests,files,url
             From the JSON, extract:
               - the PR title
               - the PR body. The body contains a marker-delimited
@@ -164,16 +155,16 @@ jobs:
                 are GitHub logins).
 
             STEP 2 — Write the message content as JSON.
-            Use the **Write** tool to write a file at the path given by
-            the env var MESSAGE_FILE. The file MUST be valid JSON with
-            EXACTLY this shape:
+            Use the **Write** tool to write a file at exactly this path:
+              ${{ github.workspace }}/.autogen-docs-slack-message.json
+            The file MUST be valid JSON with EXACTLY this shape:
               {
                 "headline": "<one line naming the upstream project/version, plain text>",
                 "summary_bullets": ["...", "..."],
                 "reviewers": [
                   {"login": "<github login>", "note": "<what THIS reviewer should check>"}
                 ],
-                "pr_url": "<the PR url>"
+                "pr_url": "${{ github.event.pull_request.html_url }}"
               }
             Rules:
               - "headline" is plain text only (NO Slack/markdown link
@@ -191,7 +182,7 @@ jobs:
                 have produced any user- or docs-facing changes, which is
                 expected and fine, and in that case their approval simply
                 confirms nothing was missed in the generated docs.
-              - "pr_url" is the value of the PR_URL env var.
+              - "pr_url" must be copied exactly as filled in above.
             Do NOT include any Slack ids, Slack mrkdwn, `<@...>` tags, or
             `<url|text>` links — only the plain content above. Do NOT
             post anything. Do NOT call curl. After writing the file,


### PR DESCRIPTION
### Description

Root cause found and confirmed locally, not another guess this time.

Claude Code's permission matcher denies any Bash command containing an unexpanded shell variable (`$PR_NUMBER`, `${GH_REPO}`, etc.), regardless of whether the rest of the command matches an `allowedTools` wildcard like `Bash(gh:*)`. It can't statically verify that expanding an unknown variable won't smuggle in extra shell metacharacters, so it always falls back to "needs approval", which is impossible to satisfy with no human in the loop. The prompt told Claude to build its `gh pr view` command from env vars using exactly that shell-expansion syntax, so every attempt was denied no matter how it was quoted or wrapped, and Claude burned through all 30 turns trying workarounds (brace expansion, subshells, `printenv`, Python `subprocess`, writing a helper script) before timing out.

I reproduced this directly: ran the `claude` CLI locally with the literal prompt text and the same `--allowedTools "Bash(gh:*),Write" --setting-sources user --max-turns 30`, and got `permission_denials: 19` and `error_max_turns`, denial #1 being the exact literal command from the prompt. The denial reason was `"Contains simple_expansion"`.

Fix: interpolate the PR number, repo, URL, and workspace path directly into the prompt text via GitHub Actions expressions (`${{ github.event.pull_request.number }}`, etc.) instead of telling Claude to reference env vars in the Bash command. None of these four values are PR-content-controlled (they're trusted event/repository/runner context, not PR title/body), so embedding them directly carries no injection risk, the existing design already correctly avoids embedding actual PR content this way.

Verified the fix the same way: rendered the new prompt with PR #992's real values and ran it through the local `claude` CLI with identical flags. Result: `num_turns: 3`, `permission_denials: 0`, and a correctly-formed output JSON with accurate PR data and reviewer notes.

### Type of change

- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Follow-up to #994, #995, #996, #997, #998

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)