### PR TITLE
docs(verify-artifacts): fix stale image-signing table and rebrand Replicated SDK references

### DIFF
--- a/docs/platform/enterprise-platform/verify-artifacts.mdx
+++ b/docs/platform/enterprise-platform/verify-artifacts.mdx
@@ -254,18 +254,20 @@ oras discover "$IMAGE"
 | `ai-gateway-operator`, `ai-gateway-main-processor`, `ai-gateway-api-key-service`                       | `_release-image.yml`               |     ✓      |
 | `cloud-ui`                                                                                             | `_release-toolhive-cloud-ui.yml`   |     ✓      |
 | `ai-gateway-controller`, `ai-gateway-extproc`, `envoy-gateway`, `envoy-ratelimit`, `presidio-analyzer` | `_release-upstream-repackaged.yml` |     ✓      |
-| Third-party dependencies (Replicated SDK)                                                              | upstream, not re-signed            |    n/a     |
+| Third-party dependencies (Stacklok License Manager)                                                    | upstream, not re-signed            |    n/a     |
 
 Envoy Gateway, Envoy Ratelimit, and Presidio are repackaged (re-signed with a
 Stacklok signature, SBOM, and provenance) rather than shipped as upstream
 passthrough — verify them the same way as any other image in this table. Only
-the Replicated SDK image remains genuine third-party passthrough.
+the Stacklok License Manager image remains genuine third-party passthrough.
 
 :::note[Third-party dependency images]
 
-The Replicated SDK image is not re-signed by Stacklok, and unlike every other
-image on this page, it is not rewritten through `image-proxy.stacklok.com` at
-all — it is pulled directly from Replicated's own registry at
+The Stacklok License Manager (the in-cluster component branded from the
+Replicated SDK — it appears as `stacklok-license-manager-*` in
+`kubectl get pods`) is not re-signed by Stacklok, and unlike every other image
+on this page, it is not rewritten through `image-proxy.stacklok.com` at all — it
+is pulled directly from Replicated's own registry at
 `proxy.replicated.com/library/replicated-sdk-image`. Verify it against its
 original publisher's signature if required. It is pulled by digest, so its
 content is pinned.
@@ -274,12 +276,12 @@ content is pinned.
 
 The repackaged third-party images each play a specific role in the platform:
 
-| Dependency      | Role in the stack                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| Envoy Gateway   | Kubernetes Gateway API data plane that fronts the AI gateway                               |
-| Envoy Ratelimit | Rate-limiting service backing the AI gateway's token budget enforcement                    |
-| Presidio        | Microsoft Presidio engine for PII and PCI detection and redaction in prompts               |
-| Replicated SDK  | In-cluster SDK that reports install status and license state to Replicated (not re-signed) |
+| Dependency               | Role in the stack                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Envoy Gateway            | Kubernetes Gateway API data plane that fronts the AI gateway                                                                 |
+| Envoy Ratelimit          | Rate-limiting service backing the AI gateway's token budget enforcement                                                      |
+| Presidio                 | Microsoft Presidio engine for PII and PCI detection and redaction in prompts                                                 |
+| Stacklok License Manager | In-cluster component (Replicated SDK, rebranded) that reports install status and license state to Replicated (not re-signed) |
 
 ## Verify across all images
 

--- a/docs/platform/enterprise-platform/verify-artifacts.mdx
+++ b/docs/platform/enterprise-platform/verify-artifacts.mdx
@@ -248,32 +248,38 @@ oras discover "$IMAGE"
 
 ## Which images are signed
 
-| Image (`<IMAGE>`)                                                                   | Signing workflow                   | Verifiable |
-| ----------------------------------------------------------------------------------- | ---------------------------------- | :--------: |
-| `operator`, `proxyrunner`, `vmcp`, `registry-api`, `toolhive-enterprise`            | `_release-image.yml`               |     ✓      |
-| `ai-gateway-operator`, `ai-gateway-main-processor`, `ai-gateway-api-key-service`    | `_release-image.yml`               |     ✓      |
-| `cloud-ui`                                                                          | `_release-toolhive-cloud-ui.yml`   |     ✓      |
-| `ai-gateway-controller`, `ai-gateway-extproc`                                       | `_release-upstream-repackaged.yml` |     ✓      |
-| Third-party dependencies (Envoy Gateway, Envoy Ratelimit, Presidio, Replicated SDK) | upstream, not re-signed            |    n/a     |
+| Image (`<IMAGE>`)                                                                                      | Signing workflow                   | Verifiable |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------- | :--------: |
+| `thv`, `operator`, `proxyrunner`, `vmcp`, `registry-api`, `toolhive-enterprise`                        | `_release-image.yml`               |     ✓      |
+| `ai-gateway-operator`, `ai-gateway-main-processor`, `ai-gateway-api-key-service`                       | `_release-image.yml`               |     ✓      |
+| `cloud-ui`                                                                                             | `_release-toolhive-cloud-ui.yml`   |     ✓      |
+| `ai-gateway-controller`, `ai-gateway-extproc`, `envoy-gateway`, `envoy-ratelimit`, `presidio-analyzer` | `_release-upstream-repackaged.yml` |     ✓      |
+| Third-party dependencies (Replicated SDK)                                                              | upstream, not re-signed            |    n/a     |
+
+Envoy Gateway, Envoy Ratelimit, and Presidio are repackaged (re-signed with a
+Stacklok signature, SBOM, and provenance) rather than shipped as upstream
+passthrough — verify them the same way as any other image in this table. Only
+the Replicated SDK image remains genuine third-party passthrough.
 
 :::note[Third-party dependency images]
 
-Third-party dependency images are served through the proxy for license-gated
-distribution but are not re-signed by Stacklok. Verify those against their
-original publishers' signatures if required. They are pulled by digest, so their
-content is pinned. Their proxy paths use the upstream host, for example
-`.../proxy/stacklok-enterprise/docker.io/<UPSTREAM>/<IMAGE>`.
+The Replicated SDK image is not re-signed by Stacklok, and unlike every other
+image on this page, it is not rewritten through `image-proxy.stacklok.com` at
+all — it is pulled directly from Replicated's own registry at
+`proxy.replicated.com/library/replicated-sdk-image`. Verify it against its
+original publisher's signature if required. It is pulled by digest, so its
+content is pinned.
 
 :::
 
-Each third-party dependency plays a specific role in the platform:
+The repackaged third-party images each play a specific role in the platform:
 
-| Dependency      | Role in the stack                                                            |
-| --------------- | ---------------------------------------------------------------------------- |
-| Envoy Gateway   | Kubernetes Gateway API data plane that fronts the AI gateway                 |
-| Envoy Ratelimit | Rate-limiting service backing the AI gateway's token budget enforcement      |
-| Presidio        | Microsoft Presidio engine for PII and PCI detection and redaction in prompts |
-| Replicated SDK  | In-cluster SDK that reports install status and license state to Replicated   |
+| Dependency      | Role in the stack                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| Envoy Gateway   | Kubernetes Gateway API data plane that fronts the AI gateway                               |
+| Envoy Ratelimit | Rate-limiting service backing the AI gateway's token budget enforcement                    |
+| Presidio        | Microsoft Presidio engine for PII and PCI detection and redaction in prompts               |
+| Replicated SDK  | In-cluster SDK that reports install status and license state to Replicated (not re-signed) |
 
 ## Verify across all images
 
@@ -285,9 +291,10 @@ IDENTITY='^https://github\.com/stacklok/stacklok-enterprise-platform/\.github/wo
 ISSUER='https://token.actions.githubusercontent.com'
 VERSION='<VERSION>'
 
-for IMAGE in operator proxyrunner vmcp registry-api toolhive-enterprise cloud-ui \
+for IMAGE in thv operator proxyrunner vmcp registry-api toolhive-enterprise cloud-ui \
              ai-gateway-operator ai-gateway-main-processor ai-gateway-api-key-service \
-             ai-gateway-controller ai-gateway-extproc; do
+             ai-gateway-controller ai-gateway-extproc \
+             envoy-gateway envoy-ratelimit presidio-analyzer; do
   # Digest lookup via docker buildx (swap for `crane digest` or `oras resolve`).
   DIGEST=$(docker buildx imagetools inspect "$BASE/$IMAGE:$VERSION" \
     --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')


### PR DESCRIPTION
### Description

The "Which images are signed" table in the artifact-verification guide had drifted from reality:

- `thv` (the CLI/API server image) was missing entirely — it's built and signed via `_release-image.yml` just like `operator`/`proxyrunner`.
- Envoy Gateway, Envoy Ratelimit, and Presidio were listed under "third-party, not re-signed." That was true once, but since stacklok/stacklok-enterprise-platform#2332 they're repackaged and Stacklok-signed (signature + SBOM + provenance + OpenVEX) through `_release-upstream-repackaged.yml`, same as `ai-gateway-controller`/`ai-gateway-extproc`. Telling a customer to check the upstream publisher's signature instead of Stacklok's for these images was actively misleading.
- Added the newly-corrected images to the "verify across all images" loop script.

`connector-gateway` is intentionally **not** added — it's still pre-release and not yet customer-facing.

A follow-up commit also rebrands the "Replicated SDK" display name to "Stacklok License Manager" throughout the page, matching stacklok/stacklok-enterprise-platform#2167, which set `nameOverride: stacklok-license-manager` on the SDK subchart — the component now appears as `stacklok-license-manager-*` in `kubectl get pods`, not `replicated-*`. The underlying image name/pull path (`replicated-sdk-image`, pulled directly from `proxy.replicated.com`, not through `image-proxy.stacklok.com`) is unchanged and called out explicitly — that's the vendor's own artifact name, not ours to rename. It remains the only genuine third-party passthrough image in the table.

### Type of change

- Documentation update
- Bug fix (typo, broken link, etc.)

### Verification

Verified live against the actual v0.7.0 release, through the real customer path (`docker login image-proxy.stacklok.com` with a live license, then `cosign verify` / `cosign verify-attestation` through the proxy) — not just against the origin registry. For every image touched by the first commit (`thv`, `envoy-gateway`, `envoy-ratelimit`, `presidio-analyzer`), confirmed all four artifacts present and valid: signature, SBOM (`spdxjson`), SLSA provenance (`slsaprovenance1`), and OpenVEX.

The rebrand commit is a display-name/prose change only (no new commands to verify) — confirmed the new pod-name claim against the vendored Replicated SDK chart's `_helpers.tpl` (`nameOverride` replaces the resource name outright, no prefix).

This follows up on a customer report of a missing OpenVEX attestation, root-caused and fixed in stacklok/stacklok-enterprise-platform#2477 (a staging-tag race in the release pipeline); this PR corrects the docs' image inventory and naming that were found stale while validating that fix.

### Related issues/PRs

stacklok/stacklok-enterprise-platform#2477
stacklok/stacklok-enterprise-platform#2167
stacklok/stacklok-enterprise-platform#2500 (same rebrand, install-helm.md)

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and style