### PR TITLE
Update stacklok/toolhive to v0.42.1 (Codex)

### DIFF
--- a/.github/upstream-projects.yaml
+++ b/.github/upstream-projects.yaml
@@ -44,7 +44,7 @@ projects:
 
   - id: toolhive
     repo: stacklok/toolhive
-    version: v0.42.0
+    version: v0.42.1
     # toolhive is a monorepo covering the CLI, the Kubernetes
     # operator, and the vMCP gateway. It also introduces cross-
     # cutting features that land in concepts/, integrations/,

--- a/docs/toolhive/concepts/cedar-policies.mdx
+++ b/docs/toolhive/concepts/cedar-policies.mdx
@@ -470,8 +470,8 @@ header, a non-JSON media type, or a near match such as `application/json-rpc`
 returns `400 Invalid or malformed MCP request` before ToolHive forwards the
 request.
 
-This applies to the transparent proxy as well as ordinary MCP endpoints. If a
-backend also exposes non-MCP form or upload endpoints, route those endpoints
+This requirement applies to the transparent proxy and standard MCP endpoints. If
+a backend also exposes non-MCP form or upload endpoints, route those endpoints
 outside a Cedar-enabled transparent proxy.
 
 ## List operations and filtering

--- a/docs/toolhive/concepts/cedar-policies.mdx
+++ b/docs/toolhive/concepts/cedar-policies.mdx
@@ -461,6 +461,19 @@ permit(principal, action == Action::"call_tool", resource == Tool::"weather") wh
 This policy allows weather tool calls only for specific locations, demonstrating
 how you can control access based on request parameters.
 
+## JSON request requirement
+
+When Cedar authorization is enabled, every MCP `POST` request must identify its
+body as JSON. Use `Content-Type: application/json`; media type matching is
+case-insensitive, and parameters such as `charset=utf-8` are accepted. A missing
+header, a non-JSON media type, or a near match such as `application/json-rpc`
+returns `400 Invalid or malformed MCP request` before ToolHive forwards the
+request.
+
+This applies to the transparent proxy as well as ordinary MCP endpoints. If a
+backend also exposes non-MCP form or upload endpoints, route those endpoints
+outside a Cedar-enabled transparent proxy.
+
 ## List operations and filtering
 
 List operations (`tools/list`, `prompts/list`, `resources/list`) bypass

--- a/docs/toolhive/concepts/embedded-auth-server.mdx
+++ b/docs/toolhive/concepts/embedded-auth-server.mdx
@@ -140,64 +140,6 @@ authorization server minted the token. If your identity provider performs its
 own token exchange and issues tokens carrying `act`, the delegation chain is
 picked up with no extra configuration.
 
-### External subject-token exchange
-
-The embedded auth server's serialized RunConfig accepts `trusted_issuers` for
-RFC 8693 token exchange. This lets the token endpoint validate a subject token
-issued by a corporate OIDC provider, such as Microsoft Entra ID, Okta, or
-Keycloak, and issue a ToolHive-scoped delegated token.
-
-:::warning[No supported end-to-end workflow]
-
-The RunConfig surface is available, but ToolHive cannot currently provision the
-confidential client that the token-exchange grant requires. DCR and CIMD create
-public clients, RunConfig has no client-seeding field, and discovery metadata
-does not advertise this grant or a secret-based client authentication method.
-There is therefore no supported CLI or Kubernetes workflow for exchanging an
-external subject token end to end. Track
-[stacklok/toolhive#6082](https://github.com/stacklok/toolhive/issues/6082) for
-the missing client provisioning and discovery support.
-
-:::
-
-Trusting an issuer is not enough to authorize delegation. A valid signature and
-audience prove that the token was issued for ToolHive, but not that the calling
-ToolHive client may act for its subject. ToolHive therefore requires both an
-issuer-specific consent signal and a ToolHive client binding:
-
-- A valid `may_act` claim can name the ToolHive client that may exchange the
-  token. For external tokens, the issuer configuration still restricts which
-  ToolHive clients may use this path.
-- Without `may_act`, the claim selected by `actor_claim` must match
-  `allowed_actors`. These values identify clients in the external provider's
-  namespace.
-- `allowed_delegate_clients` is required for every trusted issuer and lists the
-  ToolHive client IDs permitted to perform the exchange. Use `"*"` only when
-  every confidential ToolHive client with the token-exchange grant should be
-  allowed.
-
-The per-issuer RunConfig fields are:
-
-| Field                      | Purpose                                                                                                      |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `issuer_url`               | Exact external token `iss` value. HTTPS is required by default.                                              |
-| `expected_audience`        | Resource or API identifier that must appear in the token's `aud` claim.                                      |
-| `jwks_url`                 | Optional JWKS endpoint. When omitted, ToolHive uses OIDC discovery.                                          |
-| `insecure_allow_http`      | Allows HTTP discovery and JWKS requests for this issuer in development.                                      |
-| `allow_private_ips`        | Allows discovery and JWKS requests to private or loopback addresses; requires an explicit `jwks_url`.        |
-| `actor_claim`              | External client claim, defaulting to `azp`; common alternatives are `appid` for Entra v1 and `cid` for Okta. |
-| `allowed_actors`           | Accepted external actor values. When empty, only tokens with `may_act` are accepted.                         |
-| `allowed_delegate_clients` | Required ToolHive client allow-list for both consent paths.                                                  |
-
-Audience and scope remain bounded by the subject token. The requested audience
-must appear in the subject token's `aud` claim and in the embedded auth server's
-allowed audiences. Every requested scope must appear in both the ToolHive
-client's registered scopes and the subject token's `scope` or `scp` claim. An
-exchange that requests no scopes produces a zero-scope delegated token. ToolHive
-qualifies the delegated subject as `<ISSUER_URL>#<EXTERNAL_SUBJECT>` and records
-the external issuer in the nested `act` chain to prevent identity collisions and
-preserve provenance.
-
 :::note
 
 Delegation data is only available when ToolHive validates the token as a JWT

--- a/docs/toolhive/concepts/embedded-auth-server.mdx
+++ b/docs/toolhive/concepts/embedded-auth-server.mdx
@@ -140,6 +140,64 @@ authorization server minted the token. If your identity provider performs its
 own token exchange and issues tokens carrying `act`, the delegation chain is
 picked up with no extra configuration.
 
+### External subject-token exchange
+
+The embedded auth server's serialized RunConfig accepts `trusted_issuers` for
+RFC 8693 token exchange. This lets the token endpoint validate a subject token
+issued by a corporate OIDC provider, such as Microsoft Entra ID, Okta, or
+Keycloak, and issue a ToolHive-scoped delegated token.
+
+:::warning[No supported end-to-end workflow]
+
+The RunConfig surface is available, but ToolHive cannot currently provision the
+confidential client that the token-exchange grant requires. DCR and CIMD create
+public clients, RunConfig has no client-seeding field, and discovery metadata
+does not advertise this grant or a secret-based client authentication method.
+There is therefore no supported CLI or Kubernetes workflow for exchanging an
+external subject token end to end. Track
+[stacklok/toolhive#6082](https://github.com/stacklok/toolhive/issues/6082) for
+the missing client provisioning and discovery support.
+
+:::
+
+Trusting an issuer is not enough to authorize delegation. A valid signature and
+audience prove that the token was issued for ToolHive, but not that the calling
+ToolHive client may act for its subject. ToolHive therefore requires both an
+issuer-specific consent signal and a ToolHive client binding:
+
+- A valid `may_act` claim can name the ToolHive client that may exchange the
+  token. For external tokens, the issuer configuration still restricts which
+  ToolHive clients may use this path.
+- Without `may_act`, the claim selected by `actor_claim` must match
+  `allowed_actors`. These values identify clients in the external provider's
+  namespace.
+- `allowed_delegate_clients` is required for every trusted issuer and lists the
+  ToolHive client IDs permitted to perform the exchange. Use `"*"` only when
+  every confidential ToolHive client with the token-exchange grant should be
+  allowed.
+
+The per-issuer RunConfig fields are:
+
+| Field                      | Purpose                                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `issuer_url`               | Exact external token `iss` value. HTTPS is required by default.                                              |
+| `expected_audience`        | Resource or API identifier that must appear in the token's `aud` claim.                                      |
+| `jwks_url`                 | Optional JWKS endpoint. When omitted, ToolHive uses OIDC discovery.                                          |
+| `insecure_allow_http`      | Allows HTTP discovery and JWKS requests for this issuer in development.                                      |
+| `allow_private_ips`        | Allows discovery and JWKS requests to private or loopback addresses; requires an explicit `jwks_url`.        |
+| `actor_claim`              | External client claim, defaulting to `azp`; common alternatives are `appid` for Entra v1 and `cid` for Okta. |
+| `allowed_actors`           | Accepted external actor values. When empty, only tokens with `may_act` are accepted.                         |
+| `allowed_delegate_clients` | Required ToolHive client allow-list for both consent paths.                                                  |
+
+Audience and scope remain bounded by the subject token. The requested audience
+must appear in the subject token's `aud` claim and in the embedded auth server's
+allowed audiences. Every requested scope must appear in both the ToolHive
+client's registered scopes and the subject token's `scope` or `scp` claim. An
+exchange that requests no scopes produces a zero-scope delegated token. ToolHive
+qualifies the delegated subject as `<ISSUER_URL>#<EXTERNAL_SUBJECT>` and records
+the external issuer in the nested `act` chain to prevent identity collisions and
+preserve provenance.
+
 :::note
 
 Delegation data is only available when ToolHive validates the token as a JWT

--- a/docs/toolhive/guides-cli/ai-plugins.mdx
+++ b/docs/toolhive/guides-cli/ai-plugins.mdx
@@ -122,7 +122,7 @@ Filter by client, scope, or group:
 
 ```bash
 thv ai-plugin list --client claude-code
-thv ai-plugin list --scope project --project-root /path/to/project
+thv ai-plugin list --scope project --project-root .
 thv ai-plugin list --group development
 ```
 
@@ -140,7 +140,7 @@ To see metadata, version, source, and declared contents for an installed plugin:
 thv ai-plugin info my-plugin
 ```
 
-For project-scoped plugins, pass `--scope project --project-root`.
+For project-scoped plugins, pass `--scope project --project-root .`.
 
 ## Uninstall a plugin
 
@@ -152,7 +152,7 @@ For a project-scoped install:
 
 ```bash
 thv ai-plugin uninstall my-plugin --scope project \
-  --project-root /path/to/project
+  --project-root .
 ```
 
 ## Author a plugin
@@ -287,7 +287,7 @@ TOOLHIVE_API_TIMEOUT=30m thv ai-plugin install <PLUGIN_NAME>
 ```
 
 Invalid, zero, or negative values are ignored. A timeout error means the API
-server was reachable but did not finish the operation within the limit.
+server was reachable but did not respond within the limit.
 
 </details>
 

--- a/docs/toolhive/guides-cli/ai-plugins.mdx
+++ b/docs/toolhive/guides-cli/ai-plugins.mdx
@@ -95,8 +95,12 @@ thv ai-plugin install my-plugin
 
 # Project scope
 thv ai-plugin install my-plugin --scope project \
-  --project-root /path/to/project
+  --project-root .
 ```
+
+Relative project roots are resolved from the current working directory. You can
+also pass an absolute path. The same behavior applies to `install`, `info`,
+`list`, and `uninstall`.
 
 ### Overwrite or group
 
@@ -270,6 +274,22 @@ Blobs are retained on disk until every tag pointing to their digest is removed.
   routes expose the same operations for scripting and integration
 
 ## Troubleshooting
+
+<details>
+<summary>`thv ai-plugin` operation times out</summary>
+
+ToolHive allows API operations up to 10 minutes by default so large OCI pulls
+can complete. To use a different client timeout, set `TOOLHIVE_API_TIMEOUT` to a
+positive Go duration:
+
+```bash
+TOOLHIVE_API_TIMEOUT=30m thv ai-plugin install <PLUGIN_NAME>
+```
+
+Invalid, zero, or negative values are ignored. A timeout error means the API
+server was reachable but did not finish the operation within the limit.
+
+</details>
 
 <details>
 <summary>`thv ai-plugin install` reports "plugin not found in local store or registry"</summary>

--- a/docs/toolhive/guides-cli/skills-management.mdx
+++ b/docs/toolhive/guides-cli/skills-management.mdx
@@ -235,11 +235,15 @@ thv skill upgrade --project-root .
 
 A version or tag change within the same OCI repository proceeds without
 `--allow-ref-change`, including a move to an older tag. ToolHive still pins the
-resolved digest and checks for signer changes. If the catalog moves the skill to
-a different repository, organization, or registry, the upgrade is blocked.
-Review the new source, then repeat the command with `--allow-ref-change` if you
-intend to permit that repository move. ToolHive prompts before installing the
-planned changes; pass `--yes` in non-interactive environments.
+resolved digest and blocks signer changes. If the catalog moves the skill to a
+different repository, organization, or registry, the upgrade is blocked. Review
+the new source, then repeat the command with `--allow-ref-change` if you intend
+to permit that repository move. ToolHive prompts before installing the planned
+changes; pass `--yes` in non-interactive environments.
+
+See the
+[`thv skill upgrade` command reference](../reference/cli/thv_skill_upgrade.md)
+for all options.
 
 ## Uninstall a skill
 
@@ -252,7 +256,7 @@ thv skill uninstall <SKILL_NAME>
 For project-scoped skills, specify the scope and project root:
 
 ```bash
-thv skill uninstall my-skill --scope project --project-root /path/to/project
+thv skill uninstall my-skill --scope project --project-root .
 ```
 
 This removes the skill files from all associated client directories and deletes
@@ -428,7 +432,7 @@ TOOLHIVE_API_TIMEOUT=30m thv skill install <SKILL_NAME>
 ```
 
 Invalid, zero, or negative values are ignored. A timeout error means the API
-server was reachable but did not finish the operation within the limit.
+server was reachable but did not respond within the limit.
 
 </details>
 

--- a/docs/toolhive/guides-cli/skills-management.mdx
+++ b/docs/toolhive/guides-cli/skills-management.mdx
@@ -171,11 +171,12 @@ This installs the skill to your home directory (for example,
 ### Install a project-scoped skill
 
 ```bash
-thv skill install my-skill --scope project --project-root /path/to/project
+thv skill install my-skill --scope project --project-root .
 ```
 
-This installs the skill to the project directory (for example,
-`/path/to/project/.claude/skills/my-skill/` for Claude Code).
+Relative project roots are resolved from the current working directory. You can
+also pass an absolute path. This installs the skill inside the selected project
+(for example, `<PROJECT_ROOT>/.claude/skills/my-skill/` for Claude Code).
 
 :::note
 
@@ -221,6 +222,24 @@ thv skill info <SKILL_NAME>
 
 This shows the skill's name, version, description, scope, status, source
 reference, installation date, and associated clients.
+
+## Upgrade skills
+
+Skill upgrades are experimental and require `TOOLHIVE_SKILLS_LOCK_ENABLED=true`
+on the ToolHive API server. Upgrade project-scoped skills from the project
+directory:
+
+```bash
+thv skill upgrade --project-root .
+```
+
+A version or tag change within the same OCI repository proceeds without
+`--allow-ref-change`, including a move to an older tag. ToolHive still pins the
+resolved digest and checks for signer changes. If the catalog moves the skill to
+a different repository, organization, or registry, the upgrade is blocked.
+Review the new source, then repeat the command with `--allow-ref-change` if you
+intend to permit that repository move. ToolHive prompts before installing the
+planned changes; pass `--yes` in non-interactive environments.
 
 ## Uninstall a skill
 
@@ -394,6 +413,22 @@ thv serve
 ```
 
 Then retry your skill command.
+
+</details>
+
+<details>
+<summary>Skill installation or upgrade times out</summary>
+
+ToolHive allows API operations up to 10 minutes by default so large OCI pulls
+can complete. To use a different client timeout, set `TOOLHIVE_API_TIMEOUT` to a
+positive Go duration before running the command:
+
+```bash
+TOOLHIVE_API_TIMEOUT=30m thv skill install <SKILL_NAME>
+```
+
+Invalid, zero, or negative values are ignored. A timeout error means the API
+server was reachable but did not finish the operation within the limit.
 
 </details>
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -145,6 +145,35 @@ kubectl get mcpservers,mcpremoteproxies,virtualmcpservers -n toolhive-system \
     | "\(.kind)/\(.metadata.name)"'
 ```
 
+For an inline config, `issuer` must be a well-formed HTTP(S) URL with a scheme
+and host. ToolHive requires HTTPS for both `issuer` and an explicit `jwksUrl`.
+For development or testing on a trusted network, set `insecureAllowHTTP: true`
+to permit HTTP for both fields. An empty `jwksUrl` remains valid and uses OIDC
+discovery.
+
+:::info[Changed in v0.42.1]
+
+The operator validates these URLs whenever it reconciles an inline
+`MCPOIDCConfig`, including resources stored before v0.42.1. A malformed URL or
+plain HTTP without `insecureAllowHTTP: true` sets the config's `Valid` condition
+to `False`. Referencing workloads then set `OIDCConfigRefValidated=False` and
+stop reconciling. Existing pods continue running, so check both conditions if a
+spec, image, or rollout change does not take effect after an upgrade.
+
+Use HTTPS in production. For development-only HTTP issuers, set the opt-in on
+the inline config:
+
+```yaml title="development-oidc-config.yaml"
+spec:
+  type: inline
+  inline:
+    issuer: 'http://keycloak:8080/realms/toolhive'
+    jwksUrl: 'http://keycloak:8080/realms/toolhive/protocol/openid-connect/certs'
+    insecureAllowHTTP: true
+```
+
+:::
+
 :::note[Upgrading from before v0.21.0?]
 
 Older releases supported an inline `spec.oidcConfig` field directly on
@@ -399,11 +428,15 @@ kubectl logs -n toolhive-system -l app.kubernetes.io/name=weather-server-k8s
 
 **OIDC configuration issues:**
 
-- For external IdP: Ensure the issuer URL is accessible from within the cluster
+- For an external IdP, ensure the issuer and JWKS URLs are valid and accessible
+  from within the cluster. Both require HTTPS unless the inline config sets
+  `insecureAllowHTTP: true` for development.
 - For Kubernetes auth: Ensure the Kubernetes API server has OIDC enabled
 - Check that the JWKS URL returns valid keys
 - Verify the MCPOIDCConfig resource is valid:
   `kubectl get mcpoidc -n toolhive-system`
+- Inspect the validation message:
+  `kubectl get mcpoidc <NAME> -n toolhive-system -o jsonpath='{.status.conditions[?(@.type=="Valid")]}'`
 
 **Network connectivity:**
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -154,28 +154,10 @@ discovery.
 :::info[Changed in v0.42.1]
 
 The operator validates these URLs whenever it reconciles an inline
-`MCPOIDCConfig`, including resources stored before v0.42.1. A malformed URL or
-plain HTTP without `insecureAllowHTTP: true` sets the config's `Valid` condition
-to `False`. Referencing workloads then set `OIDCConfigRefValidated=False` and
-stop reconciling. Existing pods continue running, so check both conditions if a
-spec, image, or rollout change does not take effect after an upgrade.
-
-Use HTTPS in production. For development-only HTTP issuers, set the opt-in on
-the inline config:
-
-```yaml title="development-oidc-config.yaml"
-apiVersion: toolhive.stacklok.dev/v1beta1
-kind: MCPOIDCConfig
-metadata:
-  name: development-oidc
-  namespace: toolhive-system
-spec:
-  type: inline
-  inline:
-    issuer: 'http://keycloak:8080/realms/toolhive'
-    jwksUrl: 'http://keycloak:8080/realms/toolhive/protocol/openid-connect/certs'
-    insecureAllowHTTP: true
-```
+`MCPOIDCConfig`, including existing resources. Malformed URLs and plain HTTP
+URLs without `insecureAllowHTTP: true` set `Valid=False`. Referencing workloads
+stop reconciling, but existing pods continue running, so check `Valid` and
+`OIDCConfigRefValidated` if an update does not take effect.
 
 :::
 

--- a/docs/toolhive/guides-k8s/auth-k8s.mdx
+++ b/docs/toolhive/guides-k8s/auth-k8s.mdx
@@ -164,6 +164,11 @@ Use HTTPS in production. For development-only HTTP issuers, set the opt-in on
 the inline config:
 
 ```yaml title="development-oidc-config.yaml"
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPOIDCConfig
+metadata:
+  name: development-oidc
+  namespace: toolhive-system
 spec:
   type: inline
   inline:

--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -48,6 +48,66 @@ review independently.
 
 The rest of this guide uses `VirtualMCPCompositeToolDefinition`.
 
+## Describe tool behavior with annotations
+
+Set MCP tool annotations on a composite tool so clients can identify read-only,
+destructive, repeatable, or open-world behavior before calling it:
+
+```yaml title="VirtualMCPCompositeToolDefinition resource"
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: VirtualMCPCompositeToolDefinition
+metadata:
+  name: gather-pr-context
+spec:
+  name: gather_pr_context
+  description: Gather pull request context without changing the repository
+  annotations:
+    title: Gather pull request context
+    # Conservative values remain valid even if the backend omits its hints.
+    readOnlyHint: false
+    destructiveHint: true
+    idempotentHint: true
+    openWorldHint: true
+  parameters:
+    type: object
+  steps:
+    - id: pr_meta
+      tool: github_pull_request_read
+      arguments:
+        method: 'get'
+```
+
+The same `annotations` field is available on inline entries under
+`spec.config.compositeTools`. Every field is optional:
+
+| Field             | Purpose                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `title`           | Human-readable display title for the composite                 |
+| `readOnlyHint`    | The composite does not modify its environment                  |
+| `destructiveHint` | The composite may perform destructive updates                  |
+| `idempotentHint`  | Repeating the composite with the same input has no new effect  |
+| `openWorldHint`   | The composite interacts with entities outside its local domain |
+
+When you omit annotations, vMCP derives a conservative safety floor from the
+step tools:
+
+- `readOnlyHint` is `true` only when every tool step declares itself read-only.
+- `destructiveHint` and `openWorldHint` are `true` when any tool step sets the
+  hint or leaves it unspecified.
+- `idempotentHint` is not derived. Set it explicitly when the complete workflow
+  is idempotent.
+
+An explicit value can be more conservative than the derived floor. If it makes
+the composite appear safer than its steps, vMCP omits the composite from the
+advertised tool list and logs a warning that identifies the conflicting steps.
+For example, `readOnlyHint: true` conflicts when a step omits `readOnlyHint` or
+sets it to `false`. Set optimistic values only when every step tool advertises
+the hints needed to support them.
+
+`thv vmcp validate` and Kubernetes reconciliation validate the annotation
+structure, but they cannot resolve backend step annotations. Check the running
+vMCP logs and `tools/list` response to verify that the composite is advertised.
+
 ## Simple example
 
 This composite tool gathers the metadata, diff, and changed file list for a

--- a/docs/toolhive/guides-vmcp/composite-tools.mdx
+++ b/docs/toolhive/guides-vmcp/composite-tools.mdx
@@ -51,30 +51,13 @@ The rest of this guide uses `VirtualMCPCompositeToolDefinition`.
 ## Describe tool behavior with annotations
 
 Set MCP tool annotations on a composite tool so clients can identify read-only,
-destructive, repeatable, or open-world behavior before calling it:
+destructive, idempotent, or open-world behavior before calling it:
 
-```yaml title="VirtualMCPCompositeToolDefinition resource"
-apiVersion: toolhive.stacklok.dev/v1beta1
-kind: VirtualMCPCompositeToolDefinition
-metadata:
-  name: gather-pr-context
+```yaml title="VirtualMCPCompositeToolDefinition (spec)"
 spec:
-  name: gather_pr_context
-  description: Gather pull request context without changing the repository
   annotations:
     title: Gather pull request context
-    # Conservative values remain valid even if the backend omits its hints.
-    readOnlyHint: false
-    destructiveHint: true
     idempotentHint: true
-    openWorldHint: true
-  parameters:
-    type: object
-  steps:
-    - id: pr_meta
-      tool: github_pull_request_read
-      arguments:
-        method: 'get'
 ```
 
 The same `annotations` field is available on inline entries under
@@ -88,8 +71,7 @@ The same `annotations` field is available on inline entries under
 | `idempotentHint`  | Repeating the composite with the same input has no new effect  |
 | `openWorldHint`   | The composite interacts with entities outside its local domain |
 
-When you omit annotations, vMCP derives a conservative safety floor from the
-step tools:
+When you omit annotations, vMCP derives conservative values from the step tools:
 
 - `readOnlyHint` is `true` only when every tool step declares itself read-only.
 - `destructiveHint` and `openWorldHint` are `true` when any tool step sets the
@@ -97,12 +79,12 @@ step tools:
 - `idempotentHint` is not derived. Set it explicitly when the complete workflow
   is idempotent.
 
-An explicit value can be more conservative than the derived floor. If it makes
-the composite appear safer than its steps, vMCP omits the composite from the
-advertised tool list and logs a warning that identifies the conflicting steps.
+You can set values that are more conservative than the derived values. vMCP
+omits a composite from the advertised tool list when `readOnlyHint: true`,
+`destructiveHint: false`, or `openWorldHint: false` conflicts with a step tool.
 For example, `readOnlyHint: true` conflicts when a step omits `readOnlyHint` or
-sets it to `false`. Set optimistic values only when every step tool advertises
-the hints needed to support them.
+sets it to `false`. In that case, vMCP logs a warning that identifies the
+conflicting steps.
 
 `thv vmcp validate` and Kubernetes reconciliation validate the annotation
 structure, but they cannot resolve backend step annotations. Check the running
@@ -422,7 +404,7 @@ action with a `condition` that checks the `action` output field:
   dependsOn: [approval]
   defaultResults:
     # Required when condition may be false and output block or downstream
-    # steps reference this step — structure must mirror what downstream expects
+    # The structure must match what downstream steps expect.
     text: '{"status":"skipped"}'
 ```
 
@@ -665,11 +647,11 @@ vMCP validates `defaultResults` at configuration time:
   example:
 
   ```yaml
-  # Wrong — downstream templates use .output.text, not .output.status
+  # Wrong: downstream templates use .output.text, not .output.status
   defaultResults:
     status: 'skipped'
 
-  # Correct — mirrors the .output.text access pattern
+  # Correct: mirrors the .output.text access pattern
   defaultResults:
     text: '{"status":"skipped","id":0}'
   ```
@@ -848,13 +830,13 @@ For object properties, use `value` when the step returns data to deserialize, or
 ```yaml
 output:
   properties:
-    # Option 1a: step returns a JSON string already — reference it directly
+    # Option 1a: the step returns a JSON string, so reference it directly
     metadata:
       type: object
       description: Metadata returned by the backend as a JSON string
       value: '{{.steps.fetch.output.metadata_json}}'
 
-    # Option 1b: step returns structured data — use json to serialize it first
+    # Option 1b: the step returns structured data, so serialize it with json
     referrers:
       type: array
       description: OCI referrers attached to this image
@@ -900,7 +882,7 @@ spec:
         description: Repository path without tag, for listing tags
     required: [image_ref, repository]
   steps:
-    # All three steps run in parallel — no dependsOn between them
+    # All three steps run in parallel because they have no dependsOn fields
     - id: image_info
       tool: oci-registry_get_image_info
       arguments:
@@ -932,7 +914,7 @@ spec:
         type: integer
         description: Number of image layers
         value: '{{.steps.image_info.output.layers}}'
-      # referrers is a structured list — use json to serialize before output parses it
+      # Serialize the structured referrers list before the output parses it
       referrers:
         type: array
         description:
@@ -1017,7 +999,7 @@ engine renders parsed values using Go's native format, not JSON, so the result
 is not valid JSON and type coercion fails.
 
 ```yaml
-# Wrong — Go renders the parsed array as "[map[sha:... filename:...]]"
+# Wrong: Go renders the parsed array as "[map[sha:... filename:...]]"
 changedFiles:
   type: array
   description: Changed files
@@ -1076,7 +1058,7 @@ spec:
       - pullNumber
   timeout: '5m'
   steps:
-    # All five reads run in parallel — no dependsOn between them
+    # All five reads run in parallel because they have no dependsOn fields
     - id: pr_meta
       tool: github_pull_request_read
       arguments:
@@ -1165,7 +1147,7 @@ spec:
             type: string
             description: HTML URL of the pull request
             value: '{{(fromJson .steps.pr_meta.output.text).html_url}}'
-      # GitHub returns JSON text — pass through as string rather than
+      # GitHub returns JSON text. Pass it through as a string instead of
       # using fromJson + type: array (see JSON text in the output block)
       changedFiles:
         type: string

--- a/docs/toolhive/guides-vmcp/failure-handling.mdx
+++ b/docs/toolhive/guides-vmcp/failure-handling.mdx
@@ -27,7 +27,8 @@ gracefully:
   requests to failing backends instead of waiting for timeouts
 - **Partial failure modes**: Choose whether to fail entire requests or continue
   with available backends
-- **Automatic recovery**: Backends are automatically restored when they recover
+- **Recovery monitoring**: vMCP keeps probing failed backends so new sessions
+  can use them after they recover
 
 :::tip
 
@@ -174,6 +175,23 @@ is healthy, the `tools/list` response only includes tools from healthy backends:
 GitHub tools are omitted from the response because the circuit breaker is open.
 The client doesn't see unavailable backend tools, preventing timeout errors when
 attempting to call them.
+
+## Backend selection for new sessions
+
+Before opening a new client session, vMCP checks the health state it already has
+for each backend. It skips backends classified as `unhealthy` or
+`unauthenticated`, so one known-bad backend does not delay initialization for
+the entire vMCP server.
+
+vMCP still attempts backends classified as `degraded` because that state can
+also mean a backend has just recovered or is retrying authentication. It also
+attempts backends whose state is not known yet, including during startup before
+the first health check completes.
+
+This selection applies only when a session opens. A backend skipped at that
+point is not attached to the existing session after it recovers. Reconnect the
+client to open a new session that includes the recovered backend. Restored
+sessions keep their original backend set.
 
 ## Monitor circuit breaker status
 

--- a/docs/toolhive/guides-vmcp/failure-handling.mdx
+++ b/docs/toolhive/guides-vmcp/failure-handling.mdx
@@ -191,7 +191,7 @@ the first health check completes.
 This selection applies only when a session opens. A backend skipped at that
 point is not attached to the existing session after it recovers. Reconnect the
 client to open a new session that includes the recovered backend. Restored
-sessions keep their original backend set.
+sessions attempt only their original backend set.
 
 ## Monitor circuit breaker status
 

--- a/docs/toolhive/guides-vmcp/local-cli.mdx
+++ b/docs/toolhive/guides-vmcp/local-cli.mdx
@@ -176,7 +176,7 @@ aggregation:
 
 With this config, a client calling `tools/list` sees three tools
 (`filesystem_read_file`, `filesystem_write_file`, `filesystem_list_directory`)
-plus the single `fetch_fetch` tool — instead of all tools exposed by both
+plus the single `fetch_fetch` tool instead of all tools exposed by both
 backends.
 
 You can also rename tools or override descriptions without modifying the

--- a/docs/toolhive/guides-vmcp/local-cli.mdx
+++ b/docs/toolhive/guides-vmcp/local-cli.mdx
@@ -194,8 +194,14 @@ aggregation:
 To hide all backend tools globally (or per workload) and expose only
 [composite tools](./composite-tools.mdx) to clients, use
 `aggregation.excludeAllTools` or `aggregation.tools[].excludeAll`. Hidden tools
-are removed from `tools/list` but remain routable internally. See
+are removed from `tools/list` and cannot be called directly, but composite
+workflow steps can still route to them internally. See
 [Excluding all tools](./tool-aggregation.mdx#excluding-all-tools) for examples.
+
+To prevent a newly added group workload from exposing all of its tools, set
+`aggregation.defaultToolVisibility: deny` and list every workload that should
+contribute tools. See
+[Require workloads to opt in](./tool-aggregation.mdx#require-workloads-to-opt-in).
 
 For the full filter and override reference, see
 [Tool aggregation](./tool-aggregation.mdx).

--- a/docs/toolhive/guides-vmcp/tool-aggregation.mdx
+++ b/docs/toolhive/guides-vmcp/tool-aggregation.mdx
@@ -11,12 +11,13 @@ different backend servers expose tools with the same name. Virtual MCP Server
 
 ## Overview
 
-vMCP discovers tools from backend MCPServers in the referenced group and
-presents the advertised tools as a unified set to clients. By default, every
+vMCP discovers tools from backend `MCPServer` resources in the referenced group
+and presents the advertised tools as a unified set to clients. By default, every
 backend contributes tools. You can instead require each backend to be listed
-explicitly, then filter its tools. When two backend MCP servers have tools with
-the same name (for example, both GitHub and Jira have a `create_issue` tool), a
-conflict resolution strategy determines how to handle the collision.
+explicitly, then choose which tools it advertises. When two backend MCP servers
+have tools with the same name (for example, both GitHub and Jira have a
+`create_issue` tool), a conflict resolution strategy determines how to handle
+the collision.
 
 :::tip
 
@@ -114,8 +115,8 @@ tool names.
 ## Tool filtering
 
 Use filters to expose only specific tools from a backend MCP server, excluding
-all others. This is useful for reducing the tool surface area presented to LLM
-clients or removing unnecessary tools:
+all others. This reduces the number of tools presented to LLM clients and
+removes unnecessary tools:
 
 ```yaml title="VirtualMCPServer resource"
 spec:
@@ -169,19 +170,17 @@ in `aggregation.tools`. vMCP rejects the configuration otherwise.
 
 ## Excluding all tools
 
-To hide every tool from `tools/list` — globally or per workload — use
-`excludeAllTools` or `excludeAll`. These are the opt-out complement to `filter`
-(which is an allow-list): use them when you want clients to interact only
-through [composite tools](./composite-tools.mdx) workflows rather than raw
+To hide every tool from `tools/list`, either globally or per workload, use
+`excludeAllTools` or `excludeAll`. Use these settings when you want clients to
+interact only through [composite tools](./composite-tools.mdx) instead of raw
 backend tools.
 
-Hidden tools are removed from `tools/list` responses and direct `tools/call`
-requests return an unknown-tool error. On the Modern protocol path, the response
-uses JSON-RPC error `-32602` with HTTP status `400`. Call the exact
-conflict-resolved name returned by `tools/list`; the `<WORKLOAD_ID>.<TOOL_NAME>`
-form is reserved for tool references inside composite workflow steps. Hidden
-tools remain in the internal routing table so those workflow steps can still
-call them.
+Hidden tools are removed from `tools/list` responses, and direct `tools/call`
+requests return an unknown-tool error. Clients must use the exact
+conflict-resolved names returned by `tools/list`. The
+`<WORKLOAD_ID>.<TOOL_NAME>` form is reserved for tool references inside
+composite workflow steps. Hidden tools remain in the internal routing table so
+those workflow steps can still call them.
 
 ### Hide all backend tools globally
 

--- a/docs/toolhive/guides-vmcp/tool-aggregation.mdx
+++ b/docs/toolhive/guides-vmcp/tool-aggregation.mdx
@@ -11,11 +11,12 @@ different backend servers expose tools with the same name. Virtual MCP Server
 
 ## Overview
 
-vMCP discovers tools from all backend MCPServers in the referenced group and
-presents them as a unified set to clients. When two backend MCP servers have
-tools with the same name (for example, both GitHub and Jira have a
-`create_issue` tool), a conflict resolution strategy determines how to handle
-the collision.
+vMCP discovers tools from backend MCPServers in the referenced group and
+presents the advertised tools as a unified set to clients. By default, every
+backend contributes tools. You can instead require each backend to be listed
+explicitly, then filter its tools. When two backend MCP servers have tools with
+the same name (for example, both GitHub and Jira have a `create_issue` tool), a
+conflict resolution strategy determines how to handle the collision.
 
 :::tip
 
@@ -126,8 +127,45 @@ spec:
 ```
 
 Only the listed tools are advertised to clients; all others are hidden from
-`tools/list` responses. Hidden tools remain available in the internal routing
-table so composite tool workflows can still call them.
+`tools/list` responses and cannot be called directly. Hidden tools remain
+available in the internal routing table so composite tool workflow steps can
+call them.
+
+## Require workloads to opt in
+
+By default, a workload with no entry in `aggregation.tools` contributes all of
+its tools. Set `defaultToolVisibility: deny` when group membership changes over
+time and you want each workload to be reviewed before its tools become
+available:
+
+```yaml title="VirtualMCPServer resource"
+spec:
+  config:
+    aggregation:
+      defaultToolVisibility: deny
+      tools:
+        - workload: github
+          filter: ['get_issue', 'list_issues']
+        - workload: jira
+          filter: ['get_issue']
+```
+
+Only the `github` and `jira` workloads contribute tools. A listed workload is
+opted in by its entry, and its `filter` or `excludeAll` setting determines which
+tools are advertised. An unlisted workload contributes no tools, even if it is
+later added to the referenced group.
+
+The accepted values are `allow` and `deny`. An omitted value behaves as `allow`.
+This setting affects tools only; resources, resource templates, and prompts from
+unlisted workloads remain advertised.
+
+:::note[Priority strategy]
+
+When you combine `defaultToolVisibility: deny` with the `priority` conflict
+resolution strategy, every workload in `priorityOrder` must also have an entry
+in `aggregation.tools`. vMCP rejects the configuration otherwise.
+
+:::
 
 ## Excluding all tools
 
@@ -137,8 +175,13 @@ To hide every tool from `tools/list` — globally or per workload — use
 through [composite tools](./composite-tools.mdx) workflows rather than raw
 backend tools.
 
-Hidden tools are removed from `tools/list` responses but remain in the internal
-routing table, so composite tools can still call them.
+Hidden tools are removed from `tools/list` responses and direct `tools/call`
+requests return an unknown-tool error. On the Modern protocol path, the response
+uses JSON-RPC error `-32602` with HTTP status `400`. Call the exact
+conflict-resolved name returned by `tools/list`; the `<WORKLOAD_ID>.<TOOL_NAME>`
+form is reserved for tool references inside composite workflow steps. Hidden
+tools remain in the internal routing table so those workflow steps can still
+call them.
 
 ### Hide all backend tools globally
 

--- a/docs/toolhive/guides-vmcp/tool-aggregation.mdx
+++ b/docs/toolhive/guides-vmcp/tool-aggregation.mdx
@@ -160,6 +160,21 @@ The accepted values are `allow` and `deny`. An omitted value behaves as `allow`.
 This setting affects tools only; resources, resource templates, and prompts from
 unlisted workloads remain advertised.
 
+:::warning[Upgrade the CRDs first]
+
+Before using `defaultToolVisibility`, upgrade the ToolHive CRDs to v0.42.1 or
+later. Earlier CRDs prune this field when you apply the resource, so vMCP
+receives no value and uses `allow`.
+
+Verify that Kubernetes stored the field:
+
+```bash
+kubectl get virtualmcpserver <NAME> \
+  -o jsonpath='{.spec.config.aggregation.defaultToolVisibility}'
+```
+
+:::
+
 :::note[Priority strategy]
 
 When you combine `defaultToolVisibility: deny` with the `priority` conflict

--- a/docs/toolhive/reference/cli/thv_skill_upgrade.md
+++ b/docs/toolhive/reference/cli/thv_skill_upgrade.md
@@ -24,8 +24,9 @@ Skills pinned to an immutable reference (an OCI digest or a full git commit
 hash) are reported not-upgradable — there is nothing newer to resolve to.
 Use --preview to see what would change without persisting anything (OCI
 sources are still fetched into the local artifact store to compare digests),
-and --allow-ref-change to permit the resolved reference itself changing
-(e.g. a registry entry repointed at a different repository).
+and --allow-ref-change to permit the artifact moving to a different
+repository (a version bump within the same repository is not a change
+this guard blocks).
 --fail-on-changes evaluates the same plan and never installs: it is a CI
 freshness gate.
 
@@ -40,7 +41,7 @@ thv skill upgrade [skill-name...] [flags]
 ### Options
 
 ```
-      --allow-ref-change      Permit the resolved reference itself to change during upgrade
+      --allow-ref-change      Permit the artifact to move to a different repository during upgrade
       --allow-signer-change   Permit upgrading to an artifact signed by a different identity; the new identity replaces the recorded one
       --clients string        Comma-separated target client apps (e.g. claude-code,opencode), or "all" for every available client
       --fail-on-changes       Report what would change without installing anything; a CI freshness gate

--- a/static/api-specs/toolhive-api.yaml
+++ b/static/api-specs/toolhive-api.yaml
@@ -667,6 +667,28 @@ components:
           $ref: '#/components/schemas/storage.RunConfig'
         token_lifespans:
           $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver.TokenLifespanRunConfig'
+        trusted_issuers:
+          description: |-
+            TrustedIssuers lists external OIDC issuers whose tokens are accepted as
+            subject tokens during RFC 8693 token exchange. Empty (the default) means
+            only self-issued subject tokens are accepted.
+
+            Prerequisite: the token-exchange grant requires a confidential client,
+            and no supported deployment path provisions one today (DCR and CIMD
+            clients are both public-only, and there is no client-seeding field on
+            this RunConfig), so this grant is not yet usable end to end for
+            self-issued or external subject tokens alike. Tracked in
+            https://github.com/stacklok/toolhive/issues/6082.
+
+            See tokenexchange.TrustedIssuer for the per-issuer field reference, and
+            docs/arch/17-token-exchange-delegation.md for the trust model, consent
+            signals, and operator-facing constraints (audience/scope bounding,
+            subject namespace qualification, required client binding) that aren't
+            visible from the config shape alone.
+          items:
+            $ref: '#/components/schemas/github_com_stacklok_toolhive_pkg_authserver_server_tokenexchange.TrustedIssuer'
+          type: array
+          uniqueItems: false
         upstreams:
           description: |-
             Upstreams configures connections to upstream Identity Providers.
@@ -828,6 +850,75 @@ components:
           description: |-
             HTTPMethod is the HTTP method to use for the userinfo request.
             If not specified, defaults to GET.
+          type: string
+      type: object
+    github_com_stacklok_toolhive_pkg_authserver_server_tokenexchange.TrustedIssuer:
+      properties:
+        actor_claim:
+          description: |-
+            ActorClaim names the claim identifying the client that requested the
+            subject token from THIS EXTERNAL ISSUER (used by AllowedActors below).
+            Values are in the external issuer's namespace, NOT ToolHive client
+            IDs. Defaults to "azp"; use "appid" for Microsoft Entra v1, "cid" for
+            Okta. The special value "client_id" reads ValidatedClaims.ClientID
+            instead of Extra (assignClaim routes it to that field) — it is still
+            the external token's client_id claim, not a ToolHive one.
+          type: string
+        allow_private_ips:
+          description: |-
+            AllowPrivateIPs permits OIDC discovery and JWKS fetches for THIS
+            issuer to resolve to a private or loopback address. Use only when the
+            issuer is hosted inside the same cluster and has no public endpoint.
+          type: boolean
+        allowed_actors:
+          description: |-
+            AllowedActors is the allowlist of ActorClaim values authorized to
+            exchange a subject token from this issuer when it carries no
+            "may_act" claim; empty means only may_act-bearing tokens are
+            accepted. By itself names no ToolHive client — see
+            AllowedDelegateClients and docs/arch/17-token-exchange-delegation.md
+            ("Accepted limitations" #1).
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        allowed_delegate_clients:
+          description: |-
+            AllowedDelegateClients restricts which ToolHive client IDs may
+            exchange a subject token from this issuer, for BOTH consent paths.
+            Required (validateTrustedIssuer rejects empty/absent); "*" permits
+            any confidential client holding the grant. See
+            docs/arch/17-token-exchange-delegation.md ("Accepted limitations" #1).
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        expected_audience:
+          description: |-
+            ExpectedAudience is the expected "aud" claim value that must appear
+            in the token's audience list (a resource/API identifier, not a
+            client ID — required, but not enforced; see looksLikeResourceIdentifier).
+            See docs/arch/17-token-exchange-delegation.md ("ID/access-token
+            discrimination") for why and its limits.
+          type: string
+        insecure_allow_http:
+          description: |-
+            InsecureAllowHTTP permits plain-HTTP OIDC discovery and JWKS fetches
+            for THIS issuer only. Development and testing only — never set in
+            production. Does not relax the private-IP guard; see AllowPrivateIPs.
+            Deliberately per-issuer: this server's own InsecureAllowHTTP must not
+            silently permit plaintext discovery for every trusted external issuer
+            too — a network attacker who can intercept that traffic could
+            substitute a JWKS and forge subject tokens for that issuer's
+            namespace.
+          type: boolean
+        issuer_url:
+          description: IssuerURL is the expected "iss" claim value (exact match).
+          type: string
+        jwks_url:
+          description: |-
+            JWKSURL is the URL to fetch the issuer's JSON Web Key Set from.
+            If empty, it is resolved via OIDC discovery at {IssuerURL}/.well-known/openid-configuration.
           type: string
       type: object
     github_com_stacklok_toolhive_pkg_authz.Config:

--- a/static/api-specs/toolhive-crds/mcpoidcconfigs.schema.json
+++ b/static/api-specs/toolhive-crds/mcpoidcconfigs.schema.json
@@ -70,7 +70,7 @@
             },
             "insecureAllowHTTP": {
               "default": false,
-              "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuers for development/testing.\nWARNING: This is insecure and should NEVER be used in production.",
+              "description": "InsecureAllowHTTP allows HTTP (non-HTTPS) OIDC issuer and JWKS URLs for development/testing.\nWARNING: This is insecure and should NEVER be used in production.",
               "type": "boolean"
             },
             "introspectionUrl": {

--- a/static/api-specs/toolhive-crds/virtualmcpcompositetooldefinitions.schema.json
+++ b/static/api-specs/toolhive-crds/virtualmcpcompositetooldefinitions.schema.json
@@ -15,6 +15,32 @@
     "spec": {
       "description": "VirtualMCPCompositeToolDefinitionSpec defines the desired state of VirtualMCPCompositeToolDefinition.\nThis embeds the CompositeToolConfig from pkg/vmcp/config to share the configuration model\nbetween CLI and operator usage.",
       "properties": {
+        "annotations": {
+          "description": "Annotations declares MCP tool annotations for the composite tool.\n\nAnnotation derivation runs at ADVERTISE TIME (when tools/list is served\nand the backend tools are aggregated), not at CRD admission — thv vmcp\nvalidate does NOT check annotation contradictions. The derived floor is\nfail-closed: when the workflow has one or more tool steps the floor is\nalways non-nil, and any step whose annotations are nil/unknown taints the\nfloor conservatively (readOnly=false, destructive=true, openWorld=true).\nA workflow with no tool steps (e.g. only elicitation) has no floor.\n\nWhen nil, annotations are derived from the annotations of the backend tools\nreferenced by the workflow's steps (e.g. readOnlyHint is true only when every\nstep tool is read-only). When set, the values are an explicit author\ndeclaration merged over the derived floor — subject to a safety-floor\nguardrail that drops the composite tool (with a warning naming the offending\nstep tools) if an explicit hint would make the tool look safer than its\nsteps allow.",
+          "properties": {
+            "destructiveHint": {
+              "description": "DestructiveHint sets the destructive hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+              "type": "boolean"
+            },
+            "idempotentHint": {
+              "description": "IdempotentHint sets the idempotent hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+              "type": "boolean"
+            },
+            "openWorldHint": {
+              "description": "OpenWorldHint sets the open-world hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+              "type": "boolean"
+            },
+            "readOnlyHint": {
+              "description": "ReadOnlyHint sets the read-only hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+              "type": "boolean"
+            },
+            "title": {
+              "description": "Title sets the human-readable title annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "description": {
           "description": "Description describes what the workflow does.",
           "type": "string"

--- a/static/api-specs/toolhive-crds/virtualmcpservers.schema.json
+++ b/static/api-specs/toolhive-crds/virtualmcpservers.schema.json
@@ -798,6 +798,14 @@
                   },
                   "type": "object"
                 },
+                "defaultToolVisibility": {
+                  "description": "DefaultToolVisibility controls whether a backend with NO entry in Tools has its\ntools advertised to MCP clients.\n  - allow (default): every tool from an unlisted backend is advertised, so\n    adding a workload to the group exposes it without further configuration.\n  - deny: an unlisted backend contributes no tools, so only backends named in\n    Tools are advertised. Use this when the set of exposed tools must be\n    enumerated deliberately rather than inherited from group membership.\n\nA backend that DOES have a Tools entry is unaffected by this setting: the\nentry opts it in, and ExcludeAll/Filter on that entry decide the rest. Like\nevery other visibility setting here, this controls advertising only — hidden\ntools remain in the routing table for composite tools (see the type doc).\n\nThis gates TOOLS only. An unlisted backend's resources, resource templates,\nand prompts are still advertised under deny; mergeResources/mergePrompts have\nno equivalent check.",
+                  "enum": [
+                    "allow",
+                    "deny"
+                  ],
+                  "type": "string"
+                },
                 "excludeAllTools": {
                   "description": "ExcludeAllTools hides all backend tools from MCP clients when true.\nHidden tools are NOT advertised in tools/list responses, but they ARE\navailable in the routing table for composite tools to use.\nThis enables the use case where you want to hide raw backend tools from\ndirect client access while exposing curated composite tool workflows.",
                   "type": "boolean"
@@ -826,23 +834,23 @@
                               "description": "Annotations overrides specific tool annotation fields.\nOnly specified fields are overridden; others pass through from the backend.",
                               "properties": {
                                 "destructiveHint": {
-                                  "description": "DestructiveHint overrides the destructive hint annotation.",
+                                  "description": "DestructiveHint sets the destructive hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
                                   "type": "boolean"
                                 },
                                 "idempotentHint": {
-                                  "description": "IdempotentHint overrides the idempotent hint annotation.",
+                                  "description": "IdempotentHint sets the idempotent hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
                                   "type": "boolean"
                                 },
                                 "openWorldHint": {
-                                  "description": "OpenWorldHint overrides the open-world hint annotation.",
+                                  "description": "OpenWorldHint sets the open-world hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
                                   "type": "boolean"
                                 },
                                 "readOnlyHint": {
-                                  "description": "ReadOnlyHint overrides the read-only hint annotation.",
+                                  "description": "ReadOnlyHint sets the read-only hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
                                   "type": "boolean"
                                 },
                                 "title": {
-                                  "description": "Title overrides the human-readable title annotation.",
+                                  "description": "Title sets the human-readable title annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
                                   "type": "string"
                                 }
                               },
@@ -1051,6 +1059,32 @@
               "items": {
                 "description": "CompositeToolConfig defines a composite tool workflow.\nThis matches the YAML structure from the proposal (lines 173-255).",
                 "properties": {
+                  "annotations": {
+                    "description": "Annotations declares MCP tool annotations for the composite tool.\n\nAnnotation derivation runs at ADVERTISE TIME (when tools/list is served\nand the backend tools are aggregated), not at CRD admission — thv vmcp\nvalidate does NOT check annotation contradictions. The derived floor is\nfail-closed: when the workflow has one or more tool steps the floor is\nalways non-nil, and any step whose annotations are nil/unknown taints the\nfloor conservatively (readOnly=false, destructive=true, openWorld=true).\nA workflow with no tool steps (e.g. only elicitation) has no floor.\n\nWhen nil, annotations are derived from the annotations of the backend tools\nreferenced by the workflow's steps (e.g. readOnlyHint is true only when every\nstep tool is read-only). When set, the values are an explicit author\ndeclaration merged over the derived floor — subject to a safety-floor\nguardrail that drops the composite tool (with a warning naming the offending\nstep tools) if an explicit hint would make the tool look safer than its\nsteps allow.",
+                    "properties": {
+                      "destructiveHint": {
+                        "description": "DestructiveHint sets the destructive hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+                        "type": "boolean"
+                      },
+                      "idempotentHint": {
+                        "description": "IdempotentHint sets the idempotent hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+                        "type": "boolean"
+                      },
+                      "openWorldHint": {
+                        "description": "OpenWorldHint sets the open-world hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+                        "type": "boolean"
+                      },
+                      "readOnlyHint": {
+                        "description": "ReadOnlyHint sets the read-only hint annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+                        "type": "boolean"
+                      },
+                      "title": {
+                        "description": "Title sets the human-readable title annotation.\nFor tool overrides this replaces the backend value; for composite tools\nit is an explicit declaration merged over the derived safety floor.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
                   "description": {
                     "description": "Description describes what the workflow does.",
                     "type": "string"


### PR DESCRIPTION
### Description

Codex comparison run for the ToolHive v0.42.1 release-docs workflow. This branch includes the version pin and refreshed reference assets, source-verified documentation updates, and a separate editorial review pass.

### Type of change

- Documentation update

### Related issues/PRs

- Upstream release: [stacklok/toolhive v0.42.1](https://github.com/stacklok/toolhive/releases/tag/v0.42.1)
- Upstream comparison: [v0.42.0...v0.42.1](https://github.com/stacklok/toolhive/compare/v0.42.0...v0.42.1)
- Claude Code workflow comparison: [#1095](https://github.com/stacklok/docs-website/pull/1095)

### Submitter checklist

#### Content and formatting

- [x] I have reviewed the content for technical accuracy
- [x] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

### Reviewer checklist

#### Content

- [ ] I have reviewed the content for technical accuracy
- [ ] I have reviewed the content for spelling, grammar, and [style](STYLE-GUIDE.md)

---

<!-- upstream-release-docs:start -->

## Docs update for `toolhive` v0.42.1

### At a glance

| | |
| --- | --- |
| **Upstream** | `stacklok/toolhive` [`v0.42.0` → `v0.42.1`](https://github.com/stacklok/toolhive/compare/v0.42.0...v0.42.1) |
| **Hand-written changes** | 2 commit(s) |
| **Reference assets** | refreshed (separate commit) |
| **Gaps** | 0 |
| **Release contributors** | not auto-assigned for this comparison run |
| **Action required** | Spot-check Codex-authored prose for accuracy |

### Summary of changes

- Updated vMCP tool visibility and direct-call behavior in `docs/toolhive/guides-vmcp/tool-aggregation.mdx` and `docs/toolhive/guides-vmcp/local-cli.mdx`.
- Updated composite tool annotations in `docs/toolhive/guides-vmcp/composite-tools.mdx`.
- Updated vMCP session recovery behavior in `docs/toolhive/guides-vmcp/failure-handling.mdx`.
- Updated OIDC URL validation and Cedar request requirements in `docs/toolhive/guides-k8s/auth-k8s.mdx` and `docs/toolhive/concepts/cedar-policies.mdx`.
- Updated skill and AI tool plugin path, upgrade, and timeout behavior in `docs/toolhive/guides-cli/skills-management.mdx` and `docs/toolhive/guides-cli/ai-plugins.mdx`.

<details><summary>How this PR was built</summary>

Two Codex sessions were used for this comparison: a generation pass
(`upstream-release-docs` skill, 6 phases) followed by a separate editorial
review pass (`docs-review`). Prettier and ESLint auto-fixes were applied after.

Auto-synced paths - do not hand-edit these in review:

- `static/api-specs/`
- `docs/toolhive/reference/cli/`
- `docs/toolhive/reference/crds/`

No gaps requiring human context were identified.

</details>

<!-- upstream-release-docs:end -->
