### PR TITLE
Add zizmor GitHub Actions security scan to CI

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,10 +1,21 @@
 name: 'Setup Action'
 description: 'Checks out the repo, sets up node, and installs dependencies'
+inputs:
+  persist-credentials:
+    description: >-
+      Whether the checkout should keep the GITHUB_TOKEN credential in
+      the local git config. Callers that push commits after this
+      action runs (e.g. the upstream-release-docs bootstrap step)
+      need this set to 'true'; everything else should pass 'false'.
+    required: false
+    default: 'true'
 runs:
   using: 'composite'
   steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: ${{ inputs.persist-credentials }}
 
     - name: Set up Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,11 +4,11 @@ inputs:
   persist-credentials:
     description: >-
       Whether the checkout should keep the GITHUB_TOKEN credential in
-      the local git config. Callers that push commits after this
+      the local git config. Only callers that push commits after this
       action runs (e.g. the upstream-release-docs bootstrap step)
-      need this set to 'true'; everything else should pass 'false'.
+      need this set to 'true'.
     required: false
-    default: 'true'
+    default: 'false'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/_static-checks.yaml
+++ b/.github/workflows/_static-checks.yaml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          persist-credentials: false
 
       - name: Run ESLint
         run: npm run eslint

--- a/.github/workflows/_static-checks.yaml
+++ b/.github/workflows/_static-checks.yaml
@@ -13,9 +13,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          persist-credentials: false
 
       - name: Run ESLint
         run: npm run eslint

--- a/.github/workflows/autogen-docs-notify.yml
+++ b/.github/workflows/autogen-docs-notify.yml
@@ -55,7 +55,12 @@ name: Autogen Docs Slack Notify
 # directly as an env var below (DOCS_SLACK_CHANNEL_ID), not as a secret.
 # ---------------------------------------------------------------------
 
-on:
+# workflow_run is used deliberately here, not as an oversight. See
+# the SECURITY MODEL comment above: it always runs the trusted
+# main-branch definition, never checks out or executes PR-supplied
+# code, and the Claude step has no Slack token or network access
+# beyond `gh`.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ['Upstream Release Docs']
     types: [completed]
@@ -96,11 +101,14 @@ jobs:
       # Sets skip=true and exits cleanly when the PR is out of scope.
       - name: Resolve PR and check eligibility
         id: pr
+        env:
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ inputs.pr_number }}"
+            PR_NUMBER="$DISPATCH_PR_NUMBER"
           else
-            PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+            PR_NUMBER="$WORKFLOW_RUN_PR_NUMBER"
             if [ -z "$PR_NUMBER" ]; then
               echo "No PR associated with this workflow run; skipping."
               echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -136,6 +144,8 @@ jobs:
       - name: Checkout base branch
         if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # STEP 1 — Claude composes content only. Tools limited to gh + Write.
       # No Slack token in this step's env; no curl tool. So even a prompt
       # injection from PR content cannot exfiltrate the Slack token (absent)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,8 +53,6 @@ jobs:
       # scripts when asked.
       - name: Set up repo and dependencies
         uses: ./.github/actions/setup
-        with:
-          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,11 +47,14 @@ jobs:
         with:
           fetch-depth: 1
           sparse-checkout: .github
+          persist-credentials: false
 
       # Checkout + Node + deps so Claude can run build/lint/format
       # scripts when asked.
       - name: Set up repo and dependencies
         uses: ./.github/actions/setup
+        with:
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -151,10 +151,14 @@ jobs:
       # <branch>`), bump the YAML, create the PR, and emit its number +
       # branch so the rest of the workflow proceeds as if Renovate had
       # opened it.
+      # persist-credentials must stay true here: the "Bootstrap
+      # branch and PR" step below pushes a new branch with this
+      # checkout's credential. No artifact upload runs in this job,
+      # and only trusted, pinned actions run afterward.
       - name: Checkout dispatching branch for bootstrap
         if: steps.pr.outputs.mode == 'bootstrap'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
+        with: # zizmor: ignore[artipacked]
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
@@ -285,9 +289,14 @@ jobs:
             echo "PR #$PR_NUMBER is already a draft; nothing to do."
           fi
 
+      # persist-credentials must stay true here: the "Commit + push
+      # refreshed reference assets" and "Commit and push" steps below
+      # both push to this branch with this checkout's credential. No
+      # artifact upload runs in this job, and only trusted, pinned
+      # actions run afterward.
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
+        with: # zizmor: ignore[artipacked]
           ref: ${{ steps.eff.outputs.head_ref }}
           fetch-depth: 0
 

--- a/.github/workflows/upstream-release-docs.yml
+++ b/.github/workflows/upstream-release-docs.yml
@@ -161,10 +161,13 @@ jobs:
         with: # zizmor: ignore[artipacked]
           ref: ${{ github.ref_name }}
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Setup (bootstrap)
         if: steps.pr.outputs.mode == 'bootstrap'
         uses: ./.github/actions/setup
+        with:
+          persist-credentials: true
 
       - name: Set up Git (bootstrap)
         if: steps.pr.outputs.mode == 'bootstrap'
@@ -299,6 +302,7 @@ jobs:
         with: # zizmor: ignore[artipacked]
           ref: ${{ steps.eff.outputs.head_ref }}
           fetch-depth: 0
+          persist-credentials: true
 
       # NOTE: we inline the node/deps setup rather than calling the
       # ./.github/actions/setup composite because that composite starts

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,27 @@
+name: 'GitHub Actions Security (zizmor)'
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          inputs: ./.github/workflows/
+          advanced-security: 'false'
+          annotations: 'true'


### PR DESCRIPTION
### Description

Ran zizmor (a GitHub Actions security auditor) against this repo's workflows and fixed what it found:

- A template-injection risk in `autogen-docs-notify.yml`, where a workflow input was interpolated directly into a shell script instead of passed through `env`.
- Several checkouts that don't push commits afterward now set `persist-credentials: false`, including a new passthrough input on the shared `./.github/actions/setup` composite action.
- The two checkouts that do need to keep credentials (because a later step pushes with them), and the `workflow_run` trigger in `autogen-docs-notify.yml` (deliberate and already documented in that file's security-model comment), are suppressed with inline `zizmor: ignore` comments explaining why.

Also adds a `zizmor.yaml` workflow that runs zizmor on every push to `main` and every PR, mirroring the setup already used in `stacklok/infra`, so future workflow changes get flagged automatically instead of relying on someone running it locally.

### Type of change

Other (internal)