### PR TITLE
Fix GitHub handle matching for www.github.com URLs

### DIFF
--- a/.github/scripts/post_autogen_docs_slack.py
+++ b/.github/scripts/post_autogen_docs_slack.py
@@ -126,19 +126,25 @@ def slack_post_json(token, method, payload):
 def normalize_handle(value):
     """Normalize a possible GitHub handle for comparison.
 
-    Lowercases, strips a leading "@", and reduces a full
-    https://github.com/<login> URL form to just <login>.
+    Lowercases, strips a leading "@", and reduces a full GitHub profile
+    URL form (with or without a scheme or "www." subdomain) to just
+    <login>.
     """
     if not isinstance(value, str):
         return ""
     candidate = value.strip().lower()
     if not candidate:
         return ""
-    # Tolerate a full GitHub profile URL form.
-    for prefix in ("https://github.com/", "http://github.com/", "github.com/"):
-        if candidate.startswith(prefix):
-            candidate = candidate[len(prefix):]
+    # Tolerate a URL scheme and/or a "www." subdomain, in either order
+    # of presence, before checking for the "github.com/" host.
+    for scheme in ("https://", "http://"):
+        if candidate.startswith(scheme):
+            candidate = candidate[len(scheme):]
             break
+    if candidate.startswith("www."):
+        candidate = candidate[len("www."):]
+    if candidate.startswith("github.com/"):
+        candidate = candidate[len("github.com/"):]
     # Drop a trailing slash and anything after it (e.g. URL path tail).
     candidate = candidate.split("/", 1)[0]
     if candidate.startswith("@"):


### PR DESCRIPTION
### Description

The Autogen Docs Slack Notify workflow resolves each requested reviewer's GitHub login to a Slack mention by reading a "GitHub Handle" custom profile field and normalizing it for comparison. `normalize_handle()` only stripped the `github.com/`, `http://github.com/`, and `https://github.com/` prefixes. A profile value using the `www.` subdomain (`https://www.github.com/<login>`) didn't match any of those, so it fell through untouched into the trailing `split("/", 1)[0]` step, which chopped it down to `https:` instead of the login. The affected reviewer silently fell back to a plain `@handle` text mention instead of a real Slack tag.

Now strips an optional `www.` subdomain before checking for the `github.com/` host, so `www.`, non-`www.`, and scheme-less forms all normalize to the same login.

### Type of change

- Bug fix (internal/workflow)

### Related issues/PRs

None.
