### PR TITLE
Fix autogen-docs notify workflow trigger

### DIFF
--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -1,29 +1,22 @@
 name: Autogen Docs Slack Notify
 
-# Notifies the team's #documentation Slack channel when an
-# `autogen-docs` PR is flipped from draft to ready-for-review.
+# Notifies the team's #documentation Slack channel when the Upstream
+# Release Docs workflow completes successfully on an `autogen-docs` PR.
 #
-# These PRs are the version-bump docs PRs Renovate opens and the
-# Upstream Release Docs workflow augments: that workflow runs the
-# upstream-release-docs skill, assigns reviewers, and at the very
-# end flips the PR draft -> ready via `gh pr ready`. That flip emits
-# the `ready_for_review` event this workflow listens for.
-# `autogen-docs` is a LABEL Renovate applies (not a branch prefix),
-# and the PRs are authored by `renovate[bot]`, so the job gates on
-# both the label and the author below.
+# Triggers on `workflow_run` (not `pull_request_target`) because the
+# augment workflow uses GITHUB_TOKEN to flip the PR draft -> ready, and
+# GitHub suppresses events emitted by GITHUB_TOKEN to prevent loops.
+# The `autogen-docs` label + `renovate[bot]` author guard lives in the
+# "Resolve PR" step rather than the job `if:` because those fields are
+# not on the `workflow_run` payload and must be fetched via `gh pr view`.
 #
 # SECURITY MODEL
 # --------------
-# This workflow triggers on `pull_request_target` (not
-# `pull_request`). `pull_request_target` runs the workflow definition
-# from the TRUSTED BASE branch rather than from the (potentially
-# attacker-controlled) PR head, while still exposing the PR metadata
-# on `github.event.pull_request`. The label + `renovate[bot]` author
-# guard below works identically on that payload. This is safe here
-# because the workflow only checks out the TRUSTED BASE branch (the
-# default `actions/checkout` ref on `pull_request_target` is the base,
-# not the PR head) and never executes any PR-supplied code -- Claude
-# only reads PR metadata via the `gh` CLI.
+# `workflow_run` always executes the workflow definition from the
+# DEFAULT BRANCH (main), regardless of which branch the triggering PR
+# is on -- the same guarantee `pull_request_target` provided. This
+# workflow NEVER executes any PR-supplied code; Claude only reads PR
+# metadata via the `gh` CLI.
 #
 # The work is split into two steps so the prompt-injectable Claude
 # session can never touch the Slack token or make arbitrary outbound
@@ -63,8 +56,9 @@ name: Autogen Docs Slack Notify
 # ---------------------------------------------------------------------
 
 on:
-  pull_request_target:
-    types: [ready_for_review]
+  workflow_run:
+    workflows: ['Upstream Release Docs']
+    types: [completed]
 
 permissions:
   contents: read
@@ -76,31 +70,62 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only run for the Renovate-authored docs PRs carrying the
-    # `autogen-docs` label. Human PRs that happen to go ready, and
-    # any other bot's PRs, are out of scope.
+    # Only run when the augment workflow succeeded on a pull_request
+    # event. Skipping workflow_dispatch retries (no PR in the payload)
+    # and failed runs (half-written augmentation not worth notifying).
     if: |
-      contains(github.event.pull_request.labels.*.name, 'autogen-docs') &&
-      github.event.pull_request.user.login == 'renovate[bot]'
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MESSAGE_FILE: ${{ github.workspace }}/.autogen-docs-slack-message.json
     steps:
+      # Fetch the PR number from the workflow_run payload, verify it
+      # carries the autogen-docs label and was authored by renovate[bot],
+      # then surface number + url as step outputs for the steps below.
+      # Sets skip=true and exits cleanly when the PR is out of scope so
+      # the job succeeds without posting anything.
+      - name: Resolve PR and check eligibility
+        id: pr
+        run: |
+          PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR associated with this workflow run; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json labels,author,url)
+          HAS_LABEL=$(echo "$PR_JSON" \
+            | jq -r '[.labels[].name] | contains(["autogen-docs"])')
+          AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
+
+          if [ "$HAS_LABEL" != "true" ] || [ "$AUTHOR" != "renovate[bot]" ]; then
+            echo "PR #$PR_NUMBER is not an autogen-docs renovate PR; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_URL=$(echo "$PR_JSON" | jq -r '.url')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       # claude-code-action unconditionally restores trusted .claude/.mcp.json
       # config from the base branch via `git fetch`/`git checkout` before
       # running Claude, even in agent mode -- it requires a git working tree
-      # to exist. We never want to check out the PR head, so rely on
-      # `pull_request_target`'s default checkout ref: with no `ref:` override,
-      # `actions/checkout` resolves `github.sha`, which for this event is the
-      # BASE branch's HEAD, not the PR's. This stays consistent with the
-      # security model above: only trusted code ever lands in the workspace.
+      # to exist. workflow_run always executes from the default branch, so
+      # the checkout below lands trusted code in the workspace.
       - name: Checkout base branch
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # STEP 1 — Claude composes content only. Tools limited to gh + Write.
       # No Slack token in this step's env; no curl tool. So even a prompt
       # injection from PR content cannot exfiltrate the Slack token (absent)
       # nor make arbitrary network calls (no curl/Bash beyond gh).
       - name: Compose reviewer summary
+        if: steps.pr.outputs.skip != 'true'
         uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1.0.152
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -111,10 +136,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
-          # The triggering PR is authored by Renovate; without this,
-          # claude-code-action refuses to run for bot-initiated PRs as
-          # a safety default.
-          allowed_bots: 'renovate'
+          # workflow_run actor is github-actions[bot]; the PR is authored
+          # by renovate[bot]. Both are listed so claude-code-action does
+          # not refuse to run on a bot-initiated context.
+          allowed_bots: 'renovate,github-actions'
           claude_args: |
             --model claude-opus-4-7
             --max-turns 30
@@ -140,7 +165,7 @@ jobs:
             Run this exact command (the values below are already
             filled in -- do not substitute shell variables, and do
             not quote the numbers or the repo name):
-              gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,reviewRequests,files,url
+              gh pr view ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --json title,body,reviewRequests,files,url
             From the JSON, extract:
               - the PR title
               - the PR body. The body contains a marker-delimited
@@ -164,7 +189,7 @@ jobs:
                 "reviewers": [
                   {"login": "<github login>", "note": "<what THIS reviewer should check>"}
                 ],
-                "pr_url": "${{ github.event.pull_request.html_url }}"
+                "pr_url": "${{ steps.pr.outputs.url }}"
               }
             Rules:
               - "headline" is plain text only (NO Slack/markdown link
@@ -191,9 +216,10 @@ jobs:
       # token, and it only contacts slack.com. Resolves reviewer GitHub
       # handles -> Slack ids here (not in the Claude step).
       - name: Post summary to Slack
+        if: steps.pr.outputs.skip != 'true'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           DOCS_SLACK_CHANNEL_ID: C06SZA9HBHU
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ steps.pr.outputs.url }}
         run: |
           python3 .github/scripts/post_autogen_docs_slack.py


### PR DESCRIPTION
### Description

Switches the `autogen-docs-notify` workflow trigger from `pull_request_target: ready_for_review` to `workflow_run` on "Upstream Release Docs" completing. The old trigger never fired because the augment workflow calls `gh pr ready` with GITHUB_TOKEN, and GitHub suppresses events emitted by GITHUB_TOKEN to prevent recursive loops.

The `autogen-docs` label + `renovate[bot]` author guard moves from the job `if:` into a new "Resolve PR" step, since those fields aren't on the `workflow_run` payload and must be fetched via `gh pr view`.

### Type of change

- Other (internal/workflow)