### PR TITLE
Scope zizmor CI scan to .github changes only

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -3,7 +3,13 @@ name: 'GitHub Actions Security (zizmor)'
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
   pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
 
 permissions: {}
 
@@ -22,6 +28,6 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
-          inputs: ./.github/workflows/
+          inputs: ./.github/workflows/ ./.github/actions/
           advanced-security: 'false'
           annotations: 'true'


### PR DESCRIPTION
### Description

Follow-up to #1094:

- Add a `paths:` filter so the zizmor workflow only runs on pushes/PRs that touch `.github/workflows/` or `.github/actions/`, instead of every push and PR.
- Widen the scan itself to include `.github/actions/` (composite actions), which the workflow wasn't auditing in CI at all — the setup-action fix in #1094 was only caught by running zizmor locally against both directories.

A `paths:` filter is safe here since this check isn't a required status check today (only Vercel is) — it won't cause the "permanently pending required check" problem that can happen if a path-filtered check is later made required.

### Type of change

Other (internal)
