### PR TITLE
Hide Updates section in navbar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -281,11 +281,11 @@ const config: Config = {
           label: 'Resources',
           position: 'left',
         },
-        {
+        /* {
           to: '/toolhive/updates',
           label: 'Updates',
           position: 'left',
-        },
+        }, */
         {
           href: 'https://github.com/stacklok',
           className: 'navbar-icon-link fa-brands fa-github fa-lg',


### PR DESCRIPTION
### Description

Hides the updates section from the top nav menu since it's no longer being actively added to.

Previous articles continue to be built and placed in the sitemap so they don't 404 and continue to be indexed by search engines.

### Type of change

- Navigation/structure change