### PR TITLE
Trim repeated Prerequisites boilerplate in guides-k8s

### DIFF
--- a/docs/toolhive/guides-k8s/connect-clients.mdx
+++ b/docs/toolhive/guides-k8s/connect-clients.mdx
@@ -56,8 +56,6 @@ flowchart TB
   [Run MCP servers in Kubernetes](./run-mcp-k8s.mdx))
 - An Ingress controller or Gateway API implementation installed in your cluster
   (for external access)
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
-  with your cluster
 
 ## Connect from outside the cluster
 

--- a/docs/toolhive/guides-k8s/mcp-server-entry.mdx
+++ b/docs/toolhive/guides-k8s/mcp-server-entry.mdx
@@ -38,13 +38,8 @@ and connects to them directly.
 
 ## Prerequisites
 
-- A Kubernetes cluster (current and two previous minor versions are supported)
-- Permissions to create resources in the cluster
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
-  with your cluster
-- The ToolHive operator installed in your cluster (see
-  [Deploy the operator](./deploy-operator.mdx))
-- A remote MCP server that supports HTTP transport (SSE or Streamable HTTP)
+You'll need a remote MCP server that supports HTTP transport (SSE or Streamable
+HTTP).
 
 ## When to use MCPServerEntry vs. MCPRemoteProxy
 

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -44,12 +44,6 @@ flowchart LR
 
 ## Prerequisites
 
-- A Kubernetes cluster (current and two previous minor versions are supported)
-- Permissions to create resources in the cluster
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
-  with your cluster
-- The ToolHive operator installed in your cluster (see
-  [Deploy the operator](./deploy-operator.mdx))
 - An OIDC identity provider (Keycloak, Okta, Azure AD, etc.)
 - Access to a remote MCP server that supports HTTP transport (SSE or Streamable
   HTTP)

--- a/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
+++ b/docs/toolhive/guides-k8s/remote-mcp-proxy.mdx
@@ -44,7 +44,7 @@ flowchart LR
 
 ## Prerequisites
 
-- An OIDC identity provider (Keycloak, Okta, Azure AD, etc.)
+- An OIDC identity provider (Keycloak, Okta, Microsoft Entra ID, etc.)
 - Access to a remote MCP server that supports HTTP transport (SSE or Streamable
   HTTP)
 

--- a/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
+++ b/docs/toolhive/guides-k8s/run-mcp-k8s.mdx
@@ -7,12 +7,8 @@ description:
 
 ## Prerequisites
 
-- A Kubernetes cluster (current and two previous minor versions are supported)
-- Permissions to create resources in the cluster
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to communicate
-  with your cluster
-- The ToolHive operator installed in your cluster (see
-  [Deploy the operator](./deploy-operator.mdx))
+You'll need a Kubernetes cluster with the ToolHive operator installed (see
+[Deploy the operator](./deploy-operator.mdx)).
 
 ## Overview
 


### PR DESCRIPTION
### Description

Several guides-k8s how-to pages restated the same cluster/kubectl/operator-installed boilerplate that's already covered earlier in the section (Deploy the operator, Run MCP servers). This trims each page's Prerequisites section down to what's actually specific to it, following the pattern already used on `rate-limiting.mdx`, `redis-session-storage.mdx`, and the four auth pages fixed in #1014.

- `run-mcp-k8s.mdx`: condensed four boilerplate bullets into one line pointing to Deploy the operator
- `remote-mcp-proxy.mdx`: dropped cluster/permissions/kubectl/operator bullets, kept only the OIDC provider and remote server requirements
- `mcp-server-entry.mdx`: dropped the same boilerplate, kept only the remote server transport requirement
- `connect-clients.mdx`: dropped the redundant `kubectl` bullet (cluster/Ingress bullets are page-specific and stay)

`deploy-operator.mdx` and `quickstart.mdx` are left as-is since they're the actual first-touch pages where that baseline is genuinely needed.

I also did a quick check of `guides-cli`, `guides-vmcp`, and `guides-registry` and didn't find the same repeated-boilerplate pattern worth fixing there.

### Type of change

- Documentation update

### Related issues/PRs

Closes #1015

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and style
