### PR TITLE
Add directory admin access setup guide

### DIFF
--- a/docs/platform/enterprise-authz/directory-admin.mdx
+++ b/docs/platform/enterprise-authz/directory-admin.mdx
@@ -6,13 +6,17 @@ description:
   providers.
 ---
 
-The enterprise directory powers the Cloud UI's **Users** page and its REST API
-(`/v1/users`, `/v1/groups`, and related endpoints). Access to it is a separate
-grant from the `toolhive.enterprise.stacklok.com` roles described in
-[Introduction to enterprise authorization](./intro.mdx): the built-in `reader`
-and `writer` `ClusterPlatformRole` objects only cover MCP server access, so a
-directory-scoped role is always required, even for a cluster admin who already
-holds `writer`.
+The **enterprise directory** is Stacklok's own internal registry of platform
+users and groups — not your identity provider's own directory or tenant (for
+example, what Microsoft Entra ID calls your "directory" is your Entra tenant;
+the two are unrelated here). It powers the Cloud UI's **Users** page and its
+REST API (`/v1/users`, `/v1/groups`, and related endpoints).
+
+Access to it is a separate grant from the `toolhive.enterprise.stacklok.com`
+roles described in [Introduction to enterprise authorization](./intro.mdx): the
+built-in `reader` and `writer` `ClusterPlatformRole` objects only cover MCP
+server access, so a directory-scoped role is always required, even for a cluster
+admin who already holds `writer`.
 
 Without this grant, a caller sees `403 caller is not a directory admin` on every
 directory endpoint.
@@ -32,6 +36,11 @@ satisfies this check, since the wildcard expands to every action registered for
 the group.
 
 ## Step 1: Define the ClusterPlatformRole
+
+`directory-admin` below is just an example name — unlike the built-in
+`reader`/`writer` roles referenced elsewhere in this section, which are fixed,
+pre-shipped names, this one is a plain Kubernetes object name you can call
+anything you like.
 
 ```yaml title="directory-admin-role.yaml"
 apiVersion: platform.enterprise.stacklok.com/v1alpha1
@@ -62,11 +71,14 @@ spec:
         kind: ClusterPlatformRole
         name: directory-admin
       from:
-        - groups: ['platform-admins']
+        - groups: ['directory-admin']
 ```
 
-The value must match exactly what your IdP emits in the `groups` claim (a group
-name, not necessarily a display name — check a decoded token if you're unsure).
+`directory-admin` here is an illustrative group name — replace it with a group
+that already exists in your IdP (e.g. an existing "platform-admins" or "IT-ops"
+group), rather than creating a new one just for this. The value must match
+exactly what your IdP emits in the `groups` claim (a group name, not necessarily
+a display name — check a decoded token if you're unsure).
 
 ### Microsoft Entra ID
 

--- a/docs/platform/enterprise-authz/directory-admin.mdx
+++ b/docs/platform/enterprise-authz/directory-admin.mdx
@@ -1,0 +1,173 @@
+---
+title: Set up directory admin access
+description:
+  Grant admin access to the enterprise directory (Users) with a
+  ClusterPlatformRole and a binding, for both group- and role-based identity
+  providers.
+---
+
+The enterprise directory powers the Cloud UI's **Users** page and its REST API
+(`/v1/users`, `/v1/groups`, and related endpoints). Access to it is a separate
+grant from the `toolhive.enterprise.stacklok.com` roles described in
+[Introduction to enterprise authorization](./intro.mdx): the built-in `reader`
+and `writer` `ClusterPlatformRole` objects only cover MCP server access, so a
+directory-scoped role is always required, even for a cluster admin who already
+holds `writer`.
+
+Without this grant, a caller sees `403 caller is not a directory admin` on every
+directory endpoint.
+
+## The directory product action
+
+The directory service registers its own product API group,
+`directory.enterprise.stacklok.com`, with a single action:
+
+| Action  | Grants                                                             |
+| ------- | ------------------------------------------------------------------ |
+| `admin` | Full access to every directory read endpoint (users, groups, keys) |
+
+There is no narrower `read`-only action yet; `admin` is all-or-nothing until the
+directory write surface ships a more granular vocabulary. `actions: ["*"]` also
+satisfies this check, since the wildcard expands to every action registered for
+the group.
+
+## Step 1: Define the ClusterPlatformRole
+
+```yaml title="directory-admin-role.yaml"
+apiVersion: platform.enterprise.stacklok.com/v1alpha1
+kind: ClusterPlatformRole
+metadata:
+  name: directory-admin
+spec:
+  description: 'Full admin over the enterprise directory (Users)'
+  productActions:
+    - apiGroup: directory.enterprise.stacklok.com
+      actions: ['admin']
+```
+
+## Step 2: Bind it to your identity provider
+
+Which claim to bind on depends on your IdP.
+
+### Group-based IdPs (Okta, generic OIDC)
+
+```yaml title="directory-admin-binding.yaml"
+apiVersion: platform.enterprise.stacklok.com/v1alpha1
+kind: ClusterPlatformRoleBinding
+metadata:
+  name: directory-admins
+spec:
+  bindings:
+    - roleRef:
+        kind: ClusterPlatformRole
+        name: directory-admin
+      from:
+        - groups: ['platform-admins']
+```
+
+The value must match exactly what your IdP emits in the `groups` claim (a group
+name, not necessarily a display name — check a decoded token if you're unsure).
+
+### Microsoft Entra ID
+
+Entra's default `groups` claim carries group **object IDs** (GUIDs), not display
+names, so bind on an **App Role** instead — the same pattern used in
+[Quickstart - GitHub MCP with Entra ID](./quickstart-entra.mdx):
+
+1. On your app registration, add an **App role** with member type
+   **Users/Groups** and a **Value** of `directory-admin` (or any string matching
+   `^[a-z][a-z0-9_]*$`).
+2. On the matching **Enterprise application** > **Users and groups**, assign the
+   role to the users or groups who need directory access.
+3. On that Enterprise application's **Properties**, set **Assignment required**
+   to **Yes**, so unassigned users get tokens with an empty `roles` claim rather
+   than an implicit grant.
+
+```yaml title="directory-admin-binding.yaml"
+apiVersion: platform.enterprise.stacklok.com/v1alpha1
+kind: ClusterPlatformRoleBinding
+metadata:
+  name: directory-admins
+spec:
+  bindings:
+    - roleRef:
+        kind: ClusterPlatformRole
+        name: directory-admin
+      from:
+        - roles: ['directory-admin']
+```
+
+No claim-name configuration is needed on the platform side for this: Entra ID is
+auto-detected from OIDC discovery, and both the `groups` and `roles` claims are
+read by default. See [Claim mapping](./intro.mdx#claim-mapping) if your tenant
+customizes claim names.
+
+## Step 3: Apply both resources
+
+```bash
+kubectl apply -f directory-admin-role.yaml -f directory-admin-binding.yaml
+```
+
+## Verify
+
+Sign in as a bound user and call the directory REST API directly:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" https://<your-enterprise-manager-host>/v1/users
+```
+
+A `200` with a user list confirms the grant took effect. The **Users** item in
+the Cloud UI's navigation is also gated on this same grant, so it should now
+appear for that user.
+
+## Troubleshooting
+
+<details>
+<summary>Still getting 403 after applying the binding</summary>
+
+The `actions` value is matched with an exact, case-sensitive string comparison —
+`Admin`, `administrator`, or a trailing typo never matches `admin`, and there is
+currently no status condition that surfaces an unrecognized action. Double-check
+the `ClusterPlatformRole`'s `productActions[].actions` reads exactly `admin` (or
+`*`).
+
+Also confirm the binding's `from[].groups` or `from[].roles` value matches what
+your IdP actually emits — decode the caller's JWT (`jwt decode <token>` or
+`https://jwt.io`) and compare against the claim your platform identity-provider
+ConfigMap is configured to read (see
+[Claim mapping](./intro.mdx#claim-mapping)).
+
+</details>
+
+<details>
+<summary>Getting a 503 instead of a 403</summary>
+
+A `503 admin auth not yet configured` means the directory module's admin
+determiner never got wired up (no cluster cache client available at startup),
+which is a platform configuration issue, not a missing grant. This is
+independent of anything covered on this page — check the enterprise manager's
+startup logs for cache/controller-runtime errors.
+
+</details>
+
+<details>
+<summary>Tokens are missing the `roles` or `groups` claim</summary>
+
+For Entra, this means the user isn't assigned to the App Role yet. Open the
+enterprise application's **Users and groups** page and add the assignment; see
+the equivalent troubleshooting entry in
+[Quickstart - GitHub MCP with Entra ID](./quickstart-entra.mdx) for how to
+verify with the Microsoft Graph API.
+
+</details>
+
+## Next steps
+
+- See every field on both resources in the
+  [ClusterPlatformRole](../reference/crds/clusterplatformrole.mdx) and
+  [ClusterPlatformRoleBinding](../reference/crds/clusterplatformrolebinding.mdx)
+  CRD references.
+- Read [Introduction to enterprise authorization](./intro.mdx) for how claim
+  mapping and bindings work in general.
+- [Quickstart - GitHub MCP with Entra ID](./quickstart-entra.mdx) walks the same
+  App Role pattern end-to-end against a real Entra tenant.

--- a/docs/platform/enterprise-authz/directory-admin.mdx
+++ b/docs/platform/enterprise-authz/directory-admin.mdx
@@ -71,14 +71,14 @@ spec:
         kind: ClusterPlatformRole
         name: directory-admin
       from:
-        - groups: ['directory-admin']
+        - groups: ['stacklok-directory-admin']
 ```
 
-`directory-admin` here is an illustrative group name — replace it with a group
-that already exists in your IdP (e.g. an existing "platform-admins" or "IT-ops"
-group), rather than creating a new one just for this. The value must match
-exactly what your IdP emits in the `groups` claim (a group name, not necessarily
-a display name — check a decoded token if you're unsure).
+`stacklok-directory-admin` here is an illustrative group name — replace it with
+a group that already exists in your IdP (e.g. an existing "platform-admins" or
+"IT-ops" group), rather than creating a new one just for this. The value must
+match exactly what your IdP emits in the `groups` claim (a group name, not
+necessarily a display name — check a decoded token if you're unsure).
 
 ### Microsoft Entra ID
 
@@ -87,8 +87,11 @@ names, so bind on an **App Role** instead — the same pattern used in
 [Quickstart - GitHub MCP with Entra ID](./quickstart-entra.mdx):
 
 1. On your app registration, add an **App role** with member type
-   **Users/Groups** and a **Value** of `directory-admin` (or any string matching
-   `^[a-z][a-z0-9_]*$`).
+   **Users/Groups** and a **Value** of `stacklok-directory-admin` (or another
+   name of your choosing — prefixing it identifies the role as Stacklok-specific
+   in your tenant's App Roles list, rather than reading like a generic
+   "directory admin," a term commonly used for Active Directory/LDAP
+   administration).
 2. On the matching **Enterprise application** > **Users and groups**, assign the
    role to the users or groups who need directory access.
 3. On that Enterprise application's **Properties**, set **Assignment required**
@@ -106,7 +109,7 @@ spec:
         kind: ClusterPlatformRole
         name: directory-admin
       from:
-        - roles: ['directory-admin']
+        - roles: ['stacklok-directory-admin']
 ```
 
 No claim-name configuration is needed on the platform side for this: Entra ID is

--- a/docs/platform/enterprise-authz/intro.mdx
+++ b/docs/platform/enterprise-authz/intro.mdx
@@ -47,9 +47,12 @@ have used Kubernetes RBAC, the shape will feel familiar.
 - **`ClusterPlatformRole`**
   ([reference](../reference/crds/clusterplatformrole.mdx)) defines _what_ a role
   can do. It is product-agnostic. Per-product action vocabularies live under
-  `spec.productActions[]`, keyed by API group. The only supported product API
-  group is `toolhive.enterprise.stacklok.com`. Wildcard `"*"` is allowed, which
-  is how the built-in `writer` role grants every action.
+  `spec.productActions[]`, keyed by API group. This page covers
+  `toolhive.enterprise.stacklok.com` (MCP server access); the enterprise
+  directory registers its own group, `directory.enterprise.stacklok.com`,
+  covered in [Set up directory admin access](./directory-admin.mdx). Wildcard
+  `"*"` is allowed within a group, which is how the built-in `writer` role
+  grants every MCP action.
 - **`ClusterPlatformRoleBinding`**
   ([reference](../reference/crds/clusterplatformrolebinding.mdx)) defines _who_
   gets a role, cluster-wide. It maps identity-provider groups and roles (as
@@ -130,6 +133,8 @@ narrower action vocabulary than `reader` and `writer` offer.
   walkthrough against a real identity provider
 - [Namespace self-service authorization](./namespace-self-service.mdx) to see
   how a namespace owner authors their own bindings
+- [Set up directory admin access](./directory-admin.mdx) to grant access to the
+  Cloud UI's Users page and the directory REST API
 - [ToolhiveAuthorizationPolicy](../reference/crds/toolhiveauthorizationpolicy.mdx)
   for the full schema of the attachment object that ties everything together
 - [Cedar policies](../../toolhive/concepts/cedar-policies.mdx) and the

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -390,6 +390,7 @@ const platformSidebar: SidebarsConfig[string] = [
       'platform/enterprise-authz/intro',
       'platform/enterprise-authz/quickstart-entra',
       'platform/enterprise-authz/namespace-self-service',
+      'platform/enterprise-authz/directory-admin',
     ],
   },
 


### PR DESCRIPTION
### Description

Adds a setup guide for granting "directory admin" access — the RBAC gate on the Cloud UI's Users page and the directory REST API (`/v1/users`, `/v1/groups`, ...). This surface uses the same `ClusterPlatformRole`/`ClusterPlatformRoleBinding` mechanism as MCP server authorization, but registers its own product API group (`directory.enterprise.stacklok.com`), which wasn't documented anywhere — the built-in `reader`/`writer` roles don't cover it, so a caller without a dedicated grant sees `403 caller is not a directory admin` with no path to self-serve a fix.

New page: `docs/platform/enterprise-authz/directory-admin.mdx` covers:
- The `directory.enterprise.stacklok.com`/`admin` product action (all-or-nothing today, no granular read/write yet)
- Example manifests for both group-based IdPs and Microsoft Entra ID (App Roles, since Entra's default `groups` claim carries GUIDs rather than names)
- A verification step and troubleshooting entries (exact-match, case-sensitive action check with no vocabulary validation yet; 403 vs 503 distinction)

Also corrects a stale claim in `intro.mdx` — it said `toolhive.enterprise.stacklok.com` is "the only supported product API group," which predates the directory module adopting the same CRDs.

### Type of change

- New documentation
- Bug fix (typo, broken link, etc.)

### Related issues/PRs

Written up after a real customer support question hit this exact gap (no existing doc covered `directory.enterprise.stacklok.com`, in this repo or internally).

### Submitter checklist

- [x] I have reviewed the content for technical accuracy (cross-checked against `enterprise/toolhive-enterprise/internal/directory/app/admin_auth.go`, `internal/platform/rbac/admin_determiner.go`, `internal/directory/infra/k8s/admin_grant.go`, and a working example in `infra`'s staging overlay)
- [ ] I have reviewed the content for spelling, grammar, and style
- [x] New pages include a frontmatter section with title and description at a minimum
- [x] Sidebar navigation (`sidebars.ts`) updated

### Screenshots

N/A — text-only content change; `npm run build` could not be run locally in this environment due to an unrelated `thv` CLI session expiry in the `mcp-metadata-plugin` (confirmed via a clean-checkout stash test that the failure is pre-existing and unrelated to this change). `prettier`/`eslint` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)