### PR TITLE
Document registry server_api_url for the Cloud UI

### DIFF
--- a/docs/platform/enterprise-cloud-ui/configure.mdx
+++ b/docs/platform/enterprise-cloud-ui/configure.mdx
@@ -280,19 +280,6 @@ This means you can omit `API_BASE_URL` entirely and let the Enterprise Manager
 control the registry URL, or set `API_BASE_URL` as a fallback for when the
 Enterprise Manager is unreachable.
 
-:::note
-
-The Cloud UI reads the registry policy's `server_api_url` (the Registry Server's
-API root), not its `api_url`. The `api_url` value is for ToolHive clients and
-can point at a single registry (for example,
-`https://registry.example.com/registry/toolhive`); the Cloud UI's API routes are
-relative to the server root, so pointing it at a per-registry URL results in
-`404` errors. See
-[Registry URL for the Cloud UI](../enterprise-manager/policies/registry.mdx#registry-url-for-the-cloud-ui)
-for details.
-
-:::
-
 ## Feature flags
 
 The [Enterprise Manager](../enterprise-manager/index.mdx) controls Cloud UI

--- a/docs/platform/enterprise-cloud-ui/configure.mdx
+++ b/docs/platform/enterprise-cloud-ui/configure.mdx
@@ -283,10 +283,10 @@ Enterprise Manager is unreachable.
 :::note
 
 The Cloud UI reads the registry policy's `server_api_url` (the Registry Server's
-API root), not its `api_url`. The `api_url` value is shaped for ToolHive clients
-and typically points at a single registry (for example,
+API root), not its `api_url`. The `api_url` value is for ToolHive clients and
+can point at a single registry (for example,
 `https://registry.example.com/registry/toolhive`); the Cloud UI's API routes are
-relative to the server root, so pointing it at the client-shaped URL results in
+relative to the server root, so pointing it at a per-registry URL results in
 `404` errors. See
 [Registry URL for the Cloud UI](../enterprise-manager/policies/registry.mdx#registry-url-for-the-cloud-ui)
 for details.

--- a/docs/platform/enterprise-cloud-ui/configure.mdx
+++ b/docs/platform/enterprise-cloud-ui/configure.mdx
@@ -271,14 +271,27 @@ browser always loads them over the same protocol it uses to access the Cloud UI
 The Cloud UI resolves the Registry Server API URL dynamically:
 
 1. If an [Enterprise Manager](../enterprise-manager/index.mdx) is configured and
-   the [registry policy](../enterprise-manager/policies/registry.mdx) has an
-   `api_url` value, the Cloud UI uses that URL.
+   the [registry policy](../enterprise-manager/policies/registry.mdx) has a
+   `server_api_url` value, the Cloud UI uses that URL.
 2. Otherwise, the Cloud UI falls back to the `API_BASE_URL` environment
    variable.
 
 This means you can omit `API_BASE_URL` entirely and let the Enterprise Manager
 control the registry URL, or set `API_BASE_URL` as a fallback for when the
 Enterprise Manager is unreachable.
+
+:::note
+
+The Cloud UI reads the registry policy's `server_api_url` (the Registry Server's
+API root), not its `api_url`. The `api_url` value is shaped for ToolHive clients
+and typically points at a single registry (for example,
+`https://registry.example.com/registry/toolhive`); the Cloud UI's API routes are
+relative to the server root, so pointing it at the client-shaped URL results in
+`404` errors. See
+[Registry URL for the Cloud UI](../enterprise-manager/policies/registry.mdx#registry-url-for-the-cloud-ui)
+for details.
+
+:::
 
 ## Feature flags
 

--- a/docs/platform/enterprise-manager/policies/registry.mdx
+++ b/docs/platform/enterprise-manager/policies/registry.mdx
@@ -74,7 +74,7 @@ connect to the registry differently. The `api_url` value is for ToolHive clients
 (CLI and Stacklok Desktop): depending on your registry, that's either the
 registry's root URL (as in the examples above) or a per-registry path on a
 Stacklok Registry Server (for example,
-`https://registry.acme.com/registry/<REGISTRY_NAME>`). The
+`https://registry.example.com/registry/<REGISTRY_NAME>`). The
 [Enterprise Cloud UI](../../enterprise-cloud-ui/configure.mdx) needs the
 Registry Server's API root instead, set with `server_api_url`:
 
@@ -83,9 +83,9 @@ enterpriseConfig:
   registry:
     value:
       # For ToolHive clients: the registry API URL (one registry)
-      api_url: 'https://registry.acme.com/registry/toolhive'
+      api_url: 'https://registry.example.com/registry/toolhive'
       # For the Cloud UI: the Registry Server's API root
-      server_api_url: 'https://registry.acme.com'
+      server_api_url: 'https://registry.example.com'
     enforcement: 'enforced'
 ```
 

--- a/docs/platform/enterprise-manager/policies/registry.mdx
+++ b/docs/platform/enterprise-manager/policies/registry.mdx
@@ -69,13 +69,14 @@ enterpriseConfig:
 
 ### Registry URL for the Cloud UI
 
-The registry directive carries two distinct URLs because its two consumers
-expect different shapes. The `api_url` value is for ToolHive clients (CLI and
-Stacklok Desktop): depending on your registry, that's either the registry's root
-URL (as in the examples above) or a per-registry path on a Stacklok Registry
-Server (for example, `https://registry.acme.com/registry/toolhive`). The
-[Enterprise Cloud UI](../../enterprise-cloud-ui/configure.mdx) instead needs the
-Registry Server's API root, set with `server_api_url`:
+The registry directive sets two URLs because ToolHive clients and the Cloud UI
+connect to the registry differently. The `api_url` value is for ToolHive clients
+(CLI and Stacklok Desktop): depending on your registry, that's either the
+registry's root URL (as in the examples above) or a per-registry path on a
+Stacklok Registry Server (for example,
+`https://registry.acme.com/registry/<REGISTRY_NAME>`). The
+[Enterprise Cloud UI](../../enterprise-cloud-ui/configure.mdx) needs the
+Registry Server's API root instead, set with `server_api_url`:
 
 ```yaml title="values.yaml"
 enterpriseConfig:
@@ -88,19 +89,9 @@ enterpriseConfig:
     enforcement: 'enforced'
 ```
 
-Don't point the Cloud UI at a per-registry `api_url` value. The Cloud UI's API
-routes are relative to the server root, so requests return `404` errors. When
-`server_api_url` isn't set, the Cloud UI falls back to its `API_BASE_URL`
+When `server_api_url` isn't set, the Cloud UI falls back to its `API_BASE_URL`
 environment variable (see
 [Registry API URL resolution](../../enterprise-cloud-ui/configure.mdx#registry-api-url-resolution)).
-
-:::warning
-
-The Enterprise Manager rejects configuration fields it doesn't recognize and
-refuses to start. When upgrading, deploy the platform version that introduces
-`server_api_url` **before** adding the field to your configuration.
-
-:::
 
 ## Next steps
 

--- a/docs/platform/enterprise-manager/policies/registry.mdx
+++ b/docs/platform/enterprise-manager/policies/registry.mdx
@@ -71,7 +71,8 @@ enterpriseConfig:
 
 The registry directive carries two distinct URLs because its two consumers
 expect different shapes. The `api_url` value is for ToolHive clients (CLI and
-Stacklok Desktop) and typically points at a single registry on your Registry
+Stacklok Desktop): depending on your registry, that's either the registry's root
+URL (as in the examples above) or a per-registry path on a Stacklok Registry
 Server (for example, `https://registry.acme.com/registry/toolhive`). The
 [Enterprise Cloud UI](../../enterprise-cloud-ui/configure.mdx) instead needs the
 Registry Server's API root, set with `server_api_url`:
@@ -87,8 +88,8 @@ enterpriseConfig:
     enforcement: 'enforced'
 ```
 
-Don't point the Cloud UI at the client-shaped `api_url` — its API routes are
-relative to the server root, so requests return `404` errors. When
+Don't point the Cloud UI at a per-registry `api_url` value. The Cloud UI's API
+routes are relative to the server root, so requests return `404` errors. When
 `server_api_url` isn't set, the Cloud UI falls back to its `API_BASE_URL`
 environment variable (see
 [Registry API URL resolution](../../enterprise-cloud-ui/configure.mdx#registry-api-url-resolution)).

--- a/docs/platform/enterprise-manager/policies/registry.mdx
+++ b/docs/platform/enterprise-manager/policies/registry.mdx
@@ -67,6 +67,40 @@ enterpriseConfig:
     enforcement: 'enforced'
 ```
 
+### Registry URL for the Cloud UI
+
+The registry directive carries two distinct URLs because its two consumers
+expect different shapes. The `api_url` value is for ToolHive clients (CLI and
+Stacklok Desktop) and typically points at a single registry on your Registry
+Server (for example, `https://registry.acme.com/registry/toolhive`). The
+[Enterprise Cloud UI](../../enterprise-cloud-ui/configure.mdx) instead needs the
+Registry Server's API root, set with `server_api_url`:
+
+```yaml title="values.yaml"
+enterpriseConfig:
+  registry:
+    value:
+      # For ToolHive clients: the registry API URL (one registry)
+      api_url: 'https://registry.acme.com/registry/toolhive'
+      # For the Cloud UI: the Registry Server's API root
+      server_api_url: 'https://registry.acme.com'
+    enforcement: 'enforced'
+```
+
+Don't point the Cloud UI at the client-shaped `api_url` — its API routes are
+relative to the server root, so requests return `404` errors. When
+`server_api_url` isn't set, the Cloud UI falls back to its `API_BASE_URL`
+environment variable (see
+[Registry API URL resolution](../../enterprise-cloud-ui/configure.mdx#registry-api-url-resolution)).
+
+:::warning
+
+The Enterprise Manager rejects configuration fields it doesn't recognize and
+refuses to start. When upgrading, deploy the platform version that introduces
+`server_api_url` **before** adding the field to your configuration.
+
+:::
+
 ## Next steps
 
 - [Non-registry servers policy](./non-registry-servers.mdx) to control whether


### PR DESCRIPTION
### Description

[stacklok-enterprise-platform#2823](https://github.com/stacklok/stacklok-enterprise-platform/pull/2823) split the enterprise config's registry directive into two URLs: `api_url` stays the ToolHive-client-shaped registry endpoint (scoped to one registry, e.g. `https://registry.acme.com/registry/toolhive`), and the new `server_api_url` is the Registry Server API **root** the Cloud UI resolves against.

Two pages needed updating:

- **`enterprise-cloud-ui/configure.mdx`** — the "Registry API URL resolution" section named `api_url` as the config-server source for the Cloud UI, which after the split is the one value it deliberately ignores. Updated to `server_api_url`, with a note explaining the two URL shapes and why pointing the Cloud UI at the client-shaped URL 404s.
- **`enterprise-manager/policies/registry.mdx`** — new "Registry URL for the Cloud UI" variation documenting both fields side by side, plus a warning on the upgrade-ordering rule: the Enterprise Manager rejects unknown configuration fields and refuses to start, so the platform version introducing `server_api_url` must be deployed before the field is added to config.

`npm run build` passes (anchors/links verified by the build).

### Type of change

- Documentation update

### Related issues/PRs

- stacklok/stacklok-enterprise-platform#2823 (the field split)
- stacklok/stacklok-enterprise-platform#2830 (same update to the in-repo install runbook)

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)